### PR TITLE
[BUG] Fix RegexParser.parseHexDigit greedy consumption of non-braced \xNN

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -639,6 +639,22 @@ def test_regexp_hexadecimal_digits():
                 'rlike(a, "[\\\\x41b]")',
             ),
         conf=_regexp_conf)
+    # Issue #14739 (positive-match path): the random data above only contains
+    # `[abcd]`-prefixed strings, so two-character substrings like "aa", "Af",
+    # or "ab" only appear by coincidence. Add a literal dataframe with strings
+    # that DO contain the targeted two-char substrings so the matched/replaced
+    # branch of the cap fix is actually exercised on both GPU and CPU.
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: spark.createDataFrame(
+                [("aa",), ("Af",), ("ab",), ("zz",), ("Aff",), ("xaay",)],
+                "a string").selectExpr(
+                'regexp_replace(a, "\\\\x61a", "X")',  # "aa" -> "X"
+                'regexp_replace(a, "\\\\x41f", "X")',  # "Af" -> "X"
+                'rlike(a, "\\\\x61a")',
+                'rlike(a, "\\\\x41f")',
+                'rlike(a, "[\\\\x41b]")',  # [A,b] char class
+            ),
+        conf=_regexp_conf)
 
 def test_regexp_whitespace():
     gen = mk_str_gen('\u001e[abcd]\t\n{1,3} [0-9]\n {1,3}\x0b\t[abcd]\r\f[0-9]{0,10}')

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -630,6 +630,13 @@ def test_regexp_hexadecimal_digits():
                 'regexp_replace(a, "\\\\xff", "@")',
                 'regexp_replace(a, "[\\\\xa0-\\\\xb0]", "@")',
                 'regexp_replace(a, "\\\\x{10ffff}", "@")',
+                # Issue #14739: non-braced \xNN followed by another hex digit
+                # used to be greedily consumed and rejected. The cap fix below
+                # makes these patterns run on GPU instead of falling back.
+                'regexp_replace(a, "\\\\x61a", "X")',
+                'regexp_replace(a, "\\\\x41f", "X")',
+                'rlike(a, "\\\\x61a")',
+                'rlike(a, "[\\\\x41b]")',
             ),
         conf=_regexp_conf)
 

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -633,10 +633,10 @@ def test_regexp_hexadecimal_digits():
                 # Issue #14739: non-braced \xNN followed by another hex digit
                 # used to be greedily consumed and rejected. The cap fix below
                 # makes these patterns run on GPU instead of falling back.
-                'regexp_replace(a, "\\\\x61a", "X")',
-                'regexp_replace(a, "\\\\x41f", "X")',
-                'rlike(a, "\\\\x61a")',
-                'rlike(a, "[\\\\x41b]")',
+                r'regexp_replace(a, "\\x61a", "X")',
+                r'regexp_replace(a, "\\x41f", "X")',
+                r'rlike(a, "\\x61a")',
+                r'rlike(a, "[\\x41b]")',
             ),
         conf=_regexp_conf)
     # Issue #14739 (positive-match path): the random data above only contains
