### PR TITLE
Optimize GpuAverage and add expression deduplication in AggHelper

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2019,6 +2019,19 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .createWithDefault("all")
 
+  // scalastyle:off line.size.limit
+  val AVG_USE_LONG_ACCUMULATOR = conf("spark.rapids.sql.avg.longAccumulator.enabled")
+    .doc("When enabled, use LongType for internal sum accumulation when computing average " +
+      "of Long values. This avoids per-row casting from Long to Double during aggregation. " +
+      "WARNING: This optimization can cause Long overflow if the sum of values exceeds " +
+      "Long.MAX_VALUE (9.2e18). Only enable this if you are certain your data will not " +
+      "overflow. To pass hash_aggregate_test with this enabled, limit LongGen range to " +
+      "approximately +/-1e16 to prevent overflow with 100 rows.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+  // scalastyle:on line.size.limit
+
   val PARTIAL_MERGE_DISTINCT_ENABLED = conf("spark.rapids.sql.partialMerge.distinct.enabled")
     .doc("Enables aggregates that are in PartialMerge mode to run on the GPU if true")
     .internal()
@@ -3350,6 +3363,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val hybridExprsWhitelist: String = get(HYBRID_EXPRS_WHITELIST)
 
   lazy val hashAggReplaceMode: String = get(HASH_AGG_REPLACE_MODE)
+
+  lazy val avgUseLongAccumulator: Boolean = get(AVG_USE_LONG_ACCUMULATOR)
 
   lazy val partialMergeDistinctEnabled: Boolean = get(PARTIAL_MERGE_DISTINCT_ENABLED)
 

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -183,7 +183,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
         }
 
         override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
-          GpuAverage(childExprs.head, ansiEnabled)
+          GpuAverage(childExprs.head, ansiEnabled, this.conf.avgUseLongAccumulator)
 
         override def needsAnsiCheck: Boolean = false
       }),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuAverageSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuAverageSuite.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
+
+/**
+ * Integration tests for GpuAverage aggregation function.
+ *
+ * Tests cover:
+ * - avg combined with sum/count (expression deduplication)
+ * - avg on different data types (int, double, long)
+ * - avg with group by
+ * - avg(DISTINCT x) scenarios
+ *
+ * These tests verify the end-to-end correctness by comparing GPU results with CPU results.
+ */
+class GpuAverageSuite extends SparkQueryCompareTestSuite {
+
+  private def aggConf: SparkConf = new SparkConf()
+    .set(RapidsConf.ENABLE_FLOAT_AGG.key, "true")
+
+  // Test data with integers including nulls
+  private def intDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[java.lang.Integer](
+      1, 2, 3, null, 5, 6, null, 8, 9, 10
+    ).toDF("x")
+  }
+
+  // Test data with doubles including nulls
+  private def doubleDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[java.lang.Double](
+      1.5, 2.5, 3.5, null, 5.5, 6.5, null, 8.5, 9.5, 10.5
+    ).toDF("x")
+  }
+
+  // Test data with integers for group by
+  private def intGroupByDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[(String, java.lang.Integer)](
+      ("a", 1), ("a", 2), ("a", null),
+      ("b", 4), ("b", 5), ("b", null),
+      ("c", 7), ("c", 8), ("c", 9)
+    ).toDF("key", "x")
+  }
+
+  // Test data with doubles for group by
+  private def doubleGroupByDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[(String, java.lang.Double)](
+      ("a", 1.5), ("a", 2.5), ("a", null),
+      ("b", 4.5), ("b", 5.5), ("b", null),
+      ("c", 7.5), ("c", 8.5), ("c", 9.5)
+    ).toDF("key", "x")
+  }
+
+  // ==================== Reduction tests (no group by) ====================
+
+  // avg at the end - int
+  testSparkResultsAreEqual(
+    "sum(x), count(x), avg(x) - int reduction",
+    intDf,
+    conf = aggConf) { df =>
+    df.agg(sum("x"), count("x"), avg("x"))
+  }
+
+  // avg at the beginning - int
+  testSparkResultsAreEqual(
+    "avg(x), sum(x), count(x) - int reduction",
+    intDf,
+    conf = aggConf) { df =>
+    df.agg(avg("x"), sum("x"), count("x"))
+  }
+
+  // avg at the end - double
+  testSparkResultsAreEqual(
+    "sum(x), count(x), avg(x) - double reduction",
+    doubleDf,
+    conf = aggConf,
+    maxFloatDiff = 0.0001) { df =>
+    df.agg(sum("x"), count("x"), avg("x"))
+  }
+
+  // avg at the beginning - double
+  testSparkResultsAreEqual(
+    "avg(x), sum(x), count(x) - double reduction",
+    doubleDf,
+    conf = aggConf,
+    maxFloatDiff = 0.0001) { df =>
+    df.agg(avg("x"), sum("x"), count("x"))
+  }
+
+  // ==================== Group by tests ====================
+
+  // avg at the end - int
+  IGNORE_ORDER_testSparkResultsAreEqual(
+    "sum(x), count(x), avg(x) - int group by",
+    intGroupByDf,
+    conf = aggConf) { df =>
+    df.groupBy("key").agg(sum("x"), count("x"), avg("x"))
+  }
+
+  // avg at the beginning - int
+  IGNORE_ORDER_testSparkResultsAreEqual(
+    "avg(x), sum(x), count(x) - int group by",
+    intGroupByDf,
+    conf = aggConf) { df =>
+    df.groupBy("key").agg(avg("x"), sum("x"), count("x"))
+  }
+
+  // avg at the end - double
+  testSparkResultsAreEqual(
+    "sum(x), count(x), avg(x) - double group by",
+    doubleGroupByDf,
+    conf = aggConf,
+    sort = true,
+    maxFloatDiff = 0.0001) { df =>
+    df.groupBy("key").agg(sum("x"), count("x"), avg("x"))
+  }
+
+  // avg at the beginning - double
+  testSparkResultsAreEqual(
+    "avg(x), sum(x), count(x) - double group by",
+    doubleGroupByDf,
+    conf = aggConf,
+    sort = true,
+    maxFloatDiff = 0.0001) { df =>
+    df.groupBy("key").agg(avg("x"), sum("x"), count("x"))
+  }
+
+  // ==================== DISTINCT avg tests for LongType optimization ====================
+
+  // Test data with Long values (larger range to potentially trigger overflow if using Long sum)
+  private def longDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[java.lang.Long](
+      1000000000000L, 2000000000000L, 3000000000000L, null,
+      1000000000000L, 2000000000000L, // duplicates for DISTINCT
+      5000000000000L, 6000000000000L, null, 8000000000000L
+    ).toDF("x")
+  }
+
+  // Test data with Long for group by with duplicates
+  private def longGroupByDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[(String, java.lang.Long)](
+      ("a", 1000000000000L), ("a", 2000000000000L), ("a", 1000000000000L), ("a", null),
+      ("b", 4000000000000L), ("b", 5000000000000L), ("b", 4000000000000L), ("b", null),
+      ("c", 7000000000000L), ("c", 8000000000000L), ("c", 9000000000000L)
+    ).toDF("key", "x")
+  }
+
+  // avg(DISTINCT x) - Long reduction - this is the failing case
+  testSparkResultsAreEqual(
+    "avg(DISTINCT x) - Long reduction",
+    longDf,
+    conf = aggConf,
+    maxFloatDiff = 0.0001) { df =>
+    df.agg(avg(col("x")).as("avg_x"), countDistinct("x").as("cnt_distinct"))
+  }
+
+  // avg(DISTINCT x) - Long group by
+  IGNORE_ORDER_testSparkResultsAreEqual(
+    "avg(DISTINCT x) - Long group by",
+    longGroupByDf,
+    conf = aggConf) { df =>
+    df.groupBy("key").agg(avg(col("x")).as("avg_x"), countDistinct("x").as("cnt_distinct"))
+  }
+
+  // The actual failing test case: avgDistinct on Long type
+  testSparkResultsAreEqual(
+    "avgDistinct(x) - Long reduction - reproducer",
+    longDf,
+    conf = aggConf,
+    maxFloatDiff = 0.0001) { df =>
+    // Use SQL to get avg(DISTINCT x) since DataFrame API doesn't have avgDistinct
+    df.createOrReplaceTempView("long_data")
+    df.sparkSession.sql("SELECT avg(DISTINCT x) as avg_distinct_x FROM long_data")
+  }
+
+  // Test with replaceMode=partial to simulate CPU fallback scenario
+  // This is the configuration that causes integration test failures
+  private def partialModeConf: SparkConf = new SparkConf()
+    .set(RapidsConf.ENABLE_FLOAT_AGG.key, "true")
+    .set(RapidsConf.HASH_AGG_REPLACE_MODE.key, "partial")
+    .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+      "HashAggregateExec,AggregateExpression,Average,Cast,Alias,AttributeReference")
+
+  // This test simulates the integration test failure scenario
+  testSparkResultsAreEqual(
+    "avgDistinct(x) - Long with partial replaceMode (CPU fallback)",
+    longDf,
+    conf = partialModeConf,
+    maxFloatDiff = 0.0001) { df =>
+    df.createOrReplaceTempView("long_data_partial")
+    df.sparkSession.sql("SELECT avg(DISTINCT x) as avg_distinct_x FROM long_data_partial")
+  }
+}


### PR DESCRIPTION
- Add expression deduplication in AggHelper using canonicalized expressions
- Use CudfCount instead of CudfSum(isNotNull) for count aggregation
- Add optional Long accumulator for LongType inputs (spark.rapids.sql.avg.longAccumulator.enabled)
- Add internalSumType to allow different types for internal sum vs shuffle buffer
- Add GpuAverageSuite integration tests

This PR is broke up from https://github.com/NVIDIA/spark-rapids/pull/14032, please visit that to see more details

