### PR TITLE
Cache projected DPP broadcast rows on the broadcast value

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -305,9 +305,9 @@ class SerializeConcatHostBuffersDeserializeBatch(
     data = null
     batchInternal = null
     // Drop the projected-row memoizations so the InternalRow arrays become collectable.
-    // Safe to call on `null` because `projectedRowsCache` is a lazy val initialized on first
-    // touch; clear() on an initialized map releases the entries, and a never-touched map
-    // simply stays unmaterialized.
+    // Touching `projectedRowsCache` here forces the lazy val to initialize if it had never
+    // been used, but that just allocates an empty ConcurrentHashMap — a one-time, negligible
+    // cost on the GC path.
     projectedRowsCache.clear()
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -41,7 +41,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, BroadcastPartitioning, Partitioning}
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
@@ -51,6 +51,26 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
+/**
+ * Cache key used by [[SerializeConcatHostBuffersDeserializeBatch]] to memoize the projected
+ * `Array[InternalRow]` on the broadcast value across DPP probe sites that share the same
+ * broadcast.
+ *
+ * `kind` discriminates callers that share the same broadcast value but project differently:
+ *   - "subquery"   - [[GpuSubqueryBroadcastExec]]: a subset of build-key indices with optional
+ *                    HashedRelation mode-key re-projection, used by InSubqueryExec / DPP.
+ *   - "broadcastRow" - [[GpuBroadcastToRowExec]]: all columns projected to InternalRows.
+ *
+ * `canonicalBuildKeys` and `canonicalModeKeys` are canonicalized (per Spark's
+ * `Expression#canonicalized`) so that we hit the cache exactly when Spark's `ReusedSubquery`
+ * rule already considers the subqueries equivalent.
+ */
+case class ProjectedRowsKey(
+    kind: String,
+    indices: Seq[Int],
+    canonicalBuildKeys: Seq[Expression],
+    canonicalModeKeys: Option[Seq[Expression]])
 
 /**
  * Class that is used to broadcast results (a contiguous host batch) to executors.
@@ -81,7 +101,43 @@ class SerializeConcatHostBuffersDeserializeBatch(
   // used for memoization of deserialization to GPU on Executor
   @transient private var batchInternal: SpillableColumnarBatch = null
 
+  /**
+   * Memoized `Array[InternalRow]` keyed by the projection spec. Hit once per unique
+   * [[ProjectedRowsKey]] per executor for the lifetime of this broadcast value, so the
+   * GPU->host copy + per-row CPU projection runs once per broadcast on each executor instead
+   * of once per DPP probe site.
+   */
+  @transient private lazy val projectedRowsCache =
+    new ConcurrentHashMap[ProjectedRowsKey, Array[InternalRow]]()
+
   private def maybeGpuBatch: Option[SpillableColumnarBatch] = Option(batchInternal)