@@ -648,11 +648,11 @@ def test_regexp_hexadecimal_digits():
             lambda spark: spark.createDataFrame(
                 [("aa",), ("Af",), ("ab",), ("zz",), ("Aff",), ("xaay",)],
                 "a string").selectExpr(
-                'regexp_replace(a, "\\\\x61a", "X")',  # "aa" -> "X"
-                'regexp_replace(a, "\\\\x41f", "X")',  # "Af" -> "X"
-                'rlike(a, "\\\\x61a")',
-                'rlike(a, "\\\\x41f")',
-                'rlike(a, "[\\\\x41b]")',  # [A,b] char class
+                r'regexp_replace(a, "\\x61a", "X")',  # "aa" -> "X"
+                r'regexp_replace(a, "\\x41f", "X")',  # "Af" -> "X"
+                r'rlike(a, "\\x61a")',
+                r'rlike(a, "\\x41f")',
+                r'rlike(a, "[\\x41b]")',  # [A,b] char class
             ),
         conf=_regexp_conf)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -530,10 +530,8 @@ class RegexParser(pattern: String) {
     // patterns like "\\x61a" were rejected even though they are valid Java
     // regex meaning "0x61 (= 'a') followed by the literal 'a'".
     val hexLimit = if (varHex) Int.MaxValue else 2
-    var consumed = 0
-    while (consumed < hexLimit && !eof() && isHexDigit(pattern.charAt(pos))) {
+    while (pos - start < hexLimit && !eof() && isHexDigit(pattern.charAt(pos))) {
       pos += 1
-      consumed += 1
     }
     val hexDigit = pattern.substring(start, pos)
     if (varHex) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -523,8 +523,17 @@ class RegexParser(pattern: String) {
       consumeExpected('{')
     }
     val start = pos
-    while (!eof() && isHexDigit(pattern.charAt(pos))) {
+    // Java spec: non-braced `\xNN` consumes EXACTLY two hex digits and any
+    // trailing hex digits are part of the surrounding pattern. The braced form
+    // `\x{h...h}` consumes hex digits until the closing '}' (validated below).
+    // Issue #14739: previously this loop was unbounded for both forms, so
+    // patterns like "\\x61a" were rejected even though they are valid Java
+    // regex meaning "0x61 (= 'a') followed by the literal 'a'".
+    val hexLimit = if (varHex) Int.MaxValue else 2
+    var consumed = 0
+    while (consumed < hexLimit && !eof() && isHexDigit(pattern.charAt(pos))) {
       pos += 1
+      consumed += 1
     }
     val hexDigit = pattern.substring(start, pos)
     if (varHex) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -149,7 +149,7 @@ class RegularExpressionParserSuite extends AnyFunSuite {
       RegexSequence(ListBuffer(RegexHexDigit("ABC"))))
   }
 
-  test("issue-14739: non-braced \\xNN caps at 2 hex digits") {
+  test("non-braced \\xNN caps at 2 hex digits") {
     // Java spec: non-braced \x consumes EXACTLY two hex digits; any trailing
     // hex digits are part of the surrounding pattern. Previously the parser
     // greedily consumed all subsequent hex digits and then rejected the

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -149,6 +149,40 @@ class RegularExpressionParserSuite extends AnyFunSuite {
       RegexSequence(ListBuffer(RegexHexDigit("ABC"))))
   }
 
+  test("issue-14739: non-braced \\xNN caps at 2 hex digits") {
+    // Java spec: non-braced \x consumes EXACTLY two hex digits; any trailing
+    // hex digits are part of the surrounding pattern. Previously the parser
+    // greedily consumed all subsequent hex digits and then rejected the
+    // pattern because the consumed string wasn't 2 chars long.
+
+    // \x61 followed by literal 'a' (the canonical bug repro).
+    assert(parse(raw"\x61a") ===
+      RegexSequence(ListBuffer(RegexHexDigit("61"), RegexChar('a'))))
+
+    // \x41 followed by literal 'f' — 'f' is a hex digit and used to be
+    // swallowed by the greedy loop.
+    assert(parse(raw"\x41f") ===
+      RegexSequence(ListBuffer(RegexHexDigit("41"), RegexChar('f'))))
+
+    // \x05 followed by digit '7' — '7' is also a hex digit.
+    assert(parse(raw"\x057") ===
+      RegexSequence(ListBuffer(RegexHexDigit("05"), RegexChar('7'))))
+
+    // Inside a character class: \x41 followed by literal 'b' as a class
+    // member. parseCharacterClass narrows non-zero \xNN into a RegexChar with
+    // the resolved codepoint, so 0x41 -> 'A'. Confirms the 2-digit cap is
+    // applied through parseCharacterClass too (without it the parser would
+    // reject "[\\x41b]" as "Invalid hex digit: 41b").
+    assert(parse(raw"[\x41b]") ===
+      RegexSequence(ListBuffer(
+        RegexCharacterClass(negated = false,
+          ListBuffer(RegexChar('A'), RegexChar('b'))))))
+
+    // Braced form must still consume more than 2 hex digits.
+    assert(parse(raw"\x{1F600}") ===
+      RegexSequence(ListBuffer(RegexHexDigit("1F600"))))
+  }
+
   test("octal digit") {
     val digits = Seq("00", "01", "076", "077", "0123", "0177", "0377")
     for (digit <- digits) {


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +4 lines**

## Summary

Closes #14739 — sub-issue of the regex parser/transpiler epic #14733.

`RegexParser.parseHexDigit` used an unbounded `while (isHexDigit(...))` loop to consume hex digits for both the non-braced (`\xNN`) and braced (`\x{h...h}`) forms, then rejected the non-braced form if more than two digits had been consumed. As a result valid Java patterns like `\x61a` (= the character `0x61` followed by the literal letter `a`) were rejected by the spark-rapids transpiler with `Invalid hex digit: 61a` and the whole regex fell back to CPU.

This change caps the loop at two digits for the non-braced form while leaving the braced form unbounded (the trailing `}` still validates length).

### Changes

- `sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala` — cap non-braced `\xNN` consumption at 2 hex digits.
- `tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala` — new test `non-braced \xNN caps at 2 hex digits` covering `\x61a`, `\x41f`, `\x057`, `[\x41b]`, plus a `\x{1F600}` braced regression.
- `integration_tests/src/main/python/regexp_test.py` — extend the existing `test_regexp_hexadecimal_digits` inline with `regexp_replace(a, "\\x61a", "X")`, `regexp_replace(a, "\\x41f", "X")`, `rlike(a, "\\x61a")`, and `rlike(a, "[\\x41b]")`.

### Local validation

Scala unit test (worktree-local, `mvn -pl tests -am -Dbuildver=330 -DwildcardSuites=com.nvidia.spark.rapids.RegularExpressionParserSuite`):
```
Tests: succeeded 24, failed 0, canceled 0, ignored 0, pending 0
```

Python IT (`./run_pyspark_from_build.sh` with `TEST=test_regexp_hexadecimal_digits` under uvpy310 + Spark 3.3.0, GPU `allocFraction=0.3`):
```
1 passed, 39867 deselected, 8 warnings in 9.78s
```

Compile gate (`mvn -pl sql-plugin -am -Dbuildver=330 -DskipTests`):
```
BUILD SUCCESS
```

### Severity & scope

Per the sub-issue body: missed GPU acceleration, no correctness divergence (CPU fallback already produced the right answer). The fix moves these patterns onto the GPU path. The bug surface is any `\xNN` immediately followed by another hex digit; the deterministic repro is `\x61a` (`\x` + `[0-9a-fA-F]`).

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

