### PR TITLE
Remove LazySpillableColumnarBatch from join code

### DIFF
--- a/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilter.scala
+++ b/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilter.scala
@@ -387,7 +387,7 @@ private case class DeleteFilterContext(
     joinTime: GpuMetric) {
   def filter(input: Iterator[ColumnarBatch]): Iterator[ColumnarBatch] = {
     val probeSide = input.map { cb =>
-      SpillableColumnarBatch(_, "Deletes probe")
+      SpillableColumnarBatch(cb, "Deletes probe")
     }
 
     new HashedExistenceJoinIterator(buildBatch,

--- a/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilter.scala
+++ b/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilter.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.iceberg.data
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuExpression, GpuMetric, LazySpillableColumnarBatch}
+import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuExpression, GpuMetric, SpillableColumnarBatch}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric.{JOIN_TIME, OP_TIME_LEGACY}
 import com.nvidia.spark.rapids.fileio.iceberg.{IcebergFileIO, IcebergInputFile}
@@ -379,7 +379,7 @@ object GpuDeleteFilter2 {
 }
 
 private case class DeleteFilterContext(
-    buildBatch: LazySpillableColumnarBatch,
+    buildBatch: SpillableColumnarBatch,
     buildKeys: Seq[GpuExpression],
     probeKeys: Seq[GpuExpression],
     numFirstConditionColumns: Int,
@@ -387,9 +387,7 @@ private case class DeleteFilterContext(
     joinTime: GpuMetric) {
   def filter(input: Iterator[ColumnarBatch]): Iterator[ColumnarBatch] = {
     val probeSide = input.map { cb =>
-      withResource(cb) {
-        LazySpillableColumnarBatch(_, "Deletes probe")
-      }
+      SpillableColumnarBatch(_, "Deletes probe")
     }
 
     new HashedExistenceJoinIterator(buildBatch,

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
@@ -143,6 +143,7 @@ public abstract class InternalRowToColumnarBatchIterator implements Iterator<Col
     long dataLength = calcDataLengthEstimate(numRowsEstimate);
     long offsetLength = calcOffsetLengthEstimate(numRowsEstimate);
     int used[];
+
     try (SpillableHostBuffer spillableBuffer = sBufAndNumRows._1;
     ) {
       HostMemoryBuffer[] hBufs =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,10 +222,10 @@ abstract class SplittableJoinIterator(
         // that are made up of ints, so compute how many rows on the stream side will produce the
         // desired gather maps size.
         val maxJoinRows = Math.max(1, targetSize / (2 * Integer.BYTES))
-        if (numJoinRows > maxJoinRows && scb.numRows > 1) {
+        if (numJoinRows > maxJoinRows && scb.numRows() > 1) {
           // Need to split the batch to reduce the gather maps size. This takes a simplistic
           // approach of assuming the data is uniformly distributed in the stream table.
-          val numSplits = Math.min(scb.numRows,
+          val numSplits = Math.min(scb.numRows(),
             Math.ceil(numJoinRows.toDouble / maxJoinRows).toInt)
           withResource(scb) { _ =>
             splitAndSave(scb, numSplits)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalfGpu, withRestoreOnRetry, withRetry}
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
+
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -17,11 +17,10 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{GatherMap, NvtxColor, OutOfBoundsPolicy}
-import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalfGpu, withRestoreOnRetry, withRetry}
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
-
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -126,6 +125,7 @@ abstract class AbstractGpuJoinIterator(
 
   override def close(): Unit = {
     if (!closed) {
+      super.close()
       nextCb.foreach(_.close())
       nextCb = None
       gathererStore.foreach(_.close())
@@ -157,12 +157,6 @@ abstract class AbstractGpuJoinIterator(
         gathererStore.foreach(_.close())
         gathererStore = None
       }
-
-      if (ret.isDefined) {
-        // We are about to return something. We got everything we need from it so now let it spill
-        // if there is more to be gathered later on.
-        gathererStore.foreach(_.allowSpilling())
-      }
       ret
     }
   }
@@ -180,9 +174,9 @@ abstract class AbstractGpuJoinIterator(
  */
 abstract class SplittableJoinIterator(
     gatherNvtxName: String,
-    stream: Iterator[LazySpillableColumnarBatch],
+    stream: Iterator[SpillableColumnarBatch],
     streamAttributes: Seq[Attribute],
-    builtBatch: LazySpillableColumnarBatch,
+    builtBatch: SpillableColumnarBatch,
     targetSize: Long,
     opTime: GpuMetric,
     joinTime: GpuMetric)
@@ -194,9 +188,9 @@ abstract class SplittableJoinIterator(
   // For some join types even if there is no stream data we might output something
   private var isInitialJoin = true
   // If the join explodes this holds batches from the stream side split into smaller pieces.
-  private val pendingSplits = scala.collection.mutable.Queue[LazySpillableColumnarBatch]()
+  private val pendingSplits = scala.collection.mutable.Queue[SpillableColumnarBatch]()
 
-  protected def computeNumJoinRows(cb: LazySpillableColumnarBatch): Long
+  protected def computeNumJoinRows(cb: SpillableColumnarBatch): Long
 
   /**
    * Create a join gatherer.
@@ -205,7 +199,7 @@ abstract class SplittableJoinIterator(
    * @return some gatherer to use next or None if there is no next gatherer or the loop should try
    *         to build the gatherer again (e.g.: to skip a degenerate join result batch)
    */
-  protected def createGatherer(cb: LazySpillableColumnarBatch,
+  protected def createGatherer(cb: SpillableColumnarBatch,
       numJoinRows: Option[Long]): Option[JoinGatherer]
 
   override def hasNextStreamBatch: Boolean = {
@@ -222,36 +216,34 @@ abstract class SplittableJoinIterator(
         stream.next()
       }
       opTime.ns {
-        withResource(scb) { scb =>
-          val numJoinRows = computeNumJoinRows(scb)
+        val numJoinRows = closeOnExcept(scb) { _ => computeNumJoinRows(scb) }
 
-          // We want the gather maps size to be around the target size. There are two gather maps
-          // that are made up of ints, so compute how many rows on the stream side will produce the
-          // desired gather maps size.
-          val maxJoinRows = Math.max(1, targetSize / (2 * Integer.BYTES))
-          if (numJoinRows > maxJoinRows && scb.numRows > 1) {
-            // Need to split the batch to reduce the gather maps size. This takes a simplistic
-            // approach of assuming the data is uniformly distributed in the stream table.
-            val numSplits = Math.min(scb.numRows,
-              Math.ceil(numJoinRows.toDouble / maxJoinRows).toInt)
-            splitAndSave(scb.getBatch, numSplits)
-
-            // Return no gatherer so the outer loop will try again
-            return None
+        // We want the gather maps size to be around the target size. There are two gather maps
+        // that are made up of ints, so compute how many rows on the stream side will produce the
+        // desired gather maps size.
+        val maxJoinRows = Math.max(1, targetSize / (2 * Integer.BYTES))
+        if (numJoinRows > maxJoinRows && scb.numRows > 1) {
+          // Need to split the batch to reduce the gather maps size. This takes a simplistic
+          // approach of assuming the data is uniformly distributed in the stream table.
+          val numSplits = Math.min(scb.numRows,
+            Math.ceil(numJoinRows.toDouble / maxJoinRows).toInt)
+          withResource(scb) { _ =>
+            splitAndSave(scb, numSplits)
           }
 
-          createGatherer(scb, Some(numJoinRows))
+          // Return no gatherer so the outer loop will try again
+          return None
         }
+
+        createGatherer(scb, Some(numJoinRows))
       }
     } else {
       opTime.ns {
         assert(wasInitialJoin)
         import scala.collection.JavaConverters._
-        withResource(GpuColumnVector.emptyBatch(streamAttributes.asJava)) { cb =>
-          withResource(LazySpillableColumnarBatch(cb, "empty_stream")) { scb =>
-            createGatherer(scb, None)
-          }
-        }
+        val emptyStreamCb = GpuColumnVector.emptyBatch(streamAttributes.asJava)
+        val scb = SpillableColumnarBatch(emptyStreamCb, "empty_stream")
+        createGatherer(scb, None)
       }
     }
   }
@@ -266,24 +258,20 @@ abstract class SplittableJoinIterator(
   }
 
   private def splitStreamBatch(
-      cb: ColumnarBatch,
-      numBatches: Int): Seq[LazySpillableColumnarBatch] = {
-    val batchSize = cb.numRows() / numBatches
-    val splits = withResource(GpuColumnVector.from(cb)) { tab =>
-      val splitIndexes = (1 until numBatches).map(num => num * batchSize)
-      tab.contiguousSplit(splitIndexes: _*)
-    }
-    withResource(splits) { splits =>
-      val schema = GpuColumnVector.extractTypes(cb)
-      withResource(splits.safeMap(_.getTable)) { tables =>
-        withResource(tables.safeMap(GpuColumnVector.from(_, schema))) { batches =>
-          batches.safeMap { splitBatch =>
-            val lazyCb = LazySpillableColumnarBatch(splitBatch, "stream_data")
-            lazyCb.allowSpilling()
-            lazyCb
-          }
+      scb: SpillableColumnarBatch,
+      numBatches: Int): Seq[SpillableColumnarBatch] = {
+    val schema = scb.dataTypes
+    val batchSize = scb.numRows() / numBatches
+    val splits = {
+      withResource(scb.getColumnarBatch()) { cb =>
+        withResource(GpuColumnVector.from(cb)) { tab =>
+          val splitIndexes = (1 until numBatches).map(num => num * batchSize)
+          tab.contiguousSplit(splitIndexes: _*)
         }
       }
+    }
+    splits.safeMap { t =>
+      SpillableColumnarBatch(t, schema, "stream_data")
     }
   }
 
@@ -295,10 +283,10 @@ abstract class SplittableJoinIterator(
    * @param oom a prior OOM exception that this will try to recover from by splitting
    */
   protected def splitAndSave(
-      cb: ColumnarBatch,
+      scb: SpillableColumnarBatch,
       numBatches: Int,
       oom: Option[Throwable] = None): Unit = {
-    val batchSize = cb.numRows() / numBatches
+    val batchSize = scb.numRows() / numBatches
     if (oom.isDefined && batchSize < 100) {
       // We just need some kind of cutoff to not get stuck in a loop if the batches get to be too
       // small but we want to at least give it a chance to work (mostly for tests where the
@@ -311,7 +299,7 @@ abstract class SplittableJoinIterator(
     } else {
       logInfo(msg)
     }
-    pendingSplits ++= splitStreamBatch(cb, numBatches)
+    pendingSplits ++= splitStreamBatch(scb, numBatches)
   }
 
   /**
@@ -323,8 +311,8 @@ abstract class SplittableJoinIterator(
    */
   protected def makeGatherer(
       maps: Array[GatherMap],
-      leftData: LazySpillableColumnarBatch,
-      rightData: LazySpillableColumnarBatch,
+      leftData: SpillableColumnarBatch,
+      rightData: SpillableColumnarBatch,
       joinType: JoinType): Option[JoinGatherer] = {
     assert(maps.length > 0 && maps.length <= 2)
     try {
@@ -334,7 +322,7 @@ abstract class SplittableJoinIterator(
           // are not rearranged by the join.
           new JoinGathererSameTable(leftData)
         case _ =>
-          val lazyLeftMap = LazySpillableGatherMap(maps.head, "left_map")
+          val lazyLeftMap = SpillableGatherMap(maps.head, "left_map")
           // Inner joins -- manifest the intersection of both left and right sides. The gather maps
           //   contain the number of rows that must be manifested, and every index
           //   must be within bounds, so we can skip the bounds checking.
@@ -348,7 +336,7 @@ abstract class SplittableJoinIterator(
           JoinGatherer(lazyLeftMap, leftData, leftOutOfBoundsPolicy)
       }
       val rightMap = joinType match {
-        case _ if rightData.numCols == 0 => None
+        case _ if rightData.numCols() == 0 => None
         case LeftOuter if maps.length == 1 =>
           // Distinct left outer joins only produce a single gather map since left table rows
           // are not rearranged by the join.
@@ -357,7 +345,7 @@ abstract class SplittableJoinIterator(
         case _ => Some(maps(1))
       }
       val gatherer = rightMap match {
-        case None if joinType == RightOuter && rightData.numCols > 0 =>
+        case None if joinType == RightOuter && rightData.numCols() > 0 =>
           // Distinct right outer joins only produce a single gather map since right table rows
           // are not rearranged by the join.
           MultiJoinGather(leftGatherer, new JoinGathererSameTable(rightData))
@@ -377,7 +365,7 @@ abstract class SplittableJoinIterator(
             case _: InnerLike | RightOuter => OutOfBoundsPolicy.DONT_CHECK
             case _ => OutOfBoundsPolicy.NULLIFY
           }
-          val lazyRightMap = LazySpillableGatherMap(right, "right_map")
+          val lazyRightMap = SpillableGatherMap(right, "right_map")
           val rightGatherer = JoinGatherer(lazyRightMap, rightData, rightOutOfBoundsPolicy)
           MultiJoinGather(leftGatherer, rightGatherer)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -316,25 +316,25 @@ object GpuShuffledSizedHashJoinExec {
 
   def createJoinIterator(
       info: JoinInfo,
-      spillableBuiltBatch: LazySpillableColumnarBatch,
-      lazyStream: Iterator[LazySpillableColumnarBatch],
+      spillableBuiltBatch: SpillableColumnarBatch,
+      spillableStreamBatch: Iterator[SpillableColumnarBatch],
       gpuBatchSizeBytes: Long,
       opTime: GpuMetric,
       joinTime: GpuMetric): Iterator[ColumnarBatch] = {
     info.joinType match {
       case FullOuter =>
         new HashOuterJoinIterator(FullOuter, spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, None, lazyStream, info.exprs.boundStreamKeys, info.exprs.streamOutput,
+          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
           info.exprs.boundCondition, info.exprs.numFirstConditionTableColumns,
           gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
       case LeftOuter if info.buildSide == GpuBuildLeft =>
         new HashOuterJoinIterator(LeftOuter, spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, None, lazyStream, info.exprs.boundStreamKeys, info.exprs.streamOutput,
+          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
           info.exprs.boundCondition, info.exprs.numFirstConditionTableColumns,
           gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
       case RightOuter if info.buildSide == GpuBuildRight =>
         new HashOuterJoinIterator(RightOuter, spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, None, lazyStream, info.exprs.boundStreamKeys, info.exprs.streamOutput,
+          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
           info.exprs.boundCondition, info.exprs.numFirstConditionTableColumns,
           gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
       case _ if info.exprs.boundCondition.isDefined =>
@@ -342,12 +342,12 @@ object GpuShuffledSizedHashJoinExec {
         val compiledCondition = info.exprs.boundCondition.get.convertToAst(
           info.exprs.numFirstConditionTableColumns).compile()
         new ConditionalHashJoinIterator(spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, lazyStream, info.exprs.boundStreamKeys, info.exprs.streamOutput,
+          info.buildStats, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
           compiledCondition, gpuBatchSizeBytes, info.joinType, info.buildSide,
           info.exprs.compareNullsEqual, opTime, joinTime)
       case _ =>
         new HashJoinIterator(spillableBuiltBatch, info.exprs.boundBuildKeys, info.buildStats,
-          lazyStream, info.exprs.boundStreamKeys, info.exprs.streamOutput,
+          spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
           gpuBatchSizeBytes, info.joinType, info.buildSide, info.exprs.compareNullsEqual,
           opTime, joinTime)
     }
@@ -470,13 +470,11 @@ abstract class GpuShuffledSizedHashJoinExec[HOST_BATCH_TYPE <: AutoCloseable] ex
       gpuBatchSizeBytes: Long,
       metricsMap: Map[String, GpuMetric]): Iterator[ColumnarBatch] = {
     val opTime = metricsMap(OP_TIME_LEGACY)
-    val lazyStream = new Iterator[LazySpillableColumnarBatch]() {
+    val spillableStreamBatch = new Iterator[SpillableColumnarBatch]() {
       override def hasNext: Boolean = info.streamIter.hasNext
 
-      override def next(): LazySpillableColumnarBatch = {
-        withResource(info.streamIter.next()) { batch =>
-          LazySpillableColumnarBatch(batch, "stream_batch")
-        }
+      override def next(): SpillableColumnarBatch = {
+        SpillableColumnarBatch(info.streamIter.next(), "stream_batch")
       }
     }
     val buildIter = new GpuCoalesceIterator(
@@ -496,11 +494,9 @@ abstract class GpuShuffledSizedHashJoinExec[HOST_BATCH_TYPE <: AutoCloseable] ex
     } else {
       GpuColumnVector.emptyBatchFromTypes(info.exprs.buildTypes)
     }
-    val spillableBuiltBatch = withResource(batch) { batch =>
-      assert(!buildIter.hasNext, "build side should have a single batch")
-      LazySpillableColumnarBatch(batch, "built")
-    }
-    createJoinIterator(info, spillableBuiltBatch, lazyStream, gpuBatchSizeBytes, opTime,
+    assert(!buildIter.hasNext, "build side should have a single batch")
+    val spillableBuiltBatch = SpillableColumnarBatch(batch, "built")
+    createJoinIterator(info, spillableBuiltBatch, spillableStreamBatch, gpuBatchSizeBytes, opTime,
       metricsMap(JOIN_TIME))
   }
 
@@ -1422,7 +1418,7 @@ class BuildSidePartitioner(
   }
 
   private val (emptyPartitions, joinGroups) = findEmptyAndJoinGroups()
-  private val partitionBatches = new Array[LazySpillableColumnarBatch](joinGroups.length)
+  private val partitionBatches = new Array[SpillableColumnarBatch](joinGroups.length)
   private val concatTime = metrics(CONCAT_TIME)
 
   /** Returns a BitSet where a set bit corresponds to an empty partition at that index. */
@@ -1444,7 +1440,7 @@ class BuildSidePartitioner(
    * @param partitionGroupIndex the index of the join group for which to produce the batch
    * @return the batch of data for the join group
    */
-  def getBuildBatch(partitionGroupIndex: Int): LazySpillableColumnarBatch = {
+  def getBuildBatch(partitionGroupIndex: Int): SpillableColumnarBatch = {
     var batch = partitionBatches(partitionGroupIndex)
     if (batch == null) {
       val spillBatchesBuffer = new mutable.ArrayBuffer[SpillableColumnarBatch]()
@@ -1462,12 +1458,10 @@ class BuildSidePartitioner(
           }
         }
       }
-      withResource(concatBatch) { _ =>
-        batch = LazySpillableColumnarBatch(concatBatch, "build subtable")
-        partitionBatches(partitionGroupIndex) = batch
-      }
+      batch = SpillableColumnarBatch(concatBatch, "build subtable")
+      partitionBatches(partitionGroupIndex) = batch
     }
-    LazySpillableColumnarBatch.spillOnly(batch)
+    batch
   }
 
   override def close(): Unit = {
@@ -1560,7 +1554,7 @@ class StreamSidePartitioner(
   }
 
   def releasePartitions(partIndices: BitSet): Array[SpillableColumnarBatch] = {
-    partIndices.iterator.flatMap(i => partitions(i).releaseBatches().toSeq).toArray
+    partIndices.toArray.flatMap(i => partitions(i).releaseBatches())
   }
 
   override def close(): Unit = {
@@ -1729,35 +1723,38 @@ class BigSizedJoinIterator(
     val builtBatch = buildPartitioner.getBuildBatch(currentJoinGroupIndex)
     val group = joinGroups(currentJoinGroupIndex)
     val streamBatches = streamPartitioner.releasePartitions(group)
-    val lazyStream = new Iterator[LazySpillableColumnarBatch] {
+    val safeStreamIterator = new Iterator[SpillableColumnarBatch] {
       onTaskCompletion(streamBatches.safeClose())
 
       private var i = 0
 
       override def hasNext: Boolean = i < streamBatches.length
 
-      override def next(): LazySpillableColumnarBatch = {
-        withResource(streamBatches(i)) { spillBatch =>
-          streamBatches(i) = null
-          i += 1
-          withResource(spillBatch.getColumnarBatch()) { batch =>
-            LazySpillableColumnarBatch(batch, "stream_batch")
-          }
-        }
+      override def next(): SpillableColumnarBatch = {
+        val spillBatch = streamBatches(i)
+        streamBatches(i) = null
+        i += 1
+        spillBatch
       }
     }
+
     if (needTracker) {
       // Build an iterator to perform the stream-side of the outer join for the join group,
       // tracking which rows are referenced so far. The iterator will own the tracker of build side
       // rows referenced until we release it after the iterator has produced all of the batches.
       val buildRowTracker = buildSideRowTrackers(currentJoinGroupIndex)
       buildSideRowTrackers(currentJoinGroupIndex) = None
+      // we increase this here because HashJoinStreamSideIterator closes it when done
+      builtBatch.incRefCount()
       new HashJoinStreamSideIterator(info.joinType,
         builtBatch, info.exprs.boundBuildKeys, info.buildStats, buildRowTracker,
-        lazyStream, info.exprs.boundStreamKeys, info.exprs.streamOutput, compiledCondition,
+        safeStreamIterator, info.exprs.boundStreamKeys, info.exprs.streamOutput, compiledCondition,
         gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
     } else {
-      GpuShuffledSizedHashJoinExec.createJoinIterator(info, builtBatch, lazyStream,
+      // we increase this here because BigSizedJoinIterator will want to reuse the build side
+      // and manages its lifecycle, but the iterator below wants to close the batch
+      builtBatch.incRefCount()
+      GpuShuffledSizedHashJoinExec.createJoinIterator(info, builtBatch, safeStreamIterator,
         gpuBatchSizeBytes, opTime, joinTime)
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -324,27 +324,30 @@ object GpuShuffledSizedHashJoinExec {
     info.joinType match {
       case FullOuter =>
         new HashOuterJoinIterator(FullOuter, spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
-          info.exprs.boundCondition, info.exprs.numFirstConditionTableColumns,
-          gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
+          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys,
+          info.exprs.streamOutput, info.exprs.boundCondition,
+          info.exprs.numFirstConditionTableColumns, gpuBatchSizeBytes, info.buildSide,
+          info.exprs.compareNullsEqual, opTime, joinTime)
       case LeftOuter if info.buildSide == GpuBuildLeft =>
         new HashOuterJoinIterator(LeftOuter, spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
-          info.exprs.boundCondition, info.exprs.numFirstConditionTableColumns,
-          gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
+          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys,
+          info.exprs.streamOutput, info.exprs.boundCondition,
+          info.exprs.numFirstConditionTableColumns, gpuBatchSizeBytes, info.buildSide,
+          info.exprs.compareNullsEqual, opTime, joinTime)
       case RightOuter if info.buildSide == GpuBuildRight =>
         new HashOuterJoinIterator(RightOuter, spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
-          info.exprs.boundCondition, info.exprs.numFirstConditionTableColumns,
-          gpuBatchSizeBytes, info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
+          info.buildStats, None, spillableStreamBatch, info.exprs.boundStreamKeys,
+          info.exprs.streamOutput, info.exprs.boundCondition,
+          info.exprs.numFirstConditionTableColumns, gpuBatchSizeBytes, info.buildSide,
+          info.exprs.compareNullsEqual, opTime, joinTime)
       case _ if info.exprs.boundCondition.isDefined =>
         // ConditionalHashJoinIterator will close the compiled condition
         val compiledCondition = info.exprs.boundCondition.get.convertToAst(
           info.exprs.numFirstConditionTableColumns).compile()
         new ConditionalHashJoinIterator(spillableBuiltBatch, info.exprs.boundBuildKeys,
-          info.buildStats, spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,
-          compiledCondition, gpuBatchSizeBytes, info.joinType, info.buildSide,
-          info.exprs.compareNullsEqual, opTime, joinTime)
+          info.buildStats, spillableStreamBatch, info.exprs.boundStreamKeys,
+          info.exprs.streamOutput, compiledCondition, gpuBatchSizeBytes, info.joinType,
+          info.buildSide, info.exprs.compareNullsEqual, opTime, joinTime)
       case _ =>
         new HashJoinIterator(spillableBuiltBatch, info.exprs.boundBuildKeys, info.buildStats,
           spillableStreamBatch, info.exprs.boundStreamKeys, info.exprs.streamOutput,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -171,11 +171,13 @@ trait SpillableGatherMap extends AutoCloseable {
 }
 
 object SpillableGatherMap {
-  def apply(map: GatherMap, name: String): SpillableGatherMap =
+  def apply(map: GatherMap, name: String): SpillableGatherMap = {
+    val rowCount = map.getRowCount()
     new SpillableGatherMapImpl(
       SpillableBuffer(map.releaseBuffer(), SpillPriorities.ACTIVE_ON_DECK_PRIORITY),
-      map.getRowCount(),
+      rowCount,
       name)
+  }
 
   def leftCross(leftCount: Int, rightCount: Int): SpillableGatherMap =
     new LeftCrossGatherMap(leftCount, rightCount)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, HostMemoryBuffer}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{SizeProvider, withRetryNoSplit}
+import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRetryNoSplit, SizeProvider}
 import com.nvidia.spark.rapids.spill.{SpillableColumnarBatchFromBufferHandle, SpillableColumnarBatchHandle, SpillableCompressedColumnarBatchHandle, SpillableDeviceBufferHandle, SpillableHostBufferHandle, SpillableHostColumnarBatchHandle}
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, HostMemoryBuffer}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRetryNoSplit, SizeProvider}
+import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{SizeProvider, withRetryNoSplit}
 import com.nvidia.spark.rapids.spill.{SpillableColumnarBatchFromBufferHandle, SpillableColumnarBatchHandle, SpillableCompressedColumnarBatchHandle, SpillableDeviceBufferHandle, SpillableHostBufferHandle, SpillableHostColumnarBatchHandle}
 
 import org.apache.spark.TaskContext
@@ -33,6 +33,11 @@ trait SpillableColumnarBatch extends AutoCloseable with SizeProvider {
    * The number of rows stored in this batch.
    */
   def numRows(): Int
+
+  /**
+   * The number of cols in this batch.
+   */
+  def numCols(): Int = dataTypes.length
 
   /**
    * Set a new spill priority.
@@ -128,6 +133,7 @@ class SpillableColumnarBatchImpl (
     refCount += 1
     this
   }
+
 
   /**
    * Remove the `ColumnarBatch` from the cache.
@@ -349,7 +355,8 @@ object SpillableColumnarBatch {
    * @param priority      the initial spill priority of this batch
    */
   def apply(batch: ColumnarBatch,
-      priority: Long): SpillableColumnarBatch = {
+            priority: Option[Long],
+            description: Option[String] = None): SpillableColumnarBatch = {
     Cuda.DEFAULT_STREAM.sync()
     val numRows = batch.numRows()
     if (batch.numCols() <= 0) {
@@ -376,6 +383,14 @@ object SpillableColumnarBatch {
     }
   }
 
+  def apply(batch: ColumnarBatch, description: String): SpillableColumnarBatch = {
+    apply(batch, Some(SpillPriorities.ACTIVE_BATCHING_PRIORITY), Some(description))
+  }
+
+  def apply(batch: ColumnarBatch, priority: Long): SpillableColumnarBatch = {
+    apply(batch, Some(priority), None)
+  }
+
   /**
    * Create a new SpillableColumnarBatch
    * @note This takes over ownership of `ct`, and `ct` should not be used after this.
@@ -386,13 +401,29 @@ object SpillableColumnarBatch {
   def apply(
       ct: ContiguousTable,
       sparkTypes: Array[DataType],
-      priority: Long): SpillableColumnarBatch = {
+      priority: Option[Long],
+      description: Option[String]): SpillableColumnarBatch = {
     Cuda.DEFAULT_STREAM.sync()
     new SpillableColumnarBatchFromBufferImpl(
       SpillableColumnarBatchFromBufferHandle(ct, sparkTypes),
       ct.getRowCount.toInt,
       sparkTypes)
   }
+
+  def apply(
+      batch: ContiguousTable,
+      sparkTypes: Array[DataType],
+      description: String): SpillableColumnarBatch = {
+    apply(batch, sparkTypes, Some(SpillPriorities.ACTIVE_BATCHING_PRIORITY), Some(description))
+  }
+
+  def apply(
+      batch: ContiguousTable,
+      sparkTypes: Array[DataType],
+      priority: Long): SpillableColumnarBatch = {
+    apply(batch, sparkTypes, Some(priority), None)
+  }
+
 }
 
 object SpillableHostColumnarBatch {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
@@ -44,7 +44,6 @@ import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.BlockId
 
-
 /**
  * Spark-RAPIDS Spill Framework
  *
@@ -263,7 +262,6 @@ trait SpillableHandle extends StoreHandle with Logging {
       doClose()
     }
   }
-
 }
 
 /**
@@ -1280,6 +1278,9 @@ trait HandleStore[T <: StoreHandle] extends AutoCloseable with Logging {
   }
 
   override def close(): Unit = synchronized {
+    if (handles.size() > 0) {
+      logWarning(s"We have ${handles.size} handles still in the store, which we will close. ${handles.toArray().mkString(",")}")
+    }
     handles.forEach(handle => {
       handle.close()
     })

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
@@ -1279,7 +1279,7 @@ trait HandleStore[T <: StoreHandle] extends AutoCloseable with Logging {
 
   override def close(): Unit = synchronized {
     if (handles.size() > 0) {
-      logWarning(s"We have ${handles.size} handles still in the store, which we will close. ${handles.toArray().mkString(",")}")
+      logWarning(s"We have ${handles.size} handles still in the store, which we will close.")
     }
     handles.forEach(handle => {
       handle.close()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -17,13 +17,16 @@
 package org.apache.spark.sql.rapids
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
+
 import scala.collection.mutable
+
 import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.{GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuExpression, GpuMetric, GpuSemaphore, MetricsLevel, SpillableColumnarBatch}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.ShimBinaryExecNode
+
 import org.apache.spark.{Dependency, NarrowDependency, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
@@ -19,6 +19,7 @@ import ai.rapids.cudf.{ColumnVector, GatherMap, NvtxColor, Scalar, Table}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuMetric, NvtxWithMetrics, SpillableColumnarBatch, TaskAutoCloseableResource}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
+
 import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -246,6 +246,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
    * Public for tests.
    */
   def closeInternal(): Unit = this.synchronized {
+    println(s"closeInternal for broadcast with batch ${batchInternal}")
     Seq(data, batchInternal).safeClose()
     data = null
     batchInternal = null

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,7 +246,6 @@ class SerializeConcatHostBuffersDeserializeBatch(
    * Public for tests.
    */
   def closeInternal(): Unit = this.synchronized {
-    println(s"closeInternal for broadcast with batch ${batchInternal}")
     Seq(data, batchInternal).safeClose()
     data = null
     batchInternal = null

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -367,7 +367,7 @@ object GpuBroadcastNestedLoopJoinExecBase {
       override def next(): ColumnarBatch = {
         withResource(stream.next()) { streamSpillable =>
           withResource(streamSpillable.getColumnarBatch()) { streamBatch =>
-            val existsCol: ColumnVector = if (builtBatch.numRows == 0) {
+            val existsCol: ColumnVector = if (builtBatch.numRows() == 0) {
               withResource(Scalar.fromBool(false)) { falseScalar =>
                 GpuColumnVector.from(
                   cudf.ColumnVector.fromScalar(falseScalar, streamSpillable.numRows()),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -19,7 +19,7 @@ import ai.rapids.cudf.{ColumnView, DType, GatherMap, NullEquality, NvtxColor, Ou
 import ai.rapids.cudf.ast.CompiledExpression
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRetryNoSplit}
 import com.nvidia.spark.rapids.jni.GpuOOM
 import com.nvidia.spark.rapids.shims.ShimBinaryExecNode

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -500,8 +500,7 @@ class HashJoinIterator(
       // hack to work around unique_join not handling empty tables
       if (joinType.isInstanceOf[InnerLike] &&
         (leftKeys.getRowCount == 0 || rightKeys.getRowCount == 0)) {
-        leftData.close()
-        rightData.close()
+        Seq(leftData, rightData).safeClose()
         None
       } else {
         val maps = joinType match {

--- a/tests/src/test/spark350/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilterSuite.scala
+++ b/tests/src/test/spark350/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilterSuite.scala
@@ -27,12 +27,13 @@ package com.nvidia.spark.rapids.iceberg.data
 
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
+
 import com.nvidia.spark.rapids.{GpuColumnVector, NoopMetric, RapidsConf, SpillableColumnarBatch}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric.{JOIN_TIME, OP_TIME_LEGACY}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergFileIO
-import com.nvidia.spark.rapids.iceberg.{PooledTableGen, fieldIndex}
+import com.nvidia.spark.rapids.iceberg.{fieldIndex, PooledTableGen}
 import com.nvidia.spark.rapids.iceberg.data.TestGpuDeleteLoader._
 import com.nvidia.spark.rapids.iceberg.parquet.{GpuIcebergParquetReaderConf, SingleFile}
 import com.nvidia.spark.rapids.spill.SpillFramework
@@ -49,9 +50,10 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.types.{DataType, LongType, StringType, StructType}
-import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 class GpuDeleteFilterSuite extends AnyFunSuite with BeforeAndAfterAll {
   override def beforeAll(): Unit = {

--- a/tests/src/test/spark350/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilterSuite.scala
+++ b/tests/src/test/spark350/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilterSuite.scala
@@ -27,14 +27,12 @@ package com.nvidia.spark.rapids.iceberg.data
 
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
-
-import ai.rapids.cudf.{DType, HostColumnVector, HostColumnVectorCore}
-import com.nvidia.spark.rapids.{GpuColumnVector, LazySpillableColumnarBatch, NoopMetric, RapidsConf}
+import com.nvidia.spark.rapids.{GpuColumnVector, NoopMetric, RapidsConf, SpillableColumnarBatch}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric.{JOIN_TIME, OP_TIME_LEGACY}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergFileIO
-import com.nvidia.spark.rapids.iceberg.{fieldIndex, PooledTableGen}
+import com.nvidia.spark.rapids.iceberg.{PooledTableGen, fieldIndex}
 import com.nvidia.spark.rapids.iceberg.data.TestGpuDeleteLoader._
 import com.nvidia.spark.rapids.iceberg.parquet.{GpuIcebergParquetReaderConf, SingleFile}
 import com.nvidia.spark.rapids.spill.SpillFramework
@@ -51,10 +49,9 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.types.{DataType, LongType, StringType, StructType}
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 
 class GpuDeleteFilterSuite extends AnyFunSuite with BeforeAndAfterAll {
   override def beforeAll(): Unit = {
@@ -349,7 +346,7 @@ class TestGpuDeleteLoader(private val tableGen: PooledTableGen,
 
   override def loadDeletes(deletes: Seq[DeleteFile],
       schema: Schema,
-      sparkTypes: Array[DataType]): LazySpillableColumnarBatch = {
+      sparkTypes: Array[DataType]): SpillableColumnarBatch = {
     require(deletes.nonEmpty, "No deletes to load")
     require(deletes.map(_.content()).distinct.length == 1,
       "Only one kind of delete content is supported")
@@ -361,9 +358,8 @@ class TestGpuDeleteLoader(private val tableGen: PooledTableGen,
           .asScala
           .map(_.fieldId())
           .toSeq
-        withResource(tableGen.pooledHostVector(fieldIds, rows)) { batch =>
-          LazySpillableColumnarBatch(batch, "Eq deletes build")
-        }
+        val batch = tableGen.pooledHostVector(fieldIds, rows)
+        SpillableColumnarBatch(batch, "Eq deletes build")
       case FileContent.POSITION_DELETES =>
         val pairs = posDeletes
           .keys
@@ -386,9 +382,8 @@ class TestGpuDeleteLoader(private val tableGen: PooledTableGen,
             .safeMap(p => GpuColumnVector.from(p._1, p._2))
             .toArray[ColumnVector]
 
-          withResource(new ColumnarBatch(columns, pairs.length)) { batch =>
-            LazySpillableColumnarBatch(batch, "Pos deletes build")
-          }
+          val batch = new ColumnarBatch(columns, pairs.length)
+          SpillableColumnarBatch(batch, "Pos deletes build")
         }
 
       case c => throw new UnsupportedOperationException(s"Unsupported delete content: $c")

--- a/tests/src/test/spark350/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilterSuite.scala
+++ b/tests/src/test/spark350/scala/com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilterSuite.scala
@@ -28,6 +28,7 @@ package com.nvidia.spark.rapids.iceberg.data
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
 
+import ai.rapids.cudf.{DType, HostColumnVector, HostColumnVectorCore}
 import com.nvidia.spark.rapids.{GpuColumnVector, NoopMetric, RapidsConf, SpillableColumnarBatch}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric.{JOIN_TIME, OP_TIME_LEGACY}


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/7529

### Description

This PR removes `LazySpillableColumnarBatch` from the join in order to make the apis cleaner to use. I have not run performance tests on this yet.

### Checklists

- [x] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
