### PR TITLE
Enable efficient merge sort for nested types

### DIFF
--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -42,10 +42,10 @@ _nested_orderby_with_xfail = [
     pytest.param(f.col('a').asc()),
     pytest.param(f.col('a').asc_nulls_first()),
     pytest.param(f.col('a').asc_nulls_last(),
-                 marks=pytest.mark.xfail(reason='opposite null order not supported')),
+                 marks=pytest.mark.xfail(reason='asc with null_last order not supported')),
     pytest.param(f.col('a').desc()),
     pytest.param(f.col('a').desc_nulls_first(),
-                 marks=pytest.mark.xfail(reason='opposite null order not supported')),
+                 marks=pytest.mark.xfail(reason='desc with null_first order not supported')),
     pytest.param(f.col('a').desc_nulls_last()),
 ]
 

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -434,6 +434,9 @@ _deeply_nested_ridealong_gens = [
     # Struct with Map field - deeply nested
     pytest.param(StructGen([('a', long_gen), ('b', simple_string_to_string_map_gen)]),
                  id='ridealong_struct_with_map'),
+    # Struct of Struct with nested Array - tests recursive check
+    pytest.param(StructGen([('a', long_gen), ('b', StructGen([('c', long_gen), ('d', ArrayGen(string_gen, max_length=5))]))]),
+                 id='ridealong_struct_of_struct_with_array'),
 ]
 
 @pytest.mark.parametrize('ridealong_gen', _deeply_nested_ridealong_gens)


### PR DESCRIPTION
Closes #14046

This PR enables the efficient `Table.merge` path for **all types** in out-of-core sort merge operations. Previously, nested types in key or ride-along columns would trigger a fallback to `Table.concatenate` + `orderBy`, which is slower.

### Performance Impact

The `Table.merge` operation is more efficient than `Table.concatenate` + `orderBy` because:
- Merge takes advantage of the fact that input batches are already sorted
- Concatenate + orderBy must re-sort all data from scratch

This optimization now applies to all data types including:
- Nested types in sort key columns (Struct, Array)
- Deeply nested ride-along columns (Array of Struct, Struct with Array/Map, etc.)

### Testing

Added comprehensive tests in `sort_test.py` to verify cuDF merge works correctly with:
1. **Single-level nested key columns** - Array, Struct, Struct of Struct as sort keys
2. **Multi-level nested ride-along columns** - Array of Struct, Array of Array, Array of Map, Struct with Array/Map fields
