### PR TITLE
Add fast path for GpuNvl when lhs has no nulls

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -29,14 +29,24 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object GpuNvl {
   def apply(lhs: ColumnVector, rhs: ColumnVector): ColumnVector = {
-    withResource(lhs.isNotNull) { isLhsNotNull =>
-      isLhsNotNull.ifElse(lhs, rhs)
+    // Fast path: if lhs has no nulls, just return lhs directly
+    if (lhs.getNullCount == 0) {
+      lhs.incRefCount()
+    } else {
+      withResource(lhs.isNotNull) { isLhsNotNull =>
+        isLhsNotNull.ifElse(lhs, rhs)
+      }
     }
   }
 
   def apply(lhs: ColumnVector, rhs: Scalar): ColumnVector = {
-    withResource(lhs.isNotNull) { isLhsNotNull =>
-      isLhsNotNull.ifElse(lhs, rhs)
+    // Fast path: if lhs has no nulls, just return lhs directly
+    if (lhs.getNullCount == 0) {
+      lhs.incRefCount()
+    } else {
+      withResource(lhs.isNotNull) { isLhsNotNull =>
+        isLhsNotNull.ifElse(lhs, rhs)
+      }
     }
   }
 }


### PR DESCRIPTION
- Skip isNotNull + ifElse when lhs.getNullCount == 0
- Directly return lhs.incRefCount() for better performance

This PR is broke up from https://github.com/NVIDIA/spark-rapids/pull/14032, please visit that to see more details

