### PR TITLE
Add protobuf integration-test dependency infrastructure (plugin-0)

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -133,7 +133,6 @@
                                         <include>parquet-hadoop*.jar</include>
                                         <include>spark-avro*.jar</include>
                                         <include>spark-protobuf*.jar</include>
-                                        <include>protobuf-java-*.jar</include>
                                     </includes>
                                 </filesets>
                             </filesets>
@@ -168,8 +167,6 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!-- spark-protobuf shades `com.google.protobuf` internally, so the
-                         unshaded jar is shipped separately for the tests to use. -->
                     <execution>
                         <id>copy-spark-protobuf</id>
                         <phase>package</phase>
@@ -184,11 +181,6 @@
                                     <groupId>org.apache.spark</groupId>
                                     <artifactId>spark-protobuf_${scala.binary.version}</artifactId>
                                     <version>${spark.version}</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.google.protobuf</groupId>
-                                    <artifactId>protobuf-java</artifactId>
-                                    <version>3.25.5</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -132,6 +132,8 @@
                                     <includes>
                                         <include>parquet-hadoop*.jar</include>
                                         <include>spark-avro*.jar</include>
+                                        <include>spark-protobuf*.jar</include>
+                                        <include>protobuf-java-*.jar</include>
                                     </includes>
                                 </filesets>
                             </filesets>
@@ -162,6 +164,36 @@
                                     <artifactId>parquet-hadoop</artifactId>
                                     <version>${parquet.hadoop.version}</version>
                                     <classifier>tests</classifier>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!--
+                        spark-protobuf is a Spark 3.4.0+ module, and spark-protobuf shades its
+                        own `com.google.protobuf` into `org.sparkproject.spark_protobuf.protobuf`
+                        so we ship an unshaded protobuf-java alongside it for the integration
+                        tests. release33x profiles set `spark.protobuf.skipCopy=true` because
+                        spark-protobuf does not exist for Spark 3.3.x.
+                    -->
+                    <execution>
+                        <id>copy-spark-protobuf</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${spark.protobuf.skipCopy}</skip>
+                            <useBaseVersion>true</useBaseVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.spark</groupId>
+                                    <artifactId>spark-protobuf_${scala.binary.version}</artifactId>
+                                    <version>${spark.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.google.protobuf</groupId>
+                                    <artifactId>protobuf-java</artifactId>
+                                    <version>3.25.5</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -168,13 +168,8 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!--
-                        spark-protobuf is a Spark 3.4.0+ module, and spark-protobuf shades its
-                        own `com.google.protobuf` into `org.sparkproject.spark_protobuf.protobuf`
-                        so we ship an unshaded protobuf-java alongside it for the integration
-                        tests. release33x profiles set `spark.protobuf.skipCopy=true` because
-                        spark-protobuf does not exist for Spark 3.3.x.
-                    -->
+                    <!-- spark-protobuf shades `com.google.protobuf` internally, so the
+                         unshaded jar is shipped separately for the tests to use. -->
                     <execution>
                         <id>copy-spark-protobuf</id>
                         <phase>package</phase>

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -103,7 +103,7 @@ else
     # support alternate local jars NOT building from the source code
     if [ -d "$LOCAL_JAR_PATH" ]; then
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
-        PROTOBUF_JARS=$(echo "$LOCAL_JAR_PATH"/spark-protobuf*.jar "$LOCAL_JAR_PATH"/protobuf-java-*.jar)
+        PROTOBUF_JARS=$(echo "$LOCAL_JAR_PATH"/spark-protobuf*.jar)
         PLUGIN_JAR=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
         if [ -f $(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar) ]; then
             export INCLUDE_PARQUET_HADOOP_TEST_JAR=true
@@ -120,7 +120,7 @@ else
     else
         [[ "$SCALA_VERSION" != "2.12"  ]] && TARGET_DIR=${TARGET_DIR/integration_tests/scala$SCALA_VERSION\/integration_tests}
         AVRO_JARS=$(echo "$TARGET_DIR"/dependency/spark-avro*.jar)
-        PROTOBUF_JARS=$(echo "$TARGET_DIR"/dependency/spark-protobuf*.jar "$TARGET_DIR"/dependency/protobuf-java-*.jar)
+        PROTOBUF_JARS=$(echo "$TARGET_DIR"/dependency/spark-protobuf*.jar)
         PARQUET_HADOOP_TESTS=$(echo "$TARGET_DIR"/dependency/parquet-hadoop*.jar)
         # remove the log4j.properties file so it doesn't conflict with ours, ignore errors
         # if it isn't present or already removed
@@ -146,16 +146,14 @@ else
         AVRO_JARS=""
     fi
 
-    # spark-protobuf shades `com.google.protobuf.*` internally and Spark does not bundle the
-    # unshaded jar, so we must ship both jars to the test classpath.
     INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED=$(echo "${INCLUDE_SPARK_PROTOBUF_JAR}" | tr '[:upper:]' '[:lower:]')
     if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" != "false" \
-          && $(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l) -eq 2 ]];
+          && $(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l) -eq 1 ]];
     then
         export INCLUDE_SPARK_PROTOBUF_JAR=true
     else
         if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" == "true" ]]; then