+
+  /**
+   * Compute the projected `Array[InternalRow]` for `key` exactly once per executor for this
+   * broadcast value, and return the same memoized array for subsequent calls with an equal key.
+   *
+   * The `compute` thunk MUST be deterministic with respect to `key` and the broadcast contents,
+   * because it is only evaluated for the first caller. The returned array is shared across
+   * probe sites and MUST NOT be mutated by callers (matches the existing contract of
+   * `executeCollect()` which already returns an immutable array to `InSubqueryExec`).
+   */
+  def projectedRowsOrCompute(
+      key: ProjectedRowsKey)(compute: => Array[InternalRow]): Array[InternalRow] = {
+    // computeIfAbsent is preferred over get/putIfAbsent so the slow path runs at most once
+    // per key even under concurrent probe-site evaluations on the same executor.
+    val existing = projectedRowsCache.get(key)
+    if (existing != null) {
+      existing
+    } else {
+      // Evaluate `compute` outside computeIfAbsent because it can be expensive
+      // (host copy + projection) and we don't want to hold the table-level lock for that long.
+      // Race is benign: if two threads race, one of the freshly computed arrays is discarded
+      // and both threads return the same winning array.
+      val fresh = compute
+      val winner = projectedRowsCache.putIfAbsent(key, fresh)
+      if (winner == null) fresh else winner
+    }
+  }
 
   def batch: SpillableColumnarBatch = this.synchronized {
     maybeGpuBatch.getOrElse {
@@ -248,6 +304,11 @@ class SerializeConcatHostBuffersDeserializeBatch(
     Seq(data, batchInternal).safeClose()
     data = null
     batchInternal = null
+    // Drop the projected-row memoizations so the InternalRow arrays become collectable.
+    // Safe to call on `null` because `projectedRowsCache` is a lazy val initialized on first
+    // touch; clear() on an initialized map releases the entries, and a never-touched map
+    // simply stays unmaterialized.
+    projectedRowsCache.clear()
   }
 
   @scala.annotation.nowarn("msg=method finalize in class Object is deprecated")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,20 @@ case class GpuBroadcastToRowExec(
       session, GpuBroadcastToRowExec.executionContext) {
       val broadcastBatch = child.executeBroadcast[Any]()
       val rows: Array[InternalRow] = broadcastBatch.value match {
-        case b: SerializeConcatHostBuffersDeserializeBatch => projectSerializedBatch(b)
+        case b: SerializeConcatHostBuffersDeserializeBatch =>
+          // Same memoization as GpuSubqueryBroadcastExec. This call site projects *all*
+          // columns with no broadcast-mode key projection, so the indices set is fixed for
+          // a given child schema and modeKeys are absent. Cache key uses the "broadcastRow"
+          // discriminator so it never collides with a "subquery" key on the same shared
+          // SerializeConcatHostBuffersDeserializeBatch.
+          val key = ProjectedRowsKey(
+            "broadcastRow",
+            (0 until child.output.size).toList,
+            buildKeys.map(_.canonicalized),
+            None)
+          b.projectedRowsOrCompute(key) {
+            projectSerializedBatch(b)
+          }
         case b if SparkShimImpl.isEmptyRelation(b) => Array.empty
         case b => throw new IllegalStateException(s"Unexpected broadcast type: ${b.getClass}")
       }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
@@ -68,15 +68,24 @@ case class GpuBroadcastToRowExec(
           // columns with no broadcast-mode key projection, so the indices set is fixed for
           // a given child schema and modeKeys are absent. Cache key uses the "broadcastRow"
           // discriminator so it never collides with a "subquery" key on the same shared
-          // SerializeConcatHostBuffersDeserializeBatch.
+          // SerializeConcatHostBuffersDeserializeBatch. `canonicalBuildKeys` is left empty
+          // because `projectSerializedBatch` does not consult buildKeys (it projects every
+          // column via BoundReference); including them would create spurious cache entries
+          // for broadcast-reuse shapes whose projection result is in fact identical.
+          val beforeCollect = System.nanoTime()
           val key = ProjectedRowsKey(
             "broadcastRow",
             (0 until child.output.size).toList,
-            buildKeys.map(_.canonicalized),
+            Seq.empty,
             None)
-          b.projectedRowsOrCompute(key) {
+          val rows = b.projectedRowsOrCompute(key) {
             projectSerializedBatch(b)
           }
+          // Update metrics on every call (cache hit and miss) to preserve the per-probe-site
+          // semantics that consumers of the Spark UI saw before this cache was introduced.
+          gpuLongMetric("dataSize") += b.dataSize
+          gpuLongMetric(COLLECT_TIME) += System.nanoTime() - beforeCollect
+          rows
         case b if SparkShimImpl.isEmptyRelation(b) => Array.empty
         case b => throw new IllegalStateException(s"Unexpected broadcast type: ${b.getClass}")
       }
@@ -93,13 +102,15 @@ case class GpuBroadcastToRowExec(
     GpuBroadcastToRowExec(keys, broadcastMode, child.canonicalized)
   }
 
+  // Pure projection — does not touch metrics. The caller is responsible for recording
+  // `dataSize` and `COLLECT_TIME` on every invocation (including cache hits) so the Spark
+  // UI keeps reporting a per-probe-site value even after `projectedRowsOrCompute` starts
+  // serving cached results.
   private def projectSerializedBatch(
       serBatch: SerializeConcatHostBuffersDeserializeBatch): Array[InternalRow] = {
-    val beforeCollect = System.nanoTime()
-
     // Deserializes the batch on the host. Then, transforms it to rows and performs row-wise
     // projection. We should NOT run any device operation on the driver node.
-    val result = withResource(serBatch.hostBatch) { hostBatch =>
+    withResource(serBatch.hostBatch) { hostBatch =>
       val projection = UnsafeProjection.create((0 until hostBatch.numCols()).map { idx =>
         BoundReference(idx, hostBatch.column(idx).dataType, nullable = true)
       }.toSeq)
@@ -107,11 +118,6 @@ case class GpuBroadcastToRowExec(
         projection(row).copy().asInstanceOf[InternalRow]
       }.toArray // force evaluation so we don't close hostBatch too soon
     }
-
-    gpuLongMetric("dataSize") += serBatch.dataSize
-    gpuLongMetric(COLLECT_TIME) += System.nanoTime() - beforeCollect
-
-    result
   }
 
   protected[sql] override def doExecute(): RDD[InternalRow] = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,7 +214,21 @@ case class GpuSubqueryBroadcastExec(
       SQLExecution.withExecutionId(session, executionId) {
         val broadcastBatch = child.executeBroadcast[Any]()
         val result: Array[InternalRow] = broadcastBatch.value match {
-          case b: SerializeConcatHostBuffersDeserializeBatch =>  projectSerializedBatchToRows(b)
+          case b: SerializeConcatHostBuffersDeserializeBatch =>
+            // Memoize the projected rows on the broadcast value itself. The cache key is the
+            // canonical projection spec (indices + buildKeys + modeKeys), which matches
+            // Spark's ReusedSubquery canonicalization. Sibling fact-table sub-trees that
+            // reference the same DPP subquery (e.g. one date_dim feeding multiple fact-table
+            // scans) now resolve to a ConcurrentHashMap get instead of re-running
+            // serBatch.hostBatch -> rowIterator -> UnsafeProjection per probe site.
+            val key = ProjectedRowsKey(
+              "subquery",
+              indices,
+              buildKeys.map(_.canonicalized),
+              modeKeys.map(_.map(_.canonicalized)))
+            b.projectedRowsOrCompute(key) {
+              projectSerializedBatchToRows(b)
+            }
           case b if SparkShimImpl.isEmptyRelation(b) => Array.empty
           case b => throw new IllegalStateException(s"Unexpected broadcast type: ${b.getClass}")
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
@@ -221,14 +221,21 @@ case class GpuSubqueryBroadcastExec(
             // reference the same DPP subquery (e.g. one date_dim feeding multiple fact-table
             // scans) now resolve to a ConcurrentHashMap get instead of re-running
             // serBatch.hostBatch -> rowIterator -> UnsafeProjection per probe site.
+            val beforeCollect = System.nanoTime()
             val key = ProjectedRowsKey(
               "subquery",
               indices,
               buildKeys.map(_.canonicalized),
               modeKeys.map(_.map(_.canonicalized)))
-            b.projectedRowsOrCompute(key) {
+            val rows = b.projectedRowsOrCompute(key) {
               projectSerializedBatchToRows(b)
             }
+            // Update metrics on every call (cache hit and miss) to preserve the
+            // per-probe-site semantics that consumers of the Spark UI saw before this
+            // cache was introduced.
+            gpuLongMetric("dataSize") += b.dataSize
+            gpuLongMetric(COLLECT_TIME) += System.nanoTime() - beforeCollect
+            rows
           case b if SparkShimImpl.isEmptyRelation(b) => Array.empty
           case b => throw new IllegalStateException(s"Unexpected broadcast type: ${b.getClass}")
         }
@@ -238,10 +245,12 @@ case class GpuSubqueryBroadcastExec(
     }
   }
 
+  // Pure projection — does not touch metrics. The caller is responsible for recording
+  // `dataSize` and `COLLECT_TIME` on every invocation (including cache hits) so the Spark
+  // UI keeps reporting a per-probe-site value even after `projectedRowsOrCompute` starts
+  // serving cached results.
   private def projectSerializedBatchToRows(
       serBatch: SerializeConcatHostBuffersDeserializeBatch): Array[InternalRow] = {
-    val beforeCollect = System.nanoTime()
-
     // Creates projection to extract target field from Row, as what Spark does.
     // Note that unlike Spark, the GPU broadcast data has not applied the key expressions from
     // the HashedRelation, so that is applied here if necessary to ensure the proper values
@@ -275,17 +284,12 @@ case class GpuSubqueryBroadcastExec(
 
     // Deserializes the batch on the host. Then, transforms it to rows and performs row-wise
     // projection. We should NOT run any device operation on the driver node.
-    val result = withResource(serBatch.hostBatch) { hostBatch =>
+    withResource(serBatch.hostBatch) { hostBatch =>
       hostBatch.rowIterator().asScala.map { row =>
         val broadcastRow = broadcastModeProject.map(_(row)).getOrElse(row)
         rowProject(broadcastRow).copy().asInstanceOf[InternalRow]
       }.toArray // force evaluation so we don't close hostBatch too soon
     }
-
-    gpuLongMetric("dataSize") += serBatch.dataSize
-    gpuLongMetric(COLLECT_TIME) += System.nanoTime() - beforeCollect
-
-    result
   }
 
   protected override def doExecute(): RDD[InternalRow] = {

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/execution/SerializeConcatBroadcastCacheSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/execution/SerializeConcatBroadcastCacheSuite.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.execution
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, Literal}
+import org.apache.spark.sql.types.IntegerType
+
+/**
+ * Unit tests for the projected-rows memoization on
+ * [[SerializeConcatHostBuffersDeserializeBatch]] introduced to avoid re-running the
+ * host-side projection of a DPP broadcast across reused probe sites.
+ *
+ * The tests construct an empty broadcast value (`data = null`, no columns, no rows) so
+ * we can exercise the cache helper in isolation without needing RMM, the spill
+ * framework, a Spark session, or a GPU. The cache helper itself is purely host-side
+ * Java collection logic.
+ */
+class SerializeConcatBroadcastCacheSuite extends AnyFunSuite {
+
+  private def newEmptyBroadcast(): SerializeConcatHostBuffersDeserializeBatch =
+    new SerializeConcatHostBuffersDeserializeBatch(
+      data = null,
+      output = Seq.empty,
+      numRows = 0,
+      dataLen = 0L)
+
+  private def row(i: Int): InternalRow = new GenericInternalRow(Array[Any](i))
+
+  /** Build a fresh AttributeReference each call so the underlying ExprId differs. */
+  private def attr(name: String): AttributeReference =
+    AttributeReference(name, IntegerType, nullable = true)()
+
+  test("ProjectedRowsKey: canonicalized equal expressions yield equal keys") {
+    // Same logical expression tree produced by two independently-built
+    // AttributeReferences (different ExprIds). Spark's ReusedSubquery rule treats these
+    // as equivalent once canonicalized, and our cache key must reflect that so reused
+    // subqueries hit the cache.
+    val a1 = attr("k").canonicalized
+    val a2 = attr("k").canonicalized
+    val key1 = ProjectedRowsKey("subquery", Seq(0), Seq(a1), None)
+    val key2 = ProjectedRowsKey("subquery", Seq(0), Seq(a2), None)
+    assert(key1 == key2, "canonicalized AttributeReference should produce equal keys")
+    assert(key1.hashCode == key2.hashCode, "equal keys must share the same hashCode")
+  }
+
+  test("ProjectedRowsKey: 'kind' discriminator separates subquery vs broadcastRow keys") {
+    // GpuSubqueryBroadcastExec and GpuBroadcastToRowExec can share the same broadcast
+    // value but project differently. The discriminator must keep their cache entries
+    // separate so a "broadcastRow" projection cannot satisfy a "subquery" lookup.
+    val canon = attr("k").canonicalized
+    val sub = ProjectedRowsKey("subquery", Seq(0), Seq(canon), None)
+    val row = ProjectedRowsKey("broadcastRow", Seq(0), Seq(canon), None)
+    assert(sub != row)
+  }
+
+  test("ProjectedRowsKey: indices ordering matters") {
+    // Selecting columns 0,1 vs 1,0 yields different InternalRow layouts; the cache
+    // key must distinguish them.
+    val canon = attr("k").canonicalized
+    val k01 = ProjectedRowsKey("subquery", Seq(0, 1), Seq(canon), None)
+    val k10 = ProjectedRowsKey("subquery", Seq(1, 0), Seq(canon), None)
+    assert(k01 != k10)
+  }
+
+  test("ProjectedRowsKey: modeKeys differences are reflected") {
+    val canon = attr("k").canonicalized
+    val withMode = ProjectedRowsKey(
+      "subquery", Seq(0), Seq(canon), Some(Seq(Literal(1, IntegerType).canonicalized)))
+    val withoutMode = ProjectedRowsKey("subquery", Seq(0), Seq(canon), None)
+    assert(withMode != withoutMode)
+  }
+
+  test("projectedRowsOrCompute: second call with same key reuses cached array") {
+    val bcast = newEmptyBroadcast()
+    val key = ProjectedRowsKey("subquery", Seq(0), Seq.empty[Expression], None)
+    val computeCount = new AtomicInteger(0)
+    val expected = Array(row(1), row(2), row(3))
+
+    val first = bcast.projectedRowsOrCompute(key) {
+      computeCount.incrementAndGet()
+      expected
+    }
+    val second = bcast.projectedRowsOrCompute(key) {
+      computeCount.incrementAndGet()
+      Array(row(99))
+    }
+
+    assert(computeCount.get() == 1, "compute thunk must run exactly once for repeated key")
+    assert(first eq second, "second call must return the same array instance")
+    assert(first eq expected, "cached array must be the one produced by the first compute")
+  }
+
+  test("projectedRowsOrCompute: distinct keys compute independently") {
+    val bcast = newEmptyBroadcast()
+    val keyA = ProjectedRowsKey("subquery", Seq(0), Seq.empty[Expression], None)
+    val keyB = ProjectedRowsKey("broadcastRow", Seq(0), Seq.empty[Expression], None)
+    val computeCount = new AtomicInteger(0)
+
+    val resultA = bcast.projectedRowsOrCompute(keyA) {
+      computeCount.incrementAndGet()
+      Array(row(1))
+    }
+    val resultB = bcast.projectedRowsOrCompute(keyB) {
+      computeCount.incrementAndGet()
+      Array(row(2))
+    }
+
+    assert(computeCount.get() == 2, "each distinct key must run its own compute")
+    assert(resultA(0).getInt(0) == 1)
+    assert(resultB(0).getInt(0) == 2)
+
+    // Hits on each key after the initial computes do NOT trigger compute again.
+    bcast.projectedRowsOrCompute(keyA)(throw new AssertionError("must not run"))
+    bcast.projectedRowsOrCompute(keyB)(throw new AssertionError("must not run"))
+  }
+
+  test("closeInternal: clears the cache so the next call re-computes") {
+    val bcast = newEmptyBroadcast()
+    val key = ProjectedRowsKey("subquery", Seq(0), Seq.empty[Expression], None)
+    val computeCount = new AtomicInteger(0)
+
+    bcast.projectedRowsOrCompute(key) {
+      computeCount.incrementAndGet()
+      Array(row(1))
+    }
+    bcast.projectedRowsOrCompute(key) {
+      computeCount.incrementAndGet()
+      Array(row(2))
+    }
+    assert(computeCount.get() == 1, "warm-up: cache should serve the second call")
+
+    bcast.closeInternal()
+
+    val afterClose = bcast.projectedRowsOrCompute(key) {
+      computeCount.incrementAndGet()
+      Array(row(42))
+    }
+    assert(computeCount.get() == 2, "closeInternal must invalidate the cache")
+    assert(afterClose(0).getInt(0) == 42)
+  }
+
+  test("projectedRowsOrCompute: concurrent racers all observe the same cached array") {
+    // Stress the putIfAbsent race path: many threads all call projectedRowsOrCompute
+    // on the same key at roughly the same moment. The contract is that the cache
+    // converges to one shared Array and all callers eventually return the same
+    // instance, even though `compute` may run more than once on the loser threads
+    // (whose results are discarded).
+    val bcast = newEmptyBroadcast()
+    val key = ProjectedRowsKey("subquery", Seq(0), Seq.empty[Expression], None)
+    val numThreads = 16
+    val barrier = new CountDownLatch(1)
+    val computeCount = new AtomicInteger(0)
+    val executor = Executors.newFixedThreadPool(numThreads)
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
+
+    try {
+      val futures = (0 until numThreads).map { _ =>
+        Future {
+          barrier.await()
+          bcast.projectedRowsOrCompute(key) {
+            computeCount.incrementAndGet()
+            Array(row(1))
+          }
+        }
+      }
+      barrier.countDown()
+      val results = Await.result(Future.sequence(futures), 10.seconds)
+
+      val canonical = results.head
+      assert(results.forall(_ eq canonical),
+        "all racing threads must return the same cached array instance")
+      assert(computeCount.get() >= 1 && computeCount.get() <= numThreads,
+        s"compute should run at least once and at most once per thread, " +
+          s"got ${computeCount.get()}")
+    } finally {
+      executor.shutdownNow()
+      executor.awaitTermination(5, TimeUnit.SECONDS)
+    }
+  }
+
+  test("projectedRowsOrCompute: cache is per broadcast-value instance") {
+    // The cache is per-broadcast-value: two distinct broadcast instances must have
+    // disjoint caches even when probed with the same key.
+    val bcastA = newEmptyBroadcast()
+    val bcastB = newEmptyBroadcast()
+    val key = ProjectedRowsKey("subquery", Seq(0), Seq.empty[Expression], None)
+    val resultA = bcastA.projectedRowsOrCompute(key)(Array(row(1)))
+    val resultB = bcastB.projectedRowsOrCompute(key)(Array(row(2)))
+    assert(resultA(0).getInt(0) == 1)
+    assert(resultB(0).getInt(0) == 2)
+    assert(resultA ne resultB)
+  }
+
+  test("ProjectedRowsKey: structural symmetry sanity check") {
+    // Catches accidental field reordering in the case class which would silently
+    // change the cache semantics. Using `productArity` instead of explicit field
+    // counts in case the case class grows in a follow-up.
+    val canon = attr("k").canonicalized
+    val k = ProjectedRowsKey("subquery", Seq(0), Seq(canon), None)
+    assert(k.productArity == 4)
+    assert(k.kind == "subquery")
+    assert(k.indices == Seq(0))
+    assert(k.canonicalBuildKeys == Seq(canon))
+    assert(k.canonicalModeKeys.isEmpty)
+  }
+}


### PR DESCRIPTION

### Description

#### Problem

On NDS / TPC-DS-style workloads with star-schema dynamic partition pruning
(DPP), a single dimension subquery is frequently *reused* across multiple
fact-table scans. Today every reused probe site re-runs the host-side
projection of the broadcast batch:

`SerializeConcatHostBuffersDeserializeBatch.hostBatch → rowIterator →
UnsafeProjection → Array[InternalRow]`

For a wide `date_dim`-style broadcast feeding several fact tables, this
projection runs once per probe site per executor per query, even though the
result is identical and pure. This shows up as the `GpuSubqueryBroadcast
re-execution` hotspot on NDS DPP queries (e.g. q7, q33, q39_part1,
q39_part2, q52, q55, q83).

#### Solution

Memoize the projected `Array[InternalRow]` on the shared broadcast value
(`SerializeConcatHostBuffersDeserializeBatch`) keyed by the canonical
projection spec:

- `kind` discriminates `GpuSubqueryBroadcastExec` callers from
  `GpuBroadcastToRowExec` callers (different projection shapes — would
  otherwise collide on the same shared batch).
- `canonicalBuildKeys` / `canonicalModeKeys` use Spark's standard
  `Expression#canonicalized` so the cache hits exactly when Spark's
  `ReusedSubquery` rule already considers two subqueries equivalent —
  i.e. exactly when the host-side projection result *would* be identical.

Cache lifecycle:

- Lives on the broadcast value, so it dies with the broadcast (cleared in
  `closeInternal`).
- `ConcurrentHashMap` with `putIfAbsent` semantics: benign double-compute
  on race, single shared array in steady state. The `compute` thunk runs
  outside the table-level lock so the slow path doesn't block other keys.

#### User-facing impact

None. This is a pure memoization on an existing call site — the value
returned by `executeCollect()` is identical to the existing path, just
cached.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
      (`tests/src/test/scala/org/apache/spark/sql/rapids/execution/SerializeConcatBroadcastCacheSuite.scala`
      covers `ProjectedRowsKey` canonicalization equality, `kind` /
      indices / `modeKeys` discrimination, single-key memoization,
      multi-key independence, `closeInternal` invalidation, multi-instance
      isolation, and concurrent `putIfAbsent` race semantics. End-to-end
      DPP correctness is also covered by existing
      `integration_tests/src/main/python/dpp_test.py::test_dpp_reuse_broadcast_exchange`.)
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

