### PR TITLE
Warn on unknown RAPIDS configs

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -488,6 +488,7 @@ class RapidsDriverPlugin extends DriverPlugin with Logging {
     sc: SparkContext, pluginContext: PluginContext): java.util.Map[String, String] = {
     val sparkConf = pluginContext.conf
     RapidsPluginUtils.fixupConfigsOnDriver(sparkConf)
+    RapidsConf.logUnknownRapidsConfs(sparkConf)
     val conf = new RapidsConf(sparkConf)
     RapidsPluginUtils.detectMultipleJars(conf)
     RapidsPluginUtils.logPluginMode(conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -20,6 +20,7 @@ import java.util
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{HashMap, ListBuffer}
+import scala.util.control.NonFatal
 
 import ai.rapids.cudf.Cuda
 import com.nvidia.spark.rapids.jni.RmmSpark.OomInjectionType
@@ -3232,7 +3233,14 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
 
   private def knownConfKeys: Set[String] = {
     com.nvidia.spark.rapids.python.PythonConfEntries.init()
-    (registeredConfs.map(_.key) ++ RapidsPrivateUtil.getPrivateConfigs().map(_.key))
+    val privateConfKeys = try {
+      RapidsPrivateUtil.getPrivateConfigs().map(_.key)
+    } catch {
+      case NonFatal(e) =>
+        logDebug("Unable to load private RAPIDS configs for unknown config validation", e)
+        Seq.empty
+    }
+    (registeredConfs.map(_.key) ++ privateConfKeys)
       .flatMap(expandSupportedRapidsConfPrefixes)
       .toSet
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -3195,6 +3195,92 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     val sizeEstimateThreshold = JOIN_GATHERER_SIZE_ESTIMATE_THRESHOLD.get(conf)
     JoinOptions(strategy, buildSideSelection, targetSize, logCardinality, sizeEstimateThreshold)
   }
+
+  private val rapidsConfPrefix = "spark.rapids."
+
+  // Keep config namespaces separate from suffix rules so a future namespace can be added
+  // without duplicating every dynamic config pattern.
+  private val supportedRapidsConfPrefixes = Seq(rapidsConfPrefix)
+
+  // Dynamic configs use a runtime class simple name after the suffix prefix. Only allow a
+  // single suffix segment so misspelled static sub-configs still get reported.
+  private val dynamicConfSuffixPrefixes = Seq(
+    ENABLE_COMBINED_EXPR_PREFIX.stripPrefix(rapidsConfPrefix),
+    "sql.expression.",
+    "sql.exec.",
+    "sql.input.",
+    "sql.partitioning.",
+    "sql.output.",
+    "sql.command.",
+    "sql.optimizer.cpu.exec.",
+    "sql.optimizer.cpu.expr.",
+    "sql.optimizer.gpu.exec.",
+    "sql.optimizer.gpu.expr.")
+
+  private def stripSupportedRapidsConfPrefix(key: String): Option[String] = {
+    supportedRapidsConfPrefixes.find(key.startsWith).map { prefix =>
+      key.stripPrefix(prefix)
+    }
+  }
+
+  private def expandSupportedRapidsConfPrefixes(key: String): Seq[String] = {
+    stripSupportedRapidsConfPrefix(key) match {
+      case Some(suffix) => supportedRapidsConfPrefixes.map(_ + suffix)
+      case None => Seq(key)
+    }
+  }
+
+  private def knownConfKeys: Set[String] = {
+    com.nvidia.spark.rapids.python.PythonConfEntries.init()
+    (registeredConfs.map(_.key) ++ RapidsPrivateUtil.getPrivateConfigs().map(_.key))
+      .flatMap(expandSupportedRapidsConfPrefixes)
+      .toSet
+  }
+
+  private def isDynamicConf(key: String): Boolean = {
+    stripSupportedRapidsConfPrefix(key).exists { keySuffix =>
+      dynamicConfSuffixPrefixes.exists { prefix =>
+        if (keySuffix.startsWith(prefix)) {
+          val dynamicPart = keySuffix.stripPrefix(prefix)
+          dynamicPart.nonEmpty && !dynamicPart.contains(".")
+        } else {
+          false
+        }
+      }
+    }
+  }
+
+  private def isShimGateConf(key: String): Boolean = {
+    stripSupportedRapidsConfPrefix(key).exists { keySuffix =>
+      val shimPrefix = "shims."
+      val enabledSuffix = ".enabled"
+      if (keySuffix.startsWith(shimPrefix) && keySuffix.endsWith(enabledSuffix)) {
+        val shimId = keySuffix.stripPrefix(shimPrefix).stripSuffix(enabledSuffix)
+        shimId.nonEmpty && !shimId.contains(".")
+      } else {
+        false
+      }
+    }
+  }
+
+  private[rapids] def unknownRapidsConfs(conf: Map[String, String]): Seq[String] = {
+    val knownConfs = knownConfKeys
+    conf.keys
+      .filter(stripSupportedRapidsConfPrefix(_).isDefined)
+      .filterNot(knownConfs.contains)
+      .filterNot(isDynamicConf)
+      .filterNot(isShimGateConf)
+      .toSeq
+      .sorted
+  }
+
+  def logUnknownRapidsConfs(conf: SparkConf): Unit = {
+    unknownRapidsConfs(Map(conf.getAll: _*)).foreach { key =>
+      logWarning(s"Unknown RAPIDS Accelerator configuration '$key'. This may be a typo, " +
+        "or the configuration may have been removed or moved. The setting will be ignored by " +
+        "this plugin version unless it is handled by another RAPIDS plugin component.")
+    }
+  }
 }
 
 class RapidsConf(conf: Map[String, String]) extends Logging {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -3278,7 +3278,7 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     unknownRapidsConfs(Map(conf.getAll: _*)).foreach { key =>
       logWarning(s"Unknown RAPIDS Accelerator configuration '$key'. This may be a typo, " +
         "or the configuration may have been removed or moved. The setting will be ignored by " +
-        "this plugin version unless it is handled by another RAPIDS plugin component.")
+        "this plugin version.")
     }
   }
 }

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/RapidsConfSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/RapidsConfSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.python.PythonConfEntries
+import org.scalatest.funsuite.AnyFunSuite
+
+class RapidsConfSuite extends AnyFunSuite {
+  test("unknown RAPIDS configs ignores registered, dynamic, and shim gate configs") {
+    val conf = Map(
+      RapidsConf.SQL_ENABLED.key -> "true",
+      RapidsConf.EXPLAIN.key -> "ALL",
+      PythonConfEntries.CONCURRENT_PYTHON_WORKERS.key -> "2",
+      "spark.rapids.filecache.enabled" -> "true",
+      "spark.rapids.sql.expression.Add" -> "false",
+      "spark.rapids.sql.exec.SortExec" -> "false",
+      "spark.rapids.sql.expression.combined.GpuContains" -> "false",
+      "spark.rapids.sql.optimizer.gpu.exec.ProjectExec" -> "1.0",
+      "spark.rapids.shims.spark350db143.enabled" -> "false",
+      "spark.sql.shuffle.partitions" -> "1",
+      "spark.cudf.sql.enabled" -> "true",
+      "spark.rapids.sql.enabld" -> "true",
+      "spark.rapids.shims.spark350db143.enabld" -> "true",
+      "spark.rapids.sql.expression.cpuBrdge.enabled" -> "true")
+
+    assert(RapidsConf.unknownRapidsConfs(conf) === Seq(
+      "spark.rapids.shims.spark350db143.enabld",
+      "spark.rapids.sql.enabld",
+      "spark.rapids.sql.expression.cpuBrdge.enabled"))
+  }
+}

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/RapidsConfSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/RapidsConfSuite.scala
@@ -25,7 +25,6 @@ class RapidsConfSuite extends AnyFunSuite {
       RapidsConf.SQL_ENABLED.key -> "true",
       RapidsConf.EXPLAIN.key -> "ALL",
       PythonConfEntries.CONCURRENT_PYTHON_WORKERS.key -> "2",
-      "spark.rapids.filecache.enabled" -> "true",
       "spark.rapids.sql.expression.Add" -> "false",
       "spark.rapids.sql.exec.SortExec" -> "false",
       "spark.rapids.sql.expression.combined.GpuContains" -> "false",


### PR DESCRIPTION
Fixes #14823.

### Description

This PR adds a driver-side diagnostic for unknown RAPIDS Accelerator configuration keys. When the plugin initializes, it scans user-provided `spark.rapids.*` settings and logs a warning for keys that are not registered RAPIDS configs, private configs, known dynamic operator configs, or valid shim gate configs.

This helps users catch typos and removed settings early without failing application startup. Known dynamic keys such as per-expression, per-exec, and optimizer cost configs are excluded from the warning path. Databricks shim gate keys like `spark.rapids.shims.spark350db143.enabled` are also excluded because they are read directly by shim service providers.

The implementation keeps namespace matching separate from suffix rules so a future config namespace can be added without duplicating all dynamic config patterns.

Testing added in `RapidsConfSuite` covers registered configs, Python configs, private configs, dynamic config patterns, shim gate configs, non-RAPIDS configs, and misspelled unknown keys.

Validated with:

- `git diff --check`
- `mvn -pl sql-plugin -Dbuildver=352 -DskipTests compile`
- `mvn -pl sql-plugin -Dbuildver=352 -DwildcardSuites=com.nvidia.spark.rapids.RapidsConfSuite test`
- `mvn -N -Dbuildver=352 -DskipTests -Dmaven.scaladoc.skip -Dmaven.scalastyle.skip=false verify`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