-            >&2 echo "WARNING: INCLUDE_SPARK_PROTOBUF_JAR=true was requested but spark-protobuf/protobuf-java jars were not found (searched: $PROTOBUF_JARS); disabling protobuf tests."
+            >&2 echo "WARNING: INCLUDE_SPARK_PROTOBUF_JAR=true was requested but a spark-protobuf jar was not found (searched: $PROTOBUF_JARS); disabling protobuf tests."
         fi
         export INCLUDE_SPARK_PROTOBUF_JAR=false
         PROTOBUF_JARS=""

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -46,6 +46,9 @@
 #   To run all tests, including Avro tests:
 #     INCLUDE_SPARK_AVRO_JAR=true ./run_pyspark_from_build.sh
 #
+#   To run tests WITHOUT Protobuf tests (protobuf is included by default):
+#     INCLUDE_SPARK_PROTOBUF_JAR=false ./run_pyspark_from_build.sh
+#
 #   To run a specific test:
 #     TEST=my_test ./run_pyspark_from_build.sh
 #
@@ -100,6 +103,7 @@ else
     # support alternate local jars NOT building from the source code
     if [ -d "$LOCAL_JAR_PATH" ]; then
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
+        PROTOBUF_JARS=$(echo "$LOCAL_JAR_PATH"/spark-protobuf*.jar "$LOCAL_JAR_PATH"/protobuf-java-*.jar)
         PLUGIN_JAR=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
         if [ -f $(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar) ]; then
             export INCLUDE_PARQUET_HADOOP_TEST_JAR=true
@@ -116,6 +120,7 @@ else
     else
         [[ "$SCALA_VERSION" != "2.12"  ]] && TARGET_DIR=${TARGET_DIR/integration_tests/scala$SCALA_VERSION\/integration_tests}
         AVRO_JARS=$(echo "$TARGET_DIR"/dependency/spark-avro*.jar)
+        PROTOBUF_JARS=$(echo "$TARGET_DIR"/dependency/spark-protobuf*.jar "$TARGET_DIR"/dependency/protobuf-java-*.jar)
         PARQUET_HADOOP_TESTS=$(echo "$TARGET_DIR"/dependency/parquet-hadoop*.jar)
         # remove the log4j.properties file so it doesn't conflict with ours, ignore errors
         # if it isn't present or already removed
@@ -141,9 +146,22 @@ else
         AVRO_JARS=""
     fi
 
-    # ALL_JARS includes dist.jar integration-test.jar avro.jar parquet.jar if they exist
+    # Set INCLUDE_SPARK_PROTOBUF_JAR=false to skip protobuf_test.py. Both `spark-protobuf` and
+    # the unshaded `protobuf-java` come from maven-dependency-plugin and must both be present
+    # -- spark-protobuf shades `com.google.protobuf.*` internally and Spark does not bundle
+    # the unshaded jar.
+    if [[ $( echo ${INCLUDE_SPARK_PROTOBUF_JAR} | tr '[:upper:]' '[:lower:]' ) != "false" \
+          && $(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l) -eq 2 ]];
+    then
+        export INCLUDE_SPARK_PROTOBUF_JAR=true
+    else
+        export INCLUDE_SPARK_PROTOBUF_JAR=false
+        PROTOBUF_JARS=""
+    fi
+
+    # ALL_JARS includes dist.jar integration-test.jar avro.jar parquet.jar protobuf.jar if they exist
     # Remove non-existing paths and canonicalize the paths including get rid of links and `..`
-    ALL_JARS=$(readlink -e $PLUGIN_JAR $TEST_JARS $AVRO_JARS $PARQUET_HADOOP_TESTS || true)
+    ALL_JARS=$(readlink -e $PLUGIN_JAR $TEST_JARS $AVRO_JARS $PARQUET_HADOOP_TESTS $PROTOBUF_JARS || true)
     # `:` separated jars
     ALL_JARS="${ALL_JARS//$'\n'/:}"
 

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -150,11 +150,15 @@ else
     # the unshaded `protobuf-java` come from maven-dependency-plugin and must both be present
     # -- spark-protobuf shades `com.google.protobuf.*` internally and Spark does not bundle
     # the unshaded jar.
