### PR TITLE
[FEA] Add support for using nvcomp ZSTD compression

### DIFF
--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -15,8 +15,7 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write
-from spark_session import is_databricks104_or_later, is_before_spark_320
-
+from spark_session import is_before_spark_320, is_spark_cdh
 from datetime import date, datetime, timezone
 from data_gen import *
 from marks import *
@@ -93,7 +92,7 @@ def test_part_write_round_trip(spark_tmp_path, orc_gen):
 
 orc_write_compress_options = ['none', 'uncompressed', 'snappy']
 # zstd is available in spark 3.2.0 and later.
-if not is_before_spark_320():
+if not is_before_spark_320() and not is_spark_cdh():
     orc_write_compress_options.append('zstd')
 
 @pytest.mark.parametrize('compress', orc_write_compress_options)

--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -15,7 +15,8 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write
-from spark_session import is_before_spark_320
+from spark_session import is_databricks104_or_later, is_before_spark_320
+
 from datetime import date, datetime, timezone
 from data_gen import *
 from marks import *
@@ -91,6 +92,10 @@ def test_part_write_round_trip(spark_tmp_path, orc_gen):
             conf = {'spark.rapids.sql.format.orc.write.enabled': True})
 
 orc_write_compress_options = ['none', 'uncompressed', 'snappy']
+# zstd is available in spark 3.2.0 and later.
+if not is_before_spark_320():
+    orc_write_compress_options.append('zstd')
+
 @pytest.mark.parametrize('compress', orc_write_compress_options)
 def test_compress_write_round_trip(spark_tmp_path, compress):
     data_path = spark_tmp_path + '/ORC_DATA'

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -19,8 +19,7 @@ from datetime import date, datetime, timezone
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, with_gpu_session, is_before_spark_320, is_before_spark_330
-
+from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320
 import pyspark.sql.functions as f
 import pyspark.sql.utils
 import random

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -19,7 +19,8 @@ from datetime import date, datetime, timezone
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320
+from spark_session import with_cpu_session, with_gpu_session, is_before_spark_320, is_before_spark_330
+
 import pyspark.sql.functions as f
 import pyspark.sql.utils
 import random
@@ -184,6 +185,10 @@ def test_all_null_int96(spark_tmp_path):
         conf=confs)
 
 parquet_write_compress_options = ['none', 'uncompressed', 'snappy']
+# zstd is available in spark 3.2.0 and later.
+if not is_before_spark_320():
+    parquet_write_compress_options.append('zstd')
+
 @pytest.mark.parametrize('compress', parquet_write_compress_options)
 def test_compress_write_round_trip(spark_tmp_path, compress):
     data_path = spark_tmp_path + '/PARQUET_DATA'

--- a/spark2-sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/spark2-sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -85,7 +85,7 @@ object GpuOrcFileFormat extends Logging {
 
     val orcOptions = new OrcOptions(options, sqlConf)
     orcOptions.compressionCodec match {
-      case "NONE" | "SNAPPY" =>
+      case "NONE" | "SNAPPY" | "ZSTD" =>
       case c => meta.willNotWorkOnGpu(s"compression codec $c is not supported")
     }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -144,6 +144,7 @@ object GpuParquetFileFormat {
     compressionType match {
       case "NONE" | "UNCOMPRESSED" => Some(CompressionType.NONE)
       case "SNAPPY" => Some(CompressionType.SNAPPY)
+      case "ZSTD" => Some(CompressionType.ZSTD)
       case _ => None
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -90,7 +90,7 @@ object GpuOrcFileFormat extends Logging {
 
     val orcOptions = new OrcOptions(options, sqlConf)
     orcOptions.compressionCodec match {
-      case "NONE" | "SNAPPY" =>
+      case "NONE" | "SNAPPY" | "ZSTD" =>
       case c => meta.willNotWorkOnGpu(s"compression codec $c is not supported")
     }
 


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

nvcomp release 2.4 will add support for zstd compression.
https://github.com/rapidsai/cudf/pull/11551 is the cudf patch to add support for zstd compression for parquet and orc.
This patch adds support in the plug-in.

This cannot be built/merged until the nvcomp-2.4 library is released and the cudf change is merged.