### PR TITLE
Triple buffering: Bind Virtual Resource Budget to Physical Memory Allocation [databricks]

### DIFF
--- a/integration_tests/src/main/python/multithread_file_reader_utils.py
+++ b/integration_tests/src/main/python/multithread_file_reader_utils.py
@@ -44,7 +44,7 @@ def resource_bounded_multithreaded_reader_conf(file_type,
     ])
     memory_limit = ('spark.rapids.sql.multiThreadedRead.memoryLimit.size', mem_lmt)
 
-    timeout = _list_conf_helper(timeout_conf, default=[0, 1000, 60000])
+    timeout = _list_conf_helper(timeout_conf, default=[500, 3000, 60000])
     task_timeout = ('spark.rapids.sql.multiThreadedRead.memoryLimit.acquisitionTimeout', timeout)
 
     conf_matrix = [base_conf]

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -126,31 +126,10 @@ trait HostMemoryBuffersWithMetaDataBase extends AutoCloseable {
     _scheduleTime.toDouble / totalTime
   }
 
-  def releaseResource(): Unit = {
-    while (_releaseCallback.nonEmpty)  {
-      // Call the release callback to release the resources
-      _releaseCallback.dequeue()()
-    }
-  }
-
-  def addReleaseResourceCallback(callback: () => Unit): Unit = {
-    _releaseCallback.enqueue(callback)
-  }
-
-  def combineReleaseCallbacks(
-      other: HostMemoryBuffersWithMetaDataBase): Unit = {
-    while (_releaseCallback.nonEmpty) {
-      other._releaseCallback.enqueue(_releaseCallback.dequeue())
-    }
-  }
-
-  private val _releaseCallback: mutable.Queue[() => Unit] = mutable.Queue.empty
-
   // This close method is idempotent, since both SingleHMBAndMeta.close and releaseResource
   // keep idempotent.
   override def close(): Unit = {
     memBuffersAndSizes.safeClose()
-    releaseResource()
   }
 }
 
@@ -199,7 +178,8 @@ object MultiFileReaderThreadPool extends Logging {
           name,
           pool,
           numThreads,
-          boundedConf.waitMemTimeoutMs)
+          boundedConf.waitMemTimeoutMs,
+          isStageLevel = conf.stageLevelPool)
     }
     threadPoolExecutor.allowCoreThreadTimeOut(true)
     threadPoolExecutor
@@ -683,16 +663,6 @@ abstract class MultiFileCloudPartitionReaderBase(
 
   // Unwrap RunnerResult to facilitate the combination of file buffers.
   private def convertAsyncResult(taskRet: RunnerResult): BufferInfo = {
-    taskRet.releaseHook.foreach { callback =>
-      taskRet.data match {
-        // If the task result is empty, call the release callback ASAP.
-        case bufWithMeta if bufWithMeta.bytesRead == 0 =>
-          callback()
-        // inject the release callback for deferred release
-        case bufWithMeta =>
-          bufWithMeta.addReleaseResourceCallback(callback)
-      }
-    }
     taskRet.data.setScheduleTime(taskRet.metrics.scheduleTimeMs)
     taskRet.data
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1246,6 +1246,19 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
         .createWithDefault(false)
   }
 
+  val MULTITHREAD_READ_MAX_BUFFER_CLOSE_WAIT_RETRIES = {
+    conf("spark.rapids.sql.multiThreadedRead.maxBufferCloseWaitRetries")
+        .doc("The maximum number of retry attempts (each waiting 30 seconds) for all host " +
+            "memory buffers to be closed when closing a MemoryBoundedAsyncRunner. If the " +
+            "retry count exceeds this threshold, an exception will be thrown to prevent " +
+            "indefinite hangs caused by leaked buffer references. This helps detect resource " +
+            "management bugs early.")
+        .internal()
+        .integerConf
+        .checkValue(v => v > 0, "The max retry attempts must be greater than zero")
+        .createWithDefault(4)
+  } // 4 retries * 30s = 120 seconds max wait
+
   val ENABLE_PARQUET = conf("spark.rapids.sql.format.parquet.enabled")
     .doc("When set to false disables all parquet input and output acceleration")
     .booleanConf
@@ -3424,6 +3437,9 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val multiThreadReadStageLevelPool: Boolean =
     get(MULTITHREAD_READ_MEMORY_LIMIT_TEST_PER_STAGE_POOL)
+
+  lazy val multiThreadReadMaxBufferCloseWaitRetries: Int =
+    get(MULTITHREAD_READ_MAX_BUFFER_CLOSE_WAIT_RETRIES)
 
   lazy val isParquetEnabled: Boolean = get(ENABLE_PARQUET)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncRunners.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncRunners.scala
@@ -513,6 +513,7 @@ abstract class MemoryBoundedAsyncRunner[T] extends AsyncRunner[T]
     def onClosed(refCount: Int): Unit = if (refCount == 0) {
       // Return the memory back to the local pool and signal waiting onClose thread if exists
       r.withStateLock[Unit]() { _ =>
+        // TODO: check if the returned memory satisfies the ongoing borrow requests
         usedMem.addAndGet(-bufferSize)
         bufCloseCond.signal() // awaken onClose waiting thread if exists
         logDebug(s"[OnCloseHandler Closed] bufferSize=${bToStr(bufferSize)} for $r")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourceBoundedThreadExecutor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourceBoundedThreadExecutor.scala
@@ -289,7 +289,12 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
           Option(rr.result) match {
             case None => // Fatal error
               throw new IllegalStateException(s"In Completed State but NO Result: $rr")
-            case _ => // try to release unused resource as eagerly as possible
+            case _ if rr.closeStarted.get() =>
+              // close has already started, do nothing
+              // This is a rare case when the runner is closed between execution and afterExecute
+              // by other threads explicitly.
+            case _ =>
+              // try to release unused resource as eagerly as possible
               mgr.release(rr, forcefully = false)
           }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourceBoundedThreadExecutor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourceBoundedThreadExecutor.scala
@@ -39,18 +39,19 @@ import org.apache.spark.util.TaskCompletionListener
 class RapidsFutureTask[T](val runner: AsyncRunner[T])
     extends FutureTask[AsyncResult[T]](runner) with Logging {
 
-  override def run(): Unit = runner.withStateLock { rr =>
+  override def run(): Unit = runner.withStateLock(holdAnyway = true) { rr =>
     rr.getState match {
       case Running =>
         // Pass the schedule time to the task metrics builder
         rr.metricsBuilder.setScheduleTimeMs(scheduleTime)
         scheduleTime = 0L
+        // Execute as FutureTask
         super.run()
         // Check if the runner completed successfully, since the exception shall be handled
         // quietly by FutureTask and recorded internally by `setException`.
         // Note: `super.isDone` is also true even if the task finished unsuccessfully. Therefore,
         // we need to check `rr.result` as well to determine if the task completed successfully
-        if (rr.result.nonEmpty && super.isDone) {
+        if (rr.result != null && super.isDone) {
           // runner.call has completed successfully
           rr.setState(Completed)
         } else if (runner.getState.isInstanceOf[ExecFailed]) {
@@ -143,7 +144,8 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
     maximumPoolSize: Int,
     workQueue: BlockingQueue[Runnable],
     threadFactory: ThreadFactory,
-    keepAliveTime: Long = 100L) extends ThreadPoolExecutor(corePoolSize,
+    keepAliveTime: Long = 100L,
+    isStageLevel: Boolean = false) extends ThreadPoolExecutor(corePoolSize,
   maximumPoolSize, keepAliveTime, TimeUnit.SECONDS, workQueue, threadFactory) with Logging {
 
   logInfo(s"Creating ResourceBoundedThreadExecutor with resourcePool: ${mgr.toString}, " +
@@ -198,7 +200,7 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
   override def beforeExecute(t: Thread, r: Runnable): Unit = {
     val futTask = parseFutureTask(r)
 
-    futTask.runner.withStateLock { rr =>
+    futTask.runner.withStateLock(holdAnyway = true) { rr =>
       // Check if the Spark task has been interrupted before execution
       rr.sparkTaskContext.foreach {
         case ctx if ctx.isInterrupted() => rr.setState(Cancelled)
@@ -218,14 +220,16 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
           rr.setState(Pending)
           // register all the callbacks for the first time
           if (init.firstTime) {
-            setupReleaseCallback(futTask)
+            setupListeners(futTask, debugMode = isStageLevel)
           }
           // Talk to the ResourcePool to acquire resource for the runner
-          val acqStatus = mgr.acquireResource(rr, timeoutMs)
+          val acqStatus = mgr.acquire(rr, timeoutMs)
           // Update the runner state based on the acquisition result
           acqStatus match {
             // Proceed to execution: Pending -> Running
             case s: AcquireSuccessful =>
+              // Activate runner with resource pool and trigger custom startup logic
+              rr.onStart(mgr)
               rr.setState(Running)
               futTask.scheduleTime += s.elapsedTime
             // Fail the scheduling: Pending -> ScheduleFailed
@@ -249,8 +253,17 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
 
   override def afterExecute(r: Runnable, t: Throwable): Unit = {
     val futTask = parseFutureTask(r)
-
-    futTask.runner.withStateLock { rr =>
+    // Skip post-execution handling if the runner has already started closing.
+    // This is an optimization to avoid unnecessary blocking: the current thread
+    // would block waiting for the runner's state lock while the runner itself
+    // is blocked on a blocking OnClose callback (e.g., MemoryBoundedAsyncRunner.onClose)
+    if (futTask.runner.closeStarted.get()) {
+      futTask.runner.withStateLock(releaseAnyway = true) { _ =>
+        return
+      }
+    }
+    // Post execution state handling
+    futTask.runner.withStateLock(releaseAnyway = true) { rr =>
       // Throw the unexpected exception if exists, since the FutureTask should have caught
       // and recorded the exception internally.
       if (t != null) {
@@ -265,29 +278,22 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
         logError(s"Uncaught exception from $futTask: ${t.getMessage}", t)
       }
 
-      // Post execution state handling
       rr.getState match {
         case Cancelled | // very rare case: cancelled between execution and afterExecute
              ExecFailed(_) => // failed execution (ScheduleFailed should be cast to ExecFailed)
           // release holding resource immediately on exception
-          if (rr.isHoldingResource) {
-            rr.releaseResourceCallback()
-          }
+          rr.close()
 
         case Completed => // successful execution
           // release holding resource eagerly if the output does not hold the resource
-          rr.result match {
-            case None =>
-              // Fatal error
+          Option(rr.result) match {
+            case None => // Fatal error
               throw new IllegalStateException(s"In Completed State but NO Result: $rr")
-            case Some(_: FastReleaseResult[_]) if rr.isHoldingResource =>
-              rr.releaseResourceCallback()
-            case _ =>
+            case _ => // try to release unused resource as eagerly as possible
+              mgr.release(rr, forcefully = false)
           }
 
         case Pending => // timeout during resource acquisition
-          // Only runners in (`Completed`, `ExecFailed`, `Cancelled`) may hold resource
-          require(!rr.isHoldingResource, s"Pending state should NOT hold Resource: $rr")
           // Requeue runners which failed to acquire resource and bypassed the execution.
           futTask.scheduleTime += timeoutMs * 1000000L
           rr.setState(Init(firstTime = false)) // reset to Init state for re-scheduling
@@ -315,68 +321,53 @@ class ResourceBoundedThreadExecutor(mgr: ResourcePool,
     }
   }
 
-  private def setupReleaseCallback[T](fut: RapidsFutureTask[T]): Unit = {
-    // Bind the resource release callback to the AsyncRunner
-    fut.runner.releaseResourceCallback = () => {
-      require(fut.runner.isHoldingStateLock, "Must hold StateLock to release resource")
-
-      fut.runner match {
-        // Check if resource has already been released while waiting for StateLock
-        case rr if rr.isHoldingResource =>
-          val state = rr.getState
-          require(state == Cancelled ||
-              state == Completed || state.isInstanceOf[ExecFailed],
-            s"Runner $rr is expected to be: Cancelled | Completed | ExecFailed")
-
-          // Modify the status of HostMemoryPool
-          mgr.releaseResource(rr)
-
-          // Finalize the runner state
-          state match {
-            case Completed => // Completed -> Closed
-              rr.setState(Closed(None))
-            case ExecFailed(ex) => // ExecFailed -> Closed
-              rr.setState(Closed(Some(ex)))
-            case Cancelled => // Cancelled -> Closed
-              rr.setState(Closed(Some(new IllegalStateException("cancelled"))))
-            case _ =>
-              throw new IllegalStateException(s"Should NOT reach here: $rr")
-          }
-
-        case rr => // already released
-          logWarning(s"Resource has already been released by other thread: $rr")
-      }
-    }
-
+  private def setupListeners[T](fut: RapidsFutureTask[T], debugMode: Boolean): Unit = {
     // Register a callback to ensure the AsyncRunner being fully closed when the Spark task
     // completes, regardless of whether the task succeeds or fails. This is a safety net to
     // prevent resource leaks in case that Spark task is killed or fails unexpectedly.
     fut.runner.sparkTaskContext.foreach { ctx =>
       ctx.addTaskCompletionListener(new TaskCompletionListener {
         override def onTaskCompletion(context: TaskContext): Unit = {
-          if (context.isInterrupted()) {
-            logError(s"[onTaskComp] Handle runner as Task was interrupted: ${fut.runner}")
+          val isInterrupted = context.isInterrupted()
+          if (isInterrupted) {
+            val msg = s"[onTaskComp] Handle runner as Task was interrupted: ${fut.runner}"
+            if (debugMode) throw new RuntimeException(msg) else logError(msg)
           }
-          // 1. If the runner is still running, we try to cancel it first
-          if (fut.runner.getState == Running) {
-            fut.cancel(true) // mayInterruptIfRunning = true
+          val isClosed: Boolean = fut.runner.getState match {
+            case Closed(_) => true
+            case Cancelled => false
+            case _ =>
+              if (!isInterrupted) {
+                val msg = s"[onTaskComp] Task done without being closed: ${fut.runner}"
+                if (debugMode) throw new RuntimeException(msg) else logError(msg)
+              }
+              false
           }
-          // 2. Mark the runner as Cancelled
-          fut.runner.withStateLock { rr =>
-            rr.getState match {
-              case Init(_) => rr.setState(Cancelled) // Init -> Cancelled
-              case Pending => rr.setState(Cancelled) // Pending -> Cancelled
-              case Running => rr.setState(Cancelled) // Running -> Cancelled
-              case ScheduleFailed(_) => rr.setState(Cancelled) // ScheduleFailed -> Cancelled
-              case Completed => rr.setState(Cancelled) // Completed -> Cancelled
-              case Cancelled | ExecFailed(_) | Closed(_) => // do nothing
+
+          // Proceed to close the runner if it is not closed yet
+          if (!isClosed) {
+            // 1. If the runner is still running, we try to cancel it first
+            if (fut.runner.getState == Running) {
+              fut.cancel(true) // mayInterruptIfRunning = true
             }
-          }
-          // 3. If the runner is still holding resource, we release it
-          if (fut.runner.isHoldingResource) {
-            fut.runner.withStateLock {
-              _.releaseResourceCallback()
+            // 2. Convert the state to Cancelled if it is not in a terminal state yet
+            fut.runner.withStateLock(holdAnyway = true) { rr =>
+              rr.getState match {
+                case Init(_) => rr.setState(Cancelled) // Init -> Cancelled
+                case Pending => rr.setState(Cancelled) // Pending -> Cancelled
+                case Running => rr.setState(Cancelled) // Running -> Cancelled
+                case ScheduleFailed(_) => rr.setState(Cancelled) // ScheduleFailed -> Cancelled
+                case Completed => rr.setState(Cancelled) // Completed -> Cancelled
+                case Cancelled | ExecFailed(_) | Closed(_) => // do nothing
+              }
             }
+            // 3. Close the runner, the close method of AsyncRunner should be idempotent
+            fut.runner.close()
+          }
+
+          // Finally, safety check for resource leak
+          fut.runner.withStateLock() { rr =>
+            mgr.detectResourceLeak(rr)
           }
         }
       })
@@ -388,7 +379,8 @@ object ResourceBoundedThreadExecutor {
   def apply[T](name: String,
       pool: ResourcePool,
       maxThreadNumber: Int,
-      waitResourceTimeoutMs: Long): ResourceBoundedThreadExecutor = {
+      waitResourceTimeoutMs: Long,
+      isStageLevel: Boolean = false): ResourceBoundedThreadExecutor = {
     val taskQueue = new PriorityBlockingQueue(10000, new RapidsFutureTaskComparator[T])
     val threadFactory: ThreadFactory = new ThreadFactoryBuilder()
         .setDaemon(true)
@@ -400,6 +392,7 @@ object ResourceBoundedThreadExecutor {
       corePoolSize = maxThreadNumber,
       maximumPoolSize = maxThreadNumber,
       workQueue = taskQueue.asInstanceOf[BlockingQueue[Runnable]],
-      threadFactory = threadFactory)
+      threadFactory = threadFactory,
+      isStageLevel = isStageLevel)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourcePools.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourcePools.scala
@@ -16,18 +16,16 @@
 
 package com.nvidia.spark.rapids.io.async
 
-import java.util.concurrent.TimeUnit
+import java.lang.{Long => JLong}
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 
+import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.rapids.execution.TrampolineUtil.bytesToString
-
-// Being thrown when a task requests resources that are not valid or exceed the limits
-class InvalidResourceRequest(msg: String) extends RuntimeException(
-  s"Invalid resource request: $msg")
+import org.apache.spark.sql.rapids.execution.TrampolineUtil.{bytesToString => bToStr}
 
 // Represents the status of acquiring resources for a task
 sealed trait AcquireStatus
@@ -52,44 +50,70 @@ trait ResourcePool {
    * Returns true if the task can be accepted, false otherwise.
    * TrafficController will block the task from being scheduled until this method returns true.
    */
-  def acquireResource[T](task: AsyncRunner[T], timeout: Long): AcquireStatus
+  protected[async] def acquire[T](runner: AsyncRunner[T], timeout: Long): AcquireStatus
 
   /**
-   * Callback to be called when a task is completed, either successfully or with an exception.
+   * Closed a completed AsyncRunner (either successfully or failed) and cleanup its resources.
+   *
+   * This method is typically called as a callback hooked to various completion events to handle
+   * scenarios such as cancellation or end of lifecycle.
    */
-  def releaseResource[T](task: AsyncRunner[T]): Unit
+  protected[async] def finishUpRunner[T](runner: AsyncRunner[T]): Unit
+
+  /**
+   * Release resources held by the runner. If forcefully is true, release all resources regardless
+   * of what the runner actually holds. Otherwise, only release what the runner can free.
+   *
+   * NOTE: Although this method is NOT responsible for closing, it is recommended to close the
+   * runner if it is no longer holding any resources after the release, such as HostMemoryPool.
+   */
+  protected[async] def release[T](runner: AsyncRunner[T], forcefully: Boolean): Unit
+
+  /**
+   * Performed the detection after the runner has been fully closed, serving as a final safety
+   * check to catch any resource management bugs. If a leak is detected, this method should
+   * throw an IllegalStateException with details about the leak.
+   *
+   * Currently, This method is only called at the end of Spark task completion callback to verify
+   * two aspects:
+   * - Runner-side: verify the runner has zero resource usage after being closed
+   * - Pool-side: when runner count reaches zero, verify all resources have been returned
+   */
+  protected[async] def detectResourceLeak[T](runner: AsyncRunner[T]): Unit = {}
 }
 
 /**
  * HostMemoryPool enforces a maximum limit on total host memory bytes that can be held
- * by in-flight tasks simultaneously. It provides blocking resource acquisition with
- * configurable timeout and supports both individual and grouped task allocation patterns.
+ * by in-flight runner simultaneously. It provides blocking resource acquisition with
+ * configurable timeout.
  *
  * The implementation uses condition variables to efficiently block and wake up waiting
  * tasks when resources become available through task completion and resource release.
  */
 class HostMemoryPool(val maxHostMemoryBytes: Long) extends ResourcePool with Logging {
 
-  private val lock = new ReentrantLock()
+  private val poolLock = new ReentrantLock()
 
-  private val condition = lock.newCondition()
+  private val acquireCondition = poolLock.newCondition()
+  private val borrowCondition = poolLock.newCondition()
+  @volatile private var numOfBorrowWaiters: Int = 0
 
   // Tracking running AsyncRunners which actually acquires host memory, which is mainly for deadlock
   // prevention for now.
   private val numRunnerInFlight: AtomicLong = new AtomicLong(0L)
 
-  // It is safe to use thread-nonsafe variables because below states are only accessed within
-  // the lock guarded critical section.
   private var remaining: Long = maxHostMemoryBytes
 
   // Only counts for the AsyncRunners which actually acquired host memory.
-  private var numRunnerInPool: Long = 0L
+  private val numRunnerInPool: AtomicLong = new AtomicLong(0L)
 
-  private val tasksInPool = mutable.HashMap[Long, Long]()
+  // Map of TaskAttemptId -> number of active runners, use Java Long for nullability
+  private val tasksInPool = new ConcurrentHashMap[Long, JLong](64)
 
-  override def acquireResource[T](runner: AsyncRunner[T], timeoutMs: Long): AcquireStatus = {
+  override protected[async] def acquire[T](runner: AsyncRunner[T],
+      timeoutMs: Long): AcquireStatus = {
     // step 1: extract the resource requirements and runner info
-    val memoryRequire: Long = extractResource(runner).hostMemoryBytes
+    val memoryRequire: Long = extractResource(runner).sizeInBytes
 
     // step 2: try to acquire the resource with blocking and timeout
     // 2.1 If no resource needed, acquire immediately
@@ -103,110 +127,270 @@ class HostMemoryPool(val maxHostMemoryBytes: Long) extends ResourcePool with Log
       val timeoutNs = TimeUnit.MILLISECONDS.toNanos(timeoutMs)
       var waitTimeNs = timeoutNs
       // Enter into the critical section which is guarded by the lock from concurrent access
-      lock.lockInterruptibly()
+      poolLock.lockInterruptibly()
       try {
-        // [Deadlock Prevention]
-        // Due to the decay release, the virtual memory limit may interact with other dependency
-        // mechanisms, such as in a local join. In this scenario, both sides of the join may
-        // perform multithreaded scans limited by the HostMemoryPool. The join operator requires
-        // outputs from both sides, but one side may occupy all the memory budget, leaving the
-        // other side blocked and waiting for memory to be released.
-        //
-        // [Solution]
-        // If there is no runner in flight, run the request runner immediately regardless of
-        // the current available resource.
-        if (remaining < memoryRequire &&
-            numRunnerInFlight.compareAndSet(0L, 1L)) {
-          // The remaining resource should be negative here
-          remaining -= memoryRequire
-          isDone = true
-          // Register a post-hook to decrement numRunnerInFlight as soon as the runner is done
-          runner.addPostHook(() => numRunnerInFlight.decrementAndGet())
-        } else {
-          do {
-            // If enough resource is available, acquire it and exit the loop.
-            if (remaining >= memoryRequire) {
-              remaining -= memoryRequire
-              isDone = true
-              // Update numRunnerInFlight as soon as the runner being permitted to run, meanwhile
-              // register a post-hook to decrement it as soon as the runner is done
+        // The main loop to try acquiring the resource with blocking and timeout
+        do {
+          if (remaining >= memoryRequire || {
+            // [Deadlock Prevention]
+            // Due to the decay release, the virtual memory limit may interact with other dependency
+            // mechanisms, such as in a local join. In this scenario, both sides of the join may
+            // perform multithreaded scans limited by the HostMemoryPool. The join operator requires
+            // outputs from both sides, but one side may occupy all the memory budget, leaving the
+            // other side blocked and waiting for memory to be released.
+            //
+            // [Solution]
+            // If there is no runner in flight, run the request runner immediately regardless of
+            // the current available resource.
+            numRunnerInFlight.compareAndSet(0L, 1L)
+          }) {
+            remaining -= memoryRequire
+            isDone = true
+            // When remaining < 0, the increment was done by the CAS above
+            if (remaining >= 0L) {
               numRunnerInFlight.incrementAndGet()
-              runner.addPostHook(() => numRunnerInFlight.decrementAndGet())
-            } else if (waitTimeNs > 0) {
-              waitTimeNs = condition.awaitNanos(waitTimeNs)
-            } else {
-              isTimeout = true
-              logWarning(s"Failed to acquire ${bytesToString(memoryRequire)}, remaining=" +
-                  s"${bytesToString(remaining)}, AsyncRunners=$numRunnerInPool, " +
-                  s"SparkTasks=${tasksInPool.size}")
             }
-          } while (!isDone && !isTimeout)
+            // register a post-hook to decrement it as soon as the runner is done
+            runner.addPostHook(() => {
+              numRunnerInFlight.decrementAndGet()
+              // wake up potential borrowers cuz numInFlight reduced
+              poolLock.lockInterruptibly()
+              try {
+                borrowCondition.signal()
+              } finally {
+                poolLock.unlock()
+              }
+            })
+          } else if (waitTimeNs > 0L) {
+            waitTimeNs = acquireCondition.awaitNanos(waitTimeNs)
+          } else {
+            isTimeout = true
+            logWarning(s"Failed to acquire ${bToStr(memoryRequire)}: ${printStatus()}")
+          }
         }
+        while (!isDone && !isTimeout)
+
         if (!isDone) {
           AcquireFailed
         } else {
           // Update nonAtomic states if the resource is acquired successfully
-          numRunnerInPool += 1L
           runner.sparkTaskContext.foreach { ctx =>
-            val tid = ctx.taskAttemptId()
-            val numRunner = tasksInPool.getOrElse(tid, 0L)
-            tasksInPool.put(tid, numRunner + 1L)
+            registerRunner(ctx)
           }
-          // Callback to the runner for post-acquire actions, should keep thread-safe
-          runner.onAcquire()
           // Log a warning when the resource is over-committed
           if (remaining < 0) {
             logWarning(
-              s"Over-committed HostMemoryPool: exceeded_amount=${bytesToString(-remaining)}, " +
-                  s"AsyncRunners=$numRunnerInPool, SparkTasks=${tasksInPool.size}")
+              s"Over-committed HostMemoryPool: ${printStatus()}")
           }
           AcquireSuccessful(elapsedTime = timeoutNs - waitTimeNs)
         }
       } catch {
         case ex: Throwable => AcquireExcepted(ex)
       } finally {
-        lock.unlock()
+        poolLock.unlock()
       }
     }
   }
 
-  override def releaseResource[T](runner: AsyncRunner[T]): Unit = {
-    val toRelease = extractResource(runner).hostMemoryBytes
-    if (toRelease > 0) {
-      // Enter into the critical section if there is actual resource to release for.
-      lock.lock()
-      // Update nonAtomic states
-      numRunnerInPool -= 1L
-      remaining += toRelease // release the memory back to the pool
-      runner.sparkTaskContext.foreach { ctx =>
-        val tid = ctx.taskAttemptId()
-        val runnersForTask = tasksInPool.getOrElse(tid, 0L)
-        // It is possible runnersForTask == 0, if some runners were cancelled from caller side
-        if (runnersForTask <= 1L) {
-          tasksInPool -= tid
-          logDebug(s"[LOG POINT] remaining=${bytesToString(remaining)}, " +
-              s"AsyncRunners=$numRunnerInPool, SparkTasks=${tasksInPool.size})")
+  // NOTE: this method should be called within the state lock of the runner
+  override protected[async] def release[T](rr: AsyncRunner[T], forcefully: Boolean): Unit = {
+    if (rr.getState == Running) {
+      throw new IllegalStateException(s"Cannot release resources from a running runner: $rr")
+    }
+
+    // Try to free the resource from the runner as much as possible
+    val (free, remain) = rr.tryFree(forcefully)
+    if (forcefully) {
+      if (remain > 0L) {
+        throw new IllegalStateException(
+          s"Forceful release failed to free all resources from $rr, remain=${bToStr(remain)}")
+      }
+      if (!rr.closeStarted.get()) {
+        throw new IllegalStateException(
+          s"Runner must have started close process when forcefully releasing: $rr")
+      }
+    }
+
+    // Return the freed resource back to the pool
+    if (free > 0L) {
+      poolLock.lockInterruptibly()
+      try {
+        // Return the budget and wake up waiters
+        remaining += free
+        // BorrowCondition has higher priority than acquireCondition
+        if (poolLock.hasWaiters(borrowCondition)) {
+          borrowCondition.signalAll()
+        } else if (poolLock.hasWaiters(acquireCondition)) {
+          acquireCondition.signalAll()
+        }
+      } finally {
+        poolLock.unlock()
+      }
+    }
+
+    // forcefully=true implies current thread started the close process, so no need to check if
+    // the close process has already started by other threads.
+    if (forcefully || (
+        remain == 0L && rr.closeStarted.compareAndSet(false, true))) {
+      closeRunner(rr)
+    }
+  }
+
+  override protected[async] def finishUpRunner[T](runner: AsyncRunner[T]): Unit = {
+    if (runner.resource.sizeInBytes > 0) {
+      release(runner, forcefully = true)
+    } else {
+      closeRunner(runner)
+    }
+  }
+
+  /**
+   * Borrows memory from the pool with blocking and priority semantics.
+   *
+   * This method is used when a runner needs to temporarily acquire additional memory beyond its
+   * initial allocation. It blocks until sufficient memory becomes available. If all in-flight
+   * runners are waiting to borrow, deadlock prevention allows the borrower to proceed immediately,
+   * which can over-commit the pool (remaining may become negative).
+   *
+   * Borrowers have higher priority than regular acquire operations. When memory is released,
+   * waiting borrowers are awakened first. If all borrowers are satisfied and memory remains
+   * available, acquire waiters are then signaled.
+   */
+  private[async] def borrowMemory(sizeInBytes: Long): Unit = {
+    poolLock.lockInterruptibly()
+    var beAwakened = false
+    try {
+      var noWaiting = false
+      while (!noWaiting && remaining < sizeInBytes) {
+        if (numOfBorrowWaiters + 1 >= numRunnerInFlight.get()) {
+          // [Deadlock Prevention] if all in-flight runners are waiting to borrow memory,
+          // allow this borrower to proceed to avoid circular wait.
+          noWaiting = true
         } else {
-          tasksInPool.put(tid, runnersForTask - 1L)
+          numOfBorrowWaiters += 1
+          borrowCondition.await()
+          beAwakened = true
+          numOfBorrowWaiters -= 1
         }
       }
-      // Waking up waiters
-      condition.signalAll()
-      lock.unlock()
+      remaining -= sizeInBytes
+
+      if (noWaiting) {
+        logWarning(s"Deadlock prevention triggered in borrowMemory: ${printStatus()}")
+      }
+
+      // Try to trigger acquireCondition as well if all borrowers are satisfied:
+      // 1. beAwakened guarantees current thread was awakened by a release action
+      // 2. numOfBorrowWaiters == 0 ensures no other high-priority waiters are pending
+      // 3. remaining > 0L means there is available resource remained
+      // 4. lock.hasWaiters(acquireCondition) checks if there are acquireCondition waiters
+      if (beAwakened && numOfBorrowWaiters == 0 &&
+          remaining > 0L && poolLock.hasWaiters(acquireCondition)) {
+        acquireCondition.signalAll()
+      }
+    } finally {
+      poolLock.unlock()
     }
-    // Callback to the runner for post-release actions, should keep thread-safe
-    runner.onRelease()
   }
 
-  override def toString: String = {
-    s"HostMemoryPool(maxHostMemoryBytes=${bytesToString(maxHostMemoryBytes)})"
+  // Close the runner, requires the state lock of the runner
+  private def closeRunner[T](runner: AsyncRunner[T]): Unit = {
+    require(runner.isHoldingStateLock, s"The caller must hold the state lock: $this")
+
+    // Callback for onClose actions
+    runner.onClose()
+    // Finalize the runner state
+    runner.getState match {
+      case Completed => // Completed -> Closed
+        runner.setState(Closed(None))
+      case ExecFailed(ex) => // ExecFailed -> Closed
+        runner.setState(Closed(Some(ex)))
+      case Cancelled => // Cancelled -> Closed
+        runner.setState(Closed(Some(new IllegalStateException("cancelled"))))
+      case _ =>
+        throw new IllegalStateException(s"Should NOT reach here: $this")
+    }
+    // Unregister the runner from the Pool, within the lock
+    runner.sparkTaskContext.foreach { ctx =>
+      unregisterRunner(ctx)
+    }
+    logInfo(s"Closed $runner, ${printStatus()}")
   }
 
-  private def extractResource(task: AsyncRunner[_]): HostResource = {
-    task.resource match {
+  private def registerRunner(ctx: TaskContext): Unit = {
+    numRunnerInPool.incrementAndGet()
+    tasksInPool.compute(ctx.taskAttemptId(), (_, v: JLong) => {
+      if (v == null) new JLong(1) else v + 1L
+    })
+  }
+
+  private def unregisterRunner(ctx: TaskContext): Unit = {
+    numRunnerInPool.decrementAndGet()
+    val tid = ctx.taskAttemptId()
+    // Decrement the runner count for the task, remove the entry if it reaches zero
+    tasksInPool.computeIfPresent(tid, (_, v: JLong) => {
+      // It is possible runnersForTask == 0, if some runners were cancelled from caller side
+      if (v <= 1L) {
+        null
+      } else {
+        v - 1L
+      }
+    })
+  }
+
+  override protected[async] def detectResourceLeak[T](runner: AsyncRunner[T]): Unit = {
+    // Step 1. check the potential leak from the closed runner
+    if (!runner.getState.isInstanceOf[Closed]) {
+      throw new IllegalStateException(s"Detected other State than Closed: $runner")
+    }
+    if (runner.resource.sizeInBytes > 0L) {
+      throw new IllegalStateException(s"LocalPool is NOT cleaned up: $runner")
+    }
+
+    // Step 2. check the leak from the Pool side, which only happens when there is no runner
+    // in the pool
+    if (numRunnerInPool.get() == 0L) {
+      poolLock.lockInterruptibly()
+      try {
+        if (numRunnerInPool.get() == 0L) {
+          if (remaining < maxHostMemoryBytes) {
+            throw new IllegalStateException(s"Detected resource leak: $toString")
+          }
+          if (!tasksInPool.isEmpty) {
+            throw new IllegalStateException(
+              s"Detected Spark Task tracking leak, tasksInPool=${tasksInPool.toString}")
+          }
+        }
+      } finally {
+        poolLock.unlock()
+      }
+    }
+  }
+
+  override def toString: String = s"HostMemoryPool(${printStatus()})"
+
+  private def printStatus(): String = {
+    val sb = mutable.StringBuilder.newBuilder
+    sb.append("remaining=")
+        .append(bToStr(remaining))
+        .append('/')
+        .append(bToStr(maxHostMemoryBytes))
+        .append(", AsyncRunners=")
+        .append(numRunnerInFlight.get())
+        .append("/")
+        .append(numRunnerInPool.get())
+        .append(", waitingBorrowers=")
+        .append(numOfBorrowWaiters)
+        .append(", SparkTasks=")
+        .append(tasksInPool.size())
+    sb.toString()
+  }
+
+  private def extractResource(rr: AsyncRunner[_]): HostResource = {
+    rr.resource match {
       case r: HostResource => r
-      case r => throw new InvalidResourceRequest(
-        s"Task ${task.getClass.getName} does not require HostResource, but got $r")
+      case r => throw new IllegalStateException(
+        s"Unexpected resource type ${r.getClass} in $this")
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourcePools.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ResourcePools.scala
@@ -192,8 +192,9 @@ class HostMemoryPool(val maxHostMemoryBytes: Long) extends ResourcePool with Log
     }
   }
 
-  // NOTE: this method should be called within the state lock of the runner
   override protected[async] def release[T](rr: AsyncRunner[T], forcefully: Boolean): Unit = {
+    // NOTE: this method should be called within the state lock of the runner. No need to check
+    // because it is verified by the tryFree() call below.
     if (rr.getState == Running) {
       throw new IllegalStateException(s"Cannot release resources from a running runner: $rr")
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -2716,6 +2716,13 @@ class MultiFileCloudParquetPartitionReader(
 
     override val baseMemoryAllocator: HostMemoryAllocator = DefaultHostMemoryAllocator.get()
 
+    // The config only applies when `AsyncRunner.onClose` is called by the HostMemoryPool,
+    // which means that ResourceBoundedThreadPool is enabled.
+    override protected val maxRetriesOnClose: Int = poolConf match {
+      case p: MemoryBoundedPoolConf => p.maxRetriesOnClose
+      case _ => 1
+    }
+
     // Only enable `MemoryBoundedAsyncRunner.allocate` if MemoryBoundedReading enabled
     private lazy val customAllocator: Option[HostMemoryAllocator] = poolConf match {
       case _: MemoryBoundedPoolConf => Some(this)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -61,7 +61,13 @@ object TrampolineUtil {
   def jsonValue(dataType: DataType): JsonAST.JValue = dataType.jsonValue
 
   /** Get a human-readable string, e.g.: "4.0 MiB", for a value in bytes. */
-  def bytesToString(size: Long): String = Utils.bytesToString(size)
+  def bytesToString(size: Long): String = {
+    if (size >= 0) {
+      Utils.bytesToString(size)
+    } else {
+      "-" + Utils.bytesToString(-size)
+    }
+  }
 
   /** Returns true if called from code running on the Spark driver. */
   def isDriver(env: SparkEnv): Boolean = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
@@ -43,7 +43,8 @@ class GpuMultiFileReaderSuite extends AnyFunSuite with RmmSparkRetrySuiteBase {
       isMemoryBounded = true,
       memoryCapacityFromDriver =  1L << 20,
       timeoutMs = 10 * 1000L, // 10 seconds
-      stageLevelPool = false
+      stageLevelPool = false,
+      maxRetriesOnClose = 4
     ).build()
     val multiFileReader = new MultiFileCloudPartitionReaderBase(
       conf,


### PR DESCRIPTION
Closes #13969

### Overview

This PR tightly couples the virtual memory budget with the lifecycle of the actual memory buffer `HostMemoryBuffer` used in the runner, by making `MemoryBoundedAsyncRunner` serve as both the resource holder and the `HostMemoryAllocator`. This design eliminates the previous disconnect between budget accounting and actual memory usage, enabling more precise resource management and improved concurrency.

---

### Key Features
* **Early Release**: Over-claimed budget is returned to the global pool as soon as possible
* **Automatic Lifecycle**: Runners auto-close when all resources are returned, simplifying management

---
Performance comparison between V1 and V2 

|    | Memory Limit | Max Thread | Version | NDS-H | NDS  |
|:---------|:------------:|:----------:|:-------:|------:|-----:|
| baseline | /            | 64         |         | 473s  | 351s |
| enable   | 8g           | 64         | V1      | 493s  | N/A  |
| enable   | 8g           | 64         | V2      | 477s  | 359s |
| enable   | 16g          | 64         | V1      | 480s  | 441s |
| enable   | 16g          | 64         | V2      | 466s  | 357s |

---

### Design

#### Architecture Diagram

```
┌─────────────────────────────────────────────────────────────────────────────────────────┐
│                            ResourceBoundedThreadExecutor                                │
│                                                                                         │
│  ┌─────────────────────────────────────────────────────────────────────────────────┐   │
│  │                         Global HostMemoryPool                                    │   │
│  │                                                                                  │   │
│  │   ┌────────────────────────────────────────────────────────────────────────┐    │   │
│  │   │  maxHostMemoryBytes                                                    │    │   │
│  │   │  ════════════════════════════════════════════════════════════════════  │    │   │
│  │   │                                                                        │    │   │
│  │   │  remaining (available for acquire/borrow)                              │    │   │
│  │   │  ◄─────────────────────────────────────────────────────────────────────│    │   │
│  │   │                                                                        │    │   │
│  │   └────────────────────────────────────────────────────────────────────────┘    │   │
│  │                                                                                  │   │
│  │   Synchronization:                                                               │   │
│  │   • acquireCondition - waiters for initial budget acquisition                   │   │
│  │   • borrowCondition  - waiters for dynamic memory borrowing (HIGHER PRIORITY)   │   │
│  │                                                                                  │   │
│  └─────────────────────────────────────────────────────────────────────────────────┘   │
│                                          │                                              │
│                    ┌─────────────────────┼─────────────────────┐                        │
│                    │ acquire()           │ acquire()           │ acquire()              │
│                    ▼                     ▼                     ▼                        │
│       ┌─────────────────────┐ ┌─────────────────────┐ ┌─────────────────────┐          │
│       │MemoryBoundedRunner A│ │MemoryBoundedRunner B│ │MemoryBoundedRunner C│          │
│       │                     │ │                     │ │                     │          │
│       │  ┌───────────────┐  │ │  ┌───────────────┐  │ │  ┌───────────────┐  │          │
│       │  │  LocalPool A  │  │ │  │  LocalPool B  │  │ │  │  LocalPool C  │  │          │
│       │  │ ┌─────┬─────┐ │  │ │  │ ┌─────┬─────┐ │  │ │  │ ┌─────┬─────┐ │  │          │
│       │  │ │USED │FREE │ │  │ │  │ │USED │FREE │ │  │ │  │ │USED │FREE │ │  │          │
│       │  │ └─────┴─────┘ │  │ │  │ └─────┴─────┘ │  │ │  │ └─────┴─────┘ │  │          │
│       │  └───────────────┘  │ │  └───────────────┘  │ │  └───────────────┘  │          │
│       └─────────────────────┘ └─────────────────────┘ └─────────────────────┘          │
│                    │                     │                     │                        │
│                    └─────────────────────┼─────────────────────┘                        │
│                                          │ tryFree() / finishUpRunner()                 │
│                                          ▼                                              │
│                              Return budget to Global Pool                               │
└─────────────────────────────────────────────────────────────────────────────────────────┘
```


#### 1. LocalPool Initialization

When a `MemoryBoundedAsyncRunner` is scheduled for execution, it acquires a preliminary memory budget from the global `HostMemoryPool` (managed by `ResourceBoundedExecutor`). This budget becomes the runner's **LocalPool**—a private memory quota that the runner manages independently during its execution lifecycle.

The initial LocalPool size is typically derived from the `PartitionedFile` split length, representing an upper-bound estimate of the memory required to process the assigned data partition.

#### 2. LocalPool Structure: Used vs Free

The LocalPool is logically divided into two portions:

| Portion | Description |
|---------|-------------|
| **Used** | Memory currently backing live `HostMemoryBuffer` instances (tracked by `usedMem`) |
| **Free** | Remaining budget available for future allocations (`localPool - usedMem`) |

This partitioning allows the runner to track exactly how much of its budget is actively in use versus how much remains available—enabling early release of over-claimed budget.

#### 3. Allocation Flow: Local-First with Dynamic Borrowing

When a buffer allocation request arrives, the runner follows a **local-first** strategy:

1. **Check LocalPool Free Portion**: Attempt to satisfy the request using available free budget
2. **Borrow if Insufficient**: If the free portion cannot cover the request, dynamically borrow the deficit from the global `HostMemoryPool`

**Borrowing Semantics:**
- Borrow requests are **blocking**—the runner waits until sufficient budget becomes available
- Borrowers have **higher priority** than runners waiting to acquire initial budget, ensuring that active work completes before new work is scheduled
- **Forceful borrowing**: Under certain deadlock-prone conditions (e.g., all in-flight runners are blocked waiting to borrow), the borrow proceeds immediately regardless of available budget. This may leave the `HostMemoryPool` with a **negative remaining balance**, but guarantees forward progress

This dynamic borrowing mechanism handles cases where the initial budget estimate is insufficient—such as when file readers need to access metadata beyond the split boundaries (footers, adjacent row groups, etc.).

```
            ┌─────────────────────────┐
            │  runner.allocate(size)  │
            │  (HostMemoryAllocator)  │
            └───────────┬─────────────┘
                        │
                        ▼
┌─────────────────────────────────────────────────────┐
│  STEP 1: Attempt Local Allocation                   │
│  ───────────────────────────────────────────────    │
│                                                     │
│  var memToBorrow = 0L                               │
│  val newUsed = usedMem.updateAndGet { curUsed =>    │
│    val total = curUsed + size                       │
│    memToBorrow = total - localPool // Deficit       │
│    total min localPool             // Cap it        │
│  }                                                  │
│                                                     │
│  ┌───────────────────────────────────────────────┐  │
│  │ Before: │████ USED ████│░░░░ FREE ░░░░│       │  │
│  │                                               │  │
│  │ Case A (fits in FREE):                        │  │
│  │ After:  │████ USED ████│██│░░ FREE ░░│        │  │
│  │                         └┬┘                   │  │
│  │                          └── new allocation   │  │
│  │                                               │  │
│  │ Case B (need to borrow):                      │  │
│  │ After:  │████ USED ████│█████│ +BORROW──►     │  │
│  └───────────────────────────────────────────────┘  │
│                                                     │
└─────────────────────────────────────────────────────┘
                        │
                        ▼
            ┌───────────────────────┐
            │  memToBorrow > 0?     │
            └───────────┬───────────┘
                        │
            ┌───────────┴───────────┐
            │No                     │Yes
            ▼                       ▼
┌───────────────────┐  ┌───────────────────────────────┐
│ Skip to STEP 3    │  │ STEP 2: Borrow from Global    │
│ (enough locally)  │  │ ───────────────────────────── │
└───────────────────┘  │                               │
                       │ poolPtr.borrowMemory(amt)     │
                       │ // BLOCKING call              │
                       │                               │
                       │ Borrowing Semantics:          │
                       │ • Wait on borrowCondition     │
                       │ • Borrowers have HIGHER       │
                       │   priority than acquirers     │
                       │ • Deadlock Prevention:        │
                       │   if all runners waiting,     │
                       │   proceed (over-commit OK)    │
                       │                               │
                       │ After borrow:                 │
                       │ localPool += memToBorrow      │
                       │ usedMem += memToBorrow        │
                       │                               │
                       └───────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────┐
│  STEP 3: Allocate Physical Buffer                   │
│  ───────────────────────────────────────────────    │
│                                                     │
│  val buf = withRetryNoSplit {                       │
│    baseMemoryAllocator.allocate(size)               │
│  }                                                  │
│                                                     │
│  // Attach close handler for budget return          │
│  HostAlloc.addEventHandler(buf,                     │
│    new OnCloseHandler(size, this))                  │
│                                                     │
│  return buf                                         │
│                                                     │
└─────────────────────────────────────────────────────┘
```

#### 4. Deallocation Flow: Event-Driven Budget Return

Buffer release triggers an automatic cascade of budget management:

**Step 1: Return to LocalPool**  
When a `HostMemoryBuffer` is closed (refCount reaches 0), the attached `OnCloseHandler` fires and returns the corresponding virtual budget back to the runner's LocalPool (decrements `usedMem`).

**Step 2: Early Release via tryFree**  
If the runner has completed execution (no longer in `Running` state), the handler triggers `tryFree` to immediately return the **free portion** of LocalPool back to the global `HostMemoryPool`. This releases over-claimed budget as early as possible, improving pool utilization and allowing other runners to be scheduled sooner.

**Step 3: Auto-Close on Full Drain**  
When LocalPool drops to zero—meaning all physical buffers have been closed and all budget has been returned—the runner can be safely closed automatically. This simplifies lifecycle management by eliminating explicit close coordination.

```
            ┌─────────────────────────┐
            │ HostMemoryBuffer.close()│
            │ (refCount reaches 0)    │
            └───────────┬─────────────┘
                        │
                        ▼
┌─────────────────────────────────────────────────────┐
│ STEP 1: Return Budget to LocalPool                  │
│ ────────────────────────────────────────────────    │
│                                                     │
│ runner.withStateLock() {                            │
│   usedMem.addAndGet(-bufferSize)                    │
│   bufCloseCond.signal()                             │
│                                                     │
│   ┌───────────────────────────────────────────────┐ │
│   │ Before: │████████ USED ████████│░░ FREE ░░│   │ │
│   │                                               │ │
│   │ After:  │████ USED ████│░░░░░░ FREE ░░░░░░│   │ │
│   │                         └───────┬──────────┘  │ │
│   │                                 └─ returned   │ │
│   └───────────────────────────────────────────────┘ │
│ }                                                   │
│                                                     │
└─────────────────────────────────────────────────────┘
                        │
                        ▼
            ┌───────────────────────┐
            │ getState != Running &&│
            │ !closeStarted.get()?  │
            └───────────┬───────────┘
                        │
            ┌───────────┴───────────┐
            │No                     │Yes
            ▼                       ▼
┌───────────────────┐  ┌───────────────────────────────┐
│ No early release  │  │ STEP 2: Early Release         │
│ (still Running or │  │ ───────────────────────────── │
│ closing)          │  │                               │
└───────────────────┘  │ poolPtr.release(runner,false) │
                       │                               │
                       │ // tryFree() calculates:      │
                       │ free = localPool - usedMem    │
                       │ remain = usedMem              │
                       │ localPool -= free             │
                       │                               │
                       │ // Return to global pool:     │
                       │ remaining += free             │
                       │                               │
                       │ // Wake waiters (priority):   │
                       │ if (borrowCondition waiters)  │
                       │   borrowCondition.signalAll() │
                       │ else if (acquireCond waiters) │
                       │   acquireCondition.signalAll()│
                       │                               │
                       │ ┌───────────────────────────┐ │
                       │ │ Before: │██USED██│░FREE░│ │ │
                       │ │                          │ │
                       │ │ After:  │██USED██│       │ │
                       │ │          └──┬───┘        │ │
                       │ │        localPool shrinks │ │
                       │ │        FREE → Global Pool│ │
                       │ └───────────────────────────┘ │
                       │                               │
                       └───────────────────────────────┘
                                    │
                                    ▼
                       ┌───────────────────────┐
                       │ remain == 0?          │
                       │ (LocalPool drained)   │
                       └───────────┬───────────┘
                                   │
                       ┌───────────┴───────────┐
                       │No                     │Yes
                       ▼                       ▼
          ┌───────────────────┐  ┌─────────────────────┐
          │ Wait for more     │  │ STEP 3: Auto-Close  │
          │ buffers to close  │  │ ─────────────────── │
          └───────────────────┘  │                     │
                                 │ closeRunner(runner) │
                                 │ 1. runner.onClose() │
                                 │ 2. setState(Closed) │
                                 │ 3. unregisterRunner │
                                 │                     │
                                 └─────────────────────┘
```

---

### Code References

| Component | File | Lines | Description |
|-----------|------|-------|-------------|
| **Global Pool Acquire** | `ResourcePools.scala` | L108-171 | Blocking acquire with timeout and deadlock prevention |
| **Global Pool Release** | `ResourcePools.scala` | L199-235 | tryFree + return to pool + wake waiters |
| **Borrow Memory** | `ResourcePools.scala` | L248-290 | Priority-based blocking borrow with deadlock prevention |
| **LocalPool Variables** | `AsyncRunners.scala` | L525-531 | `localPool` (capacity) and `usedMem` (AtomicLong) |
| **Runner.allocate()** | `AsyncRunners.scala` | L468-498 | Local-first allocation with borrow fallback |
| **OnCloseHandler** | `AsyncRunners.scala` | L505-522 | Event-driven return to LocalPool + early release trigger |
| **onClose() Blocking** | `AsyncRunners.scala` | L417-443 | Wait for all buffers to close before runner closes |
| **tryFree()** | `AsyncRunners.scala` | L380-395 | Calculate freeable portion of LocalPool |
| **beforeExecute()** | `ResourceBoundedThreadExecutor.scala` | L200-250 | State transition and acquire orchestration |
| **afterExecute()** | `ResourceBoundedThreadExecutor.scala` | L252-315 | Post-execution handling and release |