-    if [[ $( echo ${INCLUDE_SPARK_PROTOBUF_JAR} | tr '[:upper:]' '[:lower:]' ) != "false" \
+    INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED=$(echo "${INCLUDE_SPARK_PROTOBUF_JAR}" | tr '[:upper:]' '[:lower:]')
+    if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" != "false" \
           && $(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l) -eq 2 ]];
     then
         export INCLUDE_SPARK_PROTOBUF_JAR=true
     else
+        if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" == "true" ]]; then
+            >&2 echo "WARNING: INCLUDE_SPARK_PROTOBUF_JAR=true was requested but spark-protobuf/protobuf-java jars were not found under $TARGET_DIR/dependency; disabling protobuf tests."
+        fi
         export INCLUDE_SPARK_PROTOBUF_JAR=false
         PROTOBUF_JARS=""
     fi

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -155,7 +155,7 @@ else
         export INCLUDE_SPARK_PROTOBUF_JAR=true
     else
         if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" == "true" ]]; then
-            >&2 echo "WARNING: INCLUDE_SPARK_PROTOBUF_JAR=true was requested but spark-protobuf/protobuf-java jars were not found under $TARGET_DIR/dependency; disabling protobuf tests."
+            >&2 echo "WARNING: INCLUDE_SPARK_PROTOBUF_JAR=true was requested but spark-protobuf/protobuf-java jars were not found (searched: $PROTOBUF_JARS); disabling protobuf tests."
         fi
         export INCLUDE_SPARK_PROTOBUF_JAR=false
         PROTOBUF_JARS=""

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -146,10 +146,8 @@ else
         AVRO_JARS=""
     fi
 
-    # Set INCLUDE_SPARK_PROTOBUF_JAR=false to skip protobuf_test.py. Both `spark-protobuf` and
-    # the unshaded `protobuf-java` come from maven-dependency-plugin and must both be present
-    # -- spark-protobuf shades `com.google.protobuf.*` internally and Spark does not bundle
-    # the unshaded jar.
+    # spark-protobuf shades `com.google.protobuf.*` internally and Spark does not bundle the
+    # unshaded jar, so we must ship both jars to the test classpath.
     INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED=$(echo "${INCLUDE_SPARK_PROTOBUF_JAR}" | tr '[:upper:]' '[:lower:]')
     if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" != "false" \
           && $(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l) -eq 2 ]];

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -147,12 +147,16 @@ else
     fi
 
     INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED=$(echo "${INCLUDE_SPARK_PROTOBUF_JAR}" | tr '[:upper:]' '[:lower:]')
+    PROTOBUF_JAR_COUNT=$(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l)
     if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" != "false" \
-          && $(readlink -e $PROTOBUF_JARS 2>/dev/null | wc -l) -eq 1 ]];
+          && "$PROTOBUF_JAR_COUNT" -eq 1 ]];
     then
         export INCLUDE_SPARK_PROTOBUF_JAR=true
     else
-        if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" == "true" ]]; then
+        if [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" != "false" \
+              && "$PROTOBUF_JAR_COUNT" -gt 1 ]]; then
+            >&2 echo "WARNING: Multiple spark-protobuf jars were found (matched: $PROTOBUF_JARS); disabling protobuf tests."
+        elif [[ "$INCLUDE_SPARK_PROTOBUF_JAR_REQUESTED" == "true" ]]; then
             >&2 echo "WARNING: INCLUDE_SPARK_PROTOBUF_JAR=true was requested but a spark-protobuf jar was not found (searched: $PROTOBUF_JARS); disabling protobuf tests."
         fi
         export INCLUDE_SPARK_PROTOBUF_JAR=false

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -16,6 +16,8 @@ import math
 import os
 import pytest
 import random
+import shutil
+import tempfile
 import warnings
 
 # TODO redo _spark stuff using fixtures
@@ -599,6 +601,16 @@ def spark_tmp_path(request):
     yield ret
     if not debug:
         fs.delete(path)
+
+# Driver-local counterpart to spark_tmp_path; spark_tmp_path lives in the
+# default Hadoop FS, which is not local on distributed setups.
+@pytest.fixture
+def local_tmp_path(request):
+    debug = request.config.getoption('debug_tmp_path')
+    ret = tempfile.mkdtemp(prefix='pyspark_tests_')
+    yield ret
+    if not debug:
+        shutil.rmtree(ret, ignore_errors=True)
 
 class TmpTableFactory:
   def __init__(self, base_id):

--- a/integration_tests/src/main/python/protobuf_test.py
+++ b/integration_tests/src/main/python/protobuf_test.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import os
+
+import pytest
+
+from asserts import assert_gpu_fallback_collect
+from marks import allow_non_gpu
+from spark_session import is_before_spark_340, with_cpu_session
+import pyspark.sql.functions as f
+
+if os.environ.get('INCLUDE_SPARK_PROTOBUF_JAR', 'true').lower() == 'false':
+    pytestmark = pytest.mark.skip(reason="INCLUDE_SPARK_PROTOBUF_JAR is disabled")
+else:
+    pytestmark = pytest.mark.skipif(
+        is_before_spark_340(), reason="from_protobuf is Spark 3.4.0+")
+
+
+def _try_import_from_protobuf():
+    try:
+        from pyspark.sql.protobuf.functions import from_protobuf
+        return from_protobuf
+    except Exception:
+        return None
+
+
+@pytest.fixture(scope="module")
+def from_protobuf_fn():
+    fn = _try_import_from_protobuf()
+    if fn is None:
+        pytest.skip("from_protobuf not available")
+    return fn
+
+
+def _encode_varint(value):
+    out = bytearray()
+    value &= 0xFFFFFFFFFFFFFFFF
+    while True:
+        bits = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(bits | 0x80)
+        else:
+            out.append(bits)
+            return bytes(out)
+
+
+def _encode_simple_message(i32_value, s_value):
+    buf = bytearray()
+    buf += _encode_varint((1 << 3) | 0)  # field 1, VARINT
+    buf += _encode_varint(i32_value)
+    s_bytes = s_value.encode("utf-8")
+    buf += _encode_varint((2 << 3) | 2)  # field 2, LENGTH-DELIMITED
+    buf += _encode_varint(len(s_bytes))
+    buf += s_bytes
+    return bytes(buf)
+
+
+def _build_simple_descriptor_bytes(spark):
+    D = spark.sparkContext._jvm.com.google.protobuf.DescriptorProtos
+    i32_field = D.FieldDescriptorProto.newBuilder() \
+        .setName("i32").setNumber(1) \
+        .setLabel(D.FieldDescriptorProto.Label.LABEL_OPTIONAL) \
+        .setType(D.FieldDescriptorProto.Type.TYPE_INT32).build()
+    s_field = D.FieldDescriptorProto.newBuilder() \
+        .setName("s").setNumber(2) \
+        .setLabel(D.FieldDescriptorProto.Label.LABEL_OPTIONAL) \
+        .setType(D.FieldDescriptorProto.Type.TYPE_STRING).build()
+    msg = D.DescriptorProto.newBuilder() \
+        .setName("Simple").addField(i32_field).addField(s_field).build()
+    file_builder = D.FileDescriptorProto.newBuilder() \
+        .setName("simple.proto").setPackage("test").addMessageType(msg) \
+        .setSyntax("proto2")
+    fds = D.FileDescriptorSet.newBuilder().addFile(file_builder.build()).build()
+    return bytes(fds.toByteArray())
+
+
+def _write_bytes_to_hadoop_path(spark, path_str, data_bytes):
+    sc = spark.sparkContext
+    config = sc._jsc.hadoopConfiguration()
+    jpath = sc._jvm.org.apache.hadoop.fs.Path(path_str)
+    fs = sc._jvm.org.apache.hadoop.fs.FileSystem.get(config)
+    out = fs.create(jpath, True)
+    try:
+        out.write(bytearray(data_bytes))
+    finally:
+        out.close()
+
+
+def _setup_simple_desc(spark_tmp_path):
+    desc_path = spark_tmp_path + "/simple.desc"
+    desc_bytes = with_cpu_session(_build_simple_descriptor_bytes)
+    with_cpu_session(
+        lambda spark: _write_bytes_to_hadoop_path(spark, desc_path, desc_bytes))
+    return desc_path, desc_bytes
+
+
+_smoke_rows = [(1, "a"), (-2, "bb"), (0, ""), (12345, "hello")]
+
+
+def _make_smoke_df(spark):
+    encoded = [(_encode_simple_message(i, s),) for (i, s) in _smoke_rows]
+    return spark.createDataFrame(encoded, ["bin"])
+
+
+@allow_non_gpu("ProjectExec", "ProtobufDataToCatalyst")
+def test_from_protobuf_smoke_path_api(spark_tmp_path, from_protobuf_fn):
+    desc_path, _ = _setup_simple_desc(spark_tmp_path)
+
+    def run(spark):
+        return _make_smoke_df(spark).select(
+            from_protobuf_fn(f.col("bin"), "test.Simple", desc_path).alias("d"))
+
+    assert_gpu_fallback_collect(run, "ProtobufDataToCatalyst")
+
+
+@allow_non_gpu("ProjectExec", "ProtobufDataToCatalyst")
+def test_from_protobuf_smoke_binary_descriptor_api(spark_tmp_path, from_protobuf_fn):
+    if "binaryDescriptorSet" not in inspect.signature(from_protobuf_fn).parameters:
+        pytest.skip("binaryDescriptorSet kwarg is Spark 3.5+ only")
+    _, desc_bytes = _setup_simple_desc(spark_tmp_path)
+
+    def run(spark):
+        return _make_smoke_df(spark).select(
+            from_protobuf_fn(f.col("bin"), "test.Simple",
+                             binaryDescriptorSet=bytearray(desc_bytes)).alias("d"))
+
+    assert_gpu_fallback_collect(run, "ProtobufDataToCatalyst")

--- a/integration_tests/src/main/python/protobuf_test.py
+++ b/integration_tests/src/main/python/protobuf_test.py
@@ -88,23 +88,16 @@ def _build_simple_descriptor_bytes(spark):
     return bytes(fds.toByteArray())
 
 
-def _write_bytes_to_hadoop_path(spark, path_str, data_bytes):
-    sc = spark.sparkContext
-    config = sc._jsc.hadoopConfiguration()
-    jpath = sc._jvm.org.apache.hadoop.fs.Path(path_str)
-    fs = sc._jvm.org.apache.hadoop.fs.FileSystem.get(config)
-    out = fs.create(jpath, True)
-    try:
-        out.write(bytearray(data_bytes))
-    finally:
-        out.close()
-
-
-def _setup_simple_desc(spark_tmp_path):
+@pytest.fixture
+def simple_desc(spark_tmp_path):
+    # spark-protobuf reads descFilePath with `new File(...)` + FileUtils
+    # (driver-local), not via Hadoop FileSystem -- write the descriptor with
+    # plain Python `open` like the other integration tests that share this
+    # assumption about `spark_tmp_path` (e.g. json_fuzz_test, delta_lake_test).
     desc_path = spark_tmp_path + "/simple.desc"
     desc_bytes = with_cpu_session(_build_simple_descriptor_bytes)
-    with_cpu_session(
-        lambda spark: _write_bytes_to_hadoop_path(spark, desc_path, desc_bytes))
+    with open(desc_path, "wb") as fp:
+        fp.write(desc_bytes)
     return desc_path, desc_bytes
 
 
@@ -117,8 +110,8 @@ def _make_smoke_df(spark):
 
 
 @allow_non_gpu("ProjectExec", "ProtobufDataToCatalyst")
-def test_from_protobuf_smoke_path_api(spark_tmp_path, from_protobuf_fn):
-    desc_path, _ = _setup_simple_desc(spark_tmp_path)
+def test_from_protobuf_smoke_path_api(simple_desc, from_protobuf_fn):
+    desc_path, _ = simple_desc
 
     def run(spark):
         return _make_smoke_df(spark).select(
@@ -128,10 +121,10 @@ def test_from_protobuf_smoke_path_api(spark_tmp_path, from_protobuf_fn):
 
 
 @allow_non_gpu("ProjectExec", "ProtobufDataToCatalyst")
-def test_from_protobuf_smoke_binary_descriptor_api(spark_tmp_path, from_protobuf_fn):
+def test_from_protobuf_smoke_binary_descriptor_api(simple_desc, from_protobuf_fn):
     if "binaryDescriptorSet" not in inspect.signature(from_protobuf_fn).parameters:
         pytest.skip("binaryDescriptorSet kwarg is Spark 3.5+ only")
-    _, desc_bytes = _setup_simple_desc(spark_tmp_path)
+    _, desc_bytes = simple_desc
 
     def run(spark):
         return _make_smoke_df(spark).select(

--- a/integration_tests/src/main/python/protobuf_test.py
+++ b/integration_tests/src/main/python/protobuf_test.py
@@ -90,10 +90,7 @@ def _build_simple_descriptor_bytes(spark):
 
 @pytest.fixture
 def simple_desc(spark_tmp_path):
-    # spark-protobuf reads descFilePath with `new File(...)` + FileUtils
-    # (driver-local), not via Hadoop FileSystem -- write the descriptor with
-    # plain Python `open` like the other integration tests that share this
-    # assumption about `spark_tmp_path` (e.g. json_fuzz_test, delta_lake_test).
+    # spark-protobuf reads descFilePath via `new File(...)`, not Hadoop FileSystem.
     desc_path = spark_tmp_path + "/simple.desc"
     desc_bytes = with_cpu_session(_build_simple_descriptor_bytes)
     with open(desc_path, "wb") as fp:

--- a/integration_tests/src/main/python/protobuf_test.py
+++ b/integration_tests/src/main/python/protobuf_test.py
@@ -89,8 +89,9 @@ def _build_simple_descriptor_bytes(spark):
 
 
 @pytest.fixture
-def simple_desc(spark_tmp_path):
-    desc_path = spark_tmp_path + "/simple.desc"
+def simple_desc(local_tmp_path):
+    # from_protobuf reads descFilePath via java.io.File on the driver.
+    desc_path = local_tmp_path + "/simple.desc"
     desc_bytes = with_cpu_session(_build_simple_descriptor_bytes)
     with open(desc_path, "wb") as fp:
         fp.write(desc_bytes)

--- a/integration_tests/src/main/python/protobuf_test.py
+++ b/integration_tests/src/main/python/protobuf_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from asserts import assert_gpu_fallback_collect
 from marks import allow_non_gpu
-from spark_session import is_before_spark_340, with_cpu_session
+from spark_session import is_before_spark_340
 import pyspark.sql.functions as f
 
 if os.environ.get('INCLUDE_SPARK_PROTOBUF_JAR', 'true').lower() == 'false':
@@ -69,33 +69,19 @@ def _encode_simple_message(i32_value, s_value):
     return bytes(buf)
 
 
-def _build_simple_descriptor_bytes(spark):
-    D = spark.sparkContext._jvm.com.google.protobuf.DescriptorProtos
-    i32_field = D.FieldDescriptorProto.newBuilder() \
-        .setName("i32").setNumber(1) \
-        .setLabel(D.FieldDescriptorProto.Label.LABEL_OPTIONAL) \
-        .setType(D.FieldDescriptorProto.Type.TYPE_INT32).build()
-    s_field = D.FieldDescriptorProto.newBuilder() \
-        .setName("s").setNumber(2) \
-        .setLabel(D.FieldDescriptorProto.Label.LABEL_OPTIONAL) \
-        .setType(D.FieldDescriptorProto.Type.TYPE_STRING).build()
-    msg = D.DescriptorProto.newBuilder() \
-        .setName("Simple").addField(i32_field).addField(s_field).build()
-    file_builder = D.FileDescriptorProto.newBuilder() \
-        .setName("simple.proto").setPackage("test").addMessageType(msg) \
-        .setSyntax("proto2")
-    fds = D.FileDescriptorSet.newBuilder().addFile(file_builder.build()).build()
-    return bytes(fds.toByteArray())
+# Avoid depending on whichever unshaded protobuf runtime the Spark driver provides.
+_simple_desc_bytes = bytes.fromhex(
+    "0a360a0c73696d706c652e70726f746f12047465737422200a0653696d706c65"
+    "120b0a0369333218012001280512090a0173180220012809")
 
 
 @pytest.fixture
 def simple_desc(local_tmp_path):
     # from_protobuf reads descFilePath via java.io.File on the driver.
     desc_path = local_tmp_path + "/simple.desc"
-    desc_bytes = with_cpu_session(_build_simple_descriptor_bytes)
     with open(desc_path, "wb") as fp:
-        fp.write(desc_bytes)
-    return desc_path, desc_bytes
+        fp.write(_simple_desc_bytes)
+    return desc_path, _simple_desc_bytes
 
 
 _smoke_rows = [(1, "a"), (-2, "bb"), (0, ""), (12345, "hello")]

--- a/integration_tests/src/main/python/protobuf_test.py
+++ b/integration_tests/src/main/python/protobuf_test.py
@@ -90,7 +90,6 @@ def _build_simple_descriptor_bytes(spark):
 
 @pytest.fixture
 def simple_desc(spark_tmp_path):
-    # spark-protobuf reads descFilePath via `new File(...)`, not Hadoop FileSystem.
     desc_path = spark_tmp_path + "/simple.desc"
     desc_bytes = with_cpu_session(_build_simple_descriptor_bytes)
     with open(desc_path, "wb") as fp:

--- a/pom.xml
+++ b/pom.xml
@@ -811,9 +811,7 @@
         <rapids.secondaryCacheDir>${spark.rapids.project.basedir}/target/${spark.version.classifier}/.sbt/1.0/zinc/org.scala-sbt</rapids.secondaryCacheDir>
         <allowConventionalDistJar>false</allowConventionalDistJar>
         <buildver>330</buildver>
-        <!-- Default to copying spark-protobuf and protobuf-java into target/dependency. The
-             release33x profiles override this to `true` because spark-protobuf is a Spark
-             3.4.0+ module and the artifact does not exist for Spark 3.3.x. -->
+        <!-- spark-protobuf is a Spark 3.4.0+ module; release33x profiles override to `true`. -->
         <spark.protobuf.skipCopy>false</spark.protobuf.skipCopy>
         <maven.compiler.source>1.8</maven.compiler.source>
         <java.major.version>8</java.major.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -118,6 +119,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -142,6 +144,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -166,6 +169,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -190,6 +194,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -806,6 +811,10 @@
         <rapids.secondaryCacheDir>${spark.rapids.project.basedir}/target/${spark.version.classifier}/.sbt/1.0/zinc/org.scala-sbt</rapids.secondaryCacheDir>
         <allowConventionalDistJar>false</allowConventionalDistJar>
         <buildver>330</buildver>
+        <!-- Default to copying spark-protobuf and protobuf-java into target/dependency. The
+             release33x profiles override this to `true` because spark-protobuf is a Spark
+             3.4.0+ module and the artifact does not exist for Spark 3.3.x. -->
+        <spark.protobuf.skipCopy>false</spark.protobuf.skipCopy>
         <maven.compiler.source>1.8</maven.compiler.source>
         <java.major.version>8</java.major.version>
         <scala.compiler.release>${java.major.version}</scala.compiler.release>

--- a/scala2.13/integration_tests/pom.xml
+++ b/scala2.13/integration_tests/pom.xml
@@ -133,7 +133,6 @@
                                         <include>parquet-hadoop*.jar</include>
                                         <include>spark-avro*.jar</include>
                                         <include>spark-protobuf*.jar</include>
-                                        <include>protobuf-java-*.jar</include>
                                     </includes>
                                 </filesets>
                             </filesets>
@@ -168,8 +167,6 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!-- spark-protobuf shades `com.google.protobuf` internally, so the
-                         unshaded jar is shipped separately for the tests to use. -->
                     <execution>
                         <id>copy-spark-protobuf</id>
                         <phase>package</phase>
@@ -184,11 +181,6 @@
                                     <groupId>org.apache.spark</groupId>
                                     <artifactId>spark-protobuf_${scala.binary.version}</artifactId>
                                     <version>${spark.version}</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.google.protobuf</groupId>
-                                    <artifactId>protobuf-java</artifactId>
-                                    <version>3.25.5</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/scala2.13/integration_tests/pom.xml
+++ b/scala2.13/integration_tests/pom.xml
@@ -132,6 +132,8 @@
                                     <includes>
                                         <include>parquet-hadoop*.jar</include>
                                         <include>spark-avro*.jar</include>
+                                        <include>spark-protobuf*.jar</include>
+                                        <include>protobuf-java-*.jar</include>
                                     </includes>
                                 </filesets>
                             </filesets>
@@ -162,6 +164,36 @@
                                     <artifactId>parquet-hadoop</artifactId>
                                     <version>${parquet.hadoop.version}</version>
                                     <classifier>tests</classifier>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!--
+                        spark-protobuf is a Spark 3.4.0+ module, and spark-protobuf shades its
+                        own `com.google.protobuf` into `org.sparkproject.spark_protobuf.protobuf`
+                        so we ship an unshaded protobuf-java alongside it for the integration
+                        tests. release33x profiles set `spark.protobuf.skipCopy=true` because
+                        spark-protobuf does not exist for Spark 3.3.x.
+                    -->
+                    <execution>
+                        <id>copy-spark-protobuf</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${spark.protobuf.skipCopy}</skip>
+                            <useBaseVersion>true</useBaseVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.spark</groupId>
+                                    <artifactId>spark-protobuf_${scala.binary.version}</artifactId>
+                                    <version>${spark.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.google.protobuf</groupId>
+                                    <artifactId>protobuf-java</artifactId>
+                                    <version>3.25.5</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/scala2.13/integration_tests/pom.xml
+++ b/scala2.13/integration_tests/pom.xml
@@ -168,13 +168,8 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!--
-                        spark-protobuf is a Spark 3.4.0+ module, and spark-protobuf shades its
-                        own `com.google.protobuf` into `org.sparkproject.spark_protobuf.protobuf`
-                        so we ship an unshaded protobuf-java alongside it for the integration
-                        tests. release33x profiles set `spark.protobuf.skipCopy=true` because
-                        spark-protobuf does not exist for Spark 3.3.x.
-                    -->
+                    <!-- spark-protobuf shades `com.google.protobuf` internally, so the
+                         unshaded jar is shipped separately for the tests to use. -->
                     <execution>
                         <id>copy-spark-protobuf</id>
                         <phase>package</phase>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -811,9 +811,7 @@
         <rapids.secondaryCacheDir>${spark.rapids.project.basedir}/target/${spark.version.classifier}/.sbt/1.0/zinc/org.scala-sbt</rapids.secondaryCacheDir>
         <allowConventionalDistJar>false</allowConventionalDistJar>
         <buildver>330</buildver>
-        <!-- Default to copying spark-protobuf and protobuf-java into target/dependency. The
-             release33x profiles override this to `true` because spark-protobuf is a Spark
-             3.4.0+ module and the artifact does not exist for Spark 3.3.x. -->
+        <!-- spark-protobuf is a Spark 3.4.0+ module; release33x profiles override to `true`. -->
         <spark.protobuf.skipCopy>false</spark.protobuf.skipCopy>
         <maven.compiler.source>1.8</maven.compiler.source>
         <java.major.version>8</java.major.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -94,6 +94,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -118,6 +119,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -142,6 +144,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -166,6 +169,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -190,6 +194,7 @@
                 <rapids.delta.artifactId1>rapids-4-spark-delta-21x</rapids.delta.artifactId1>
                 <rapids.delta.artifactId2>rapids-4-spark-delta-22x</rapids.delta.artifactId2>
                 <rapids.delta.artifactId3>rapids-4-spark-delta-23x</rapids.delta.artifactId3>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
             </properties>
             <modules>
                 <module>delta-lake/delta-21x</module>
@@ -806,6 +811,10 @@
         <rapids.secondaryCacheDir>${spark.rapids.project.basedir}/target/${spark.version.classifier}/.sbt/1.0/zinc/org.scala-sbt</rapids.secondaryCacheDir>
         <allowConventionalDistJar>false</allowConventionalDistJar>
         <buildver>330</buildver>
+        <!-- Default to copying spark-protobuf and protobuf-java into target/dependency. The
+             release33x profiles override this to `true` because spark-protobuf is a Spark
+             3.4.0+ module and the artifact does not exist for Spark 3.3.x. -->
+        <spark.protobuf.skipCopy>false</spark.protobuf.skipCopy>
         <maven.compiler.source>1.8</maven.compiler.source>
         <java.major.version>8</java.major.version>
         <scala.compiler.release>${java.major.version}</scala.compiler.release>


### PR DESCRIPTION
Part of #14069. First slice carved out of #14354 following the plugin-side split plan in the issue.

### Description

#### Problem

`from_protobuf` is provided by Spark's optional `spark-protobuf` module, which is not normally present on the integration-test classpath. Subsequent GPU-support PRs need a stable CPU fallback baseline without introducing an unshaded protobuf runtime dependency.

#### Changes

- Copy `spark-protobuf_${scala.binary.version}` into the integration-test dependencies for Spark 3.4+, for both Scala 2.12 and 2.13 builds. Spark 3.3 profiles skip this artifact.
- Add `INCLUDE_SPARK_PROTOBUF_JAR` handling to `run_pyspark_from_build.sh`. Protobuf tests are enabled by default when exactly one matching jar is found:
  - one jar: add it to `ALL_JARS`;
  - no jar: disable the tests, warning when inclusion was explicitly requested;
  - multiple jars: warn and disable the tests to avoid classpath-dependent API selection;
  - `INCLUDE_SPARK_PROTOBUF_JAR=false`: disable the tests without a warning.
- Add a driver-local `local_tmp_path` fixture. The path-based protobuf API reads its descriptor with `java.io.File`, so a Hadoop-backed temporary path is not suitable on distributed filesystems.
- Add two CPU-fallback smoke tests:
  - `test_from_protobuf_smoke_path_api` for Spark 3.4+;
  - `test_from_protobuf_smoke_binary_descriptor_api` for Spark 3.5+, skipped when the PySpark API does not expose `binaryDescriptorSet`.

The tests use static `FileDescriptorSet` bytes and hand-encoded messages. This avoids depending on whichever unshaded protobuf runtime the Spark driver provides. The path-based test writes those bytes to `local_tmp_path`; the Spark 3.5+ test passes the same bytes directly.

No GPU implementation is added. Both tests use `assert_gpu_fallback_collect("ProtobufDataToCatalyst")` to compare CPU and GPU-mode results while verifying CPU fallback.

#### Testing

- Spark 3.5.2 targeted integration run:
  - `test_from_protobuf_smoke_path_api`
  - `test_from_protobuf_smoke_binary_descriptor_api`
  - Result: `2 passed`
- Spark 3.4.1 standalone compatibility probe: the path-based API successfully read the static descriptor; the binary descriptor API is not available in Spark 3.4.
- Multiple matching `spark-protobuf` jars: warning emitted, jars excluded, and protobuf tests skipped.
- `bash -n`, `shellcheck -S error`, and `git diff --check` passed.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
