### PR TITLE
Add GPU support for find_in_set

### DIFF
--- a/docs/additional-functionality/advanced_configs.md
+++ b/docs/additional-functionality/advanced_configs.md
@@ -272,6 +272,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.Exp"></a>spark.rapids.sql.expression.Exp|`exp`|Euler's number e raised to a power|true|None|
 <a name="sql.expression.Explode"></a>spark.rapids.sql.expression.Explode|`explode_outer`, `explode`|Given an input array produces a sequence of rows for each value in the array|true|None|
 <a name="sql.expression.Expm1"></a>spark.rapids.sql.expression.Expm1|`expm1`|Euler's number e raised to a power minus 1|true|None|
+<a name="sql.expression.FindInSet"></a>spark.rapids.sql.expression.FindInSet|`find_in_set`|Find string in comma-delimited string list|true|None|
 <a name="sql.expression.Flatten"></a>spark.rapids.sql.expression.Flatten|`flatten`|Creates a single array from an array of arrays|true|None|
 <a name="sql.expression.Floor"></a>spark.rapids.sql.expression.Floor| |Floor of a number|true|None|
 <a name="sql.expression.FormatNumber"></a>spark.rapids.sql.expression.FormatNumber|`format_number`|Formats the number x like '#,###,###.##', rounded to d decimal places.|true|None|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -7941,6 +7941,80 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<td rowSpan="3">FindInSet</td>
+<td rowSpan="3">`find_in_set`</td>
+<td rowSpan="3">Find string in comma-delimited string list</td>
+<td rowSpan="3">None</td>
+<td rowSpan="3">project</td>
+<td>str</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>strArray</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
 <td rowSpan="2">Flatten</td>
 <td rowSpan="2">`flatten`</td>
 <td rowSpan="2">Creates a single array from an array of arrays</td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -8066,6 +8066,34 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+<th>DAYTIME</th>
+<th>YEARMONTH</th>
+</tr>
+<tr>
 <td rowSpan="2">Floor</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Floor of a number</td>
@@ -8189,34 +8217,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-<th>DAYTIME</th>
-<th>YEARMONTH</th>
 </tr>
 <tr>
 <td rowSpan="3">FromUTCTimestamp</td>
@@ -8492,6 +8492,34 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+<th>DAYTIME</th>
+<th>YEARMONTH</th>
+</tr>
+<tr>
 <td rowSpan="3">GetJsonObject</td>
 <td rowSpan="3">`get_json_object`</td>
 <td rowSpan="3">Extracts a json object from path</td>
@@ -8638,34 +8666,6 @@ are limited.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-<th>DAYTIME</th>
-<th>YEARMONTH</th>
 </tr>
 <tr>
 <td rowSpan="2">GetStructField</td>
@@ -8937,6 +8937,34 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+<th>DAYTIME</th>
+<th>YEARMONTH</th>
+</tr>
+<tr>
 <td rowSpan="6">GreaterThanOrEqual</td>
 <td rowSpan="6">`>=`</td>
 <td rowSpan="6">>= operator</td>
@@ -9079,34 +9107,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-<th>DAYTIME</th>
-<th>YEARMONTH</th>
 </tr>
 <tr>
 <td rowSpan="2">Greatest</td>
@@ -9387,6 +9387,34 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+<th>DAYTIME</th>
+<th>YEARMONTH</th>
+</tr>
+<tr>
 <td rowSpan="4">If</td>
 <td rowSpan="4">`if`</td>
 <td rowSpan="4">IF expression</td>
@@ -9482,34 +9510,6 @@ are limited.
 <td><b>NS</b></td>
 <td>S</td>
 <td>S</td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-<th>DAYTIME</th>
-<th>YEARMONTH</th>
 </tr>
 <tr>
 <td rowSpan="3">In</td>
@@ -9846,6 +9846,34 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+<th>DAYTIME</th>
+<th>YEARMONTH</th>
+</tr>
+<tr>
 <td rowSpan="2">IsNaN</td>
 <td rowSpan="2">`isnan`</td>
 <td rowSpan="2">Checks if a value is NaN</td>
@@ -9895,34 +9923,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-<th>DAYTIME</th>
-<th>YEARMONTH</th>
 </tr>
 <tr>
 <td rowSpan="4">IsNotNull</td>
@@ -10246,6 +10246,34 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+<th>DAYTIME</th>
+<th>YEARMONTH</th>
+</tr>
+<tr>
 <td rowSpan="2">KnownFloatingPointNormalized</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Tag to prevent redundant normalization</td>
@@ -10295,34 +10323,6 @@ are limited.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-<th>DAYTIME</th>
-<th>YEARMONTH</th>
 </tr>
 <tr>
 <td rowSpan="2">KnownNotNull</td>

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -340,6 +340,8 @@ def test_find_in_set():
         ('missing', 'abc,b,ab,c,def'),
         ('a,b', 'abc,b,ab,c,def'),
         ('', ',abc,,def,'),
+        ('a', 'b,a,a'),
+        ('a', 'x'),
         (None, 'abc,b,ab,c,def'),
         ('ab', None),
         (None, None),
@@ -352,6 +354,8 @@ def test_find_in_set():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.createDataFrame(data, schema).selectExpr(
             'find_in_set("ab", set)',
+            'find_in_set("a", set)',
+            'find_in_set("a,b", set)',
             'find_in_set(word, set)',
             'find_in_set(word, "abc,b,ab,c,def")',
             'find_in_set(word, ",abc,,def,")',

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -332,6 +332,32 @@ def test_unsupported_fallback_instr():
     assert_gpu_did_fallback('instr("a", a)')
 
 
+def test_find_in_set():
+    data = [
+        ('ab', 'abc,b,ab,c,def'),
+        ('abc', 'abc,b,ab,c,def'),
+        ('def', 'abc,b,ab,c,def'),
+        ('missing', 'abc,b,ab,c,def'),
+        ('a,b', 'abc,b,ab,c,def'),
+        ('', ',abc,,def,'),
+        (None, 'abc,b,ab,c,def'),
+        ('ab', None),
+        (None, None),
+        ('é', 'a,é,中'),
+        ('中', 'a,é,中'),
+    ]
+    schema = StructType([
+        StructField('word', StringType()),
+        StructField('set', StringType())])
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame(data, schema).selectExpr(
+            'find_in_set("ab", set)',
+            'find_in_set(word, set)',
+            'find_in_set(word, "abc,b,ab,c,def")',
+            'find_in_set(CAST(NULL AS STRING), set)',
+            'find_in_set(word, CAST(NULL AS STRING))'))
+
+
 def test_contains():
     gen = mk_str_gen('.{0,3}Z?_Z?.{0,3}A?.{0,3}')
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -354,6 +354,10 @@ def test_find_in_set():
             'find_in_set("ab", set)',
             'find_in_set(word, set)',
             'find_in_set(word, "abc,b,ab,c,def")',
+            'find_in_set(word, ",abc,,def,")',
+            'find_in_set("a", "b,a,a")',
+            'find_in_set("", "")',
+            'find_in_set("a,b", "a,b")',
             'find_in_set(CAST(NULL AS STRING), set)',
             'find_in_set(word, CAST(NULL AS STRING))'))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3244,6 +3244,17 @@ object GpuOverrides extends Logging {
             substr: Expression): GpuExpression =
           GpuStringInstr(str, substr)
       }),
+    expr[FindInSet](
+      "Find string in comma-delimited string list",
+      ExprChecks.binaryProject(TypeSig.INT, TypeSig.INT,
+        ("str", TypeSig.STRING, TypeSig.STRING),
+        ("strArray", TypeSig.STRING, TypeSig.STRING)),
+      (in, conf, p, r) => new BinaryExprMeta[FindInSet](in, conf, p, r) {
+        override def convertToGpu(
+            str: Expression,
+            strArray: Expression): GpuExpression =
+          GpuFindInSet(str, strArray)
+      }),
     expr[Substring](
       "Substring operator",
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING + TypeSig.BINARY,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
+import java.lang.reflect.InvocationTargetException
 import java.nio.charset.Charset
 import java.text.DecimalFormatSymbols
 import java.util.{EnumSet, Locale, Optional}
@@ -2205,6 +2206,25 @@ case class GpuStringInstr(str: Expression, substr: Expression)
   }
 }
 
+object GpuFindInSet {
+  private lazy val nativeFindInSetMethod = try {
+    Some(Class.forName("com.nvidia.spark.rapids.jni.StringUtils").getMethod(
+      "findInSet", classOf[ColumnView], classOf[String]))
+  } catch {
+    case _: ClassNotFoundException | _: NoSuchMethodException => None
+  }
+
+  private def nativeFindInSet(word: String, set: ColumnView): Option[ColumnVector] = {
+    nativeFindInSetMethod.map { method =>
+      try {
+        method.invoke(null, set, word).asInstanceOf[ColumnVector]
+      } catch {
+        case e: InvocationTargetException => throw e.getCause
+      }
+    }
+  }
+}
+
 case class GpuFindInSet(left: Expression, right: Expression)
   extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
   override def dataType: DataType = IntegerType
@@ -2407,8 +2427,12 @@ case class GpuFindInSet(left: Expression, right: Expression)
       if (word.indexOf(',') >= 0) {
         zeroOrNullFromSetNulls(rhs)
       } else {
-        findInRepeatedSets(word, rhs).getOrElse {
-          findInSplitSet(rhs, lhs.getBase)
+        GpuFindInSet.nativeFindInSet(word, rhs.getBase).getOrElse {
+          // Fall back until Spark RAPIDS depends on a JNI build with native find_in_set.
+          // This preserves compatibility with older 26.08.0-SNAPSHOT jars.
+          findInRepeatedSets(word, rhs).getOrElse {
+            findInSplitSet(rhs, lhs.getBase)
+          }
         }
       }
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ast, BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, OutOfBoundsPolicy, PadSide, RegexFlag, RegexProgram, Scalar, Table}
+import ai.rapids.cudf.{ast, BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, NullPolicy, OutOfBoundsPolicy, PadSide, RegexFlag, RegexProgram, Scalar, Table}
 import ai.rapids.cudf.ColumnView.FindOptions
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
@@ -2211,6 +2211,10 @@ case class GpuFindInSet(left: Expression, right: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
   override def prettyName: String = "find_in_set"
 
+  // Avoid copying large high-cardinality set columns to the host. The split/list fallback is
+  // safer once the number of distinct RHS set strings in a batch is no longer small.
+  private val maxDistinctSetsForScalarWord = 4096
+
   private def stringFromScalar(s: GpuScalar): String = s.getValue match {
     case utf8: UTF8String => utf8.toString
     case str: String => str
@@ -2237,6 +2241,38 @@ case class GpuFindInSet(left: Expression, right: Expression)
         i += 1
       }
       0
+    }
+  }
+
+  private def buildPositionColumnForSets(word: String, sets: ColumnView): ColumnVector = {
+    withResource(sets.copyToHost()) { hostSets =>
+      val positions = new Array[java.lang.Integer](hostSets.getRowCount.toInt)
+      var i = 0
+      while (i < positions.length) {
+        if (hostSets.isNull(i.toLong)) {
+          positions(i) = null
+        } else {
+          positions(i) = Integer.valueOf(findInSetOnHost(word, hostSets.getJavaString(i.toLong)))
+        }
+        i += 1
+      }
+      ColumnVector.fromBoxedInts(positions: _*)
+    }
+  }
+
+  private def buildPositionColumnForSingleSet(
+      word: String,
+      sets: ColumnView,
+      numRows: Int): ColumnVector = {
+    withResource(sets.copyToHost()) { hostSets =>
+      if (hostSets.isNull(0)) {
+        nullIntColumn(numRows)
+      } else {
+        val position = findInSetOnHost(word, hostSets.getJavaString(0))
+        withResource(Scalar.fromInt(position)) { positionScalar =>
+          ColumnVector.fromScalar(positionScalar, numRows)
+        }
+      }
     }
   }
 
@@ -2304,6 +2340,42 @@ case class GpuFindInSet(left: Expression, right: Expression)
     }
   }
 
+  private def findInRepeatedSets(word: String, set: GpuColumnVector): Option[ColumnVector] = {
+    val numRows = set.getRowCount.toInt
+    if (numRows == 0) {
+      Some(nullIntColumn(numRows))
+    } else {
+      val distinctSetCount = set.getBase.distinctCount(NullPolicy.INCLUDE)
+      if (distinctSetCount > maxDistinctSetsForScalarWord) {
+        None
+      } else {
+        Some(withResource(new Table(set.getBase)) { setTable =>
+          withResource(setTable.dropDuplicates(
+              Array(0), Table.DuplicateKeepOption.KEEP_ANY, true)) { distinctSetsTable =>
+            if (distinctSetCount == 1) {
+              buildPositionColumnForSingleSet(word, distinctSetsTable.getColumn(0), numRows)
+            } else {
+              withResource(buildPositionColumnForSets(word,
+                  distinctSetsTable.getColumn(0))) { positionCv =>
+                withResource(setTable.leftDistinctJoinGatherMap(
+                    distinctSetsTable, true)) { positionMap =>
+                  withResource(positionMap.toColumnView(0, numRows)) { positionMapView =>
+                    withResource(new Table(positionCv)) { positionTable =>
+                      withResource(positionTable.gather(
+                          positionMapView, OutOfBoundsPolicy.NULLIFY)) { gatheredTable =>
+                        gatheredTable.getColumn(0).incRefCount()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      }
+    }
+  }
+
   private def findInSplitSet(set: GpuColumnVector, word: Scalar): ColumnVector = {
     withResource(set.getBase.stringSplitRecord(",", -1)) { splitSet =>
       withResource(splitSet.listIndexOf(word, FindOptions.FIND_FIRST)) { zeroBasedPos =>
@@ -2335,7 +2407,9 @@ case class GpuFindInSet(left: Expression, right: Expression)
       if (word.indexOf(',') >= 0) {
         zeroOrNullFromSetNulls(rhs)
       } else {
-        findInSplitSet(rhs, lhs.getBase)
+        findInRepeatedSets(word, rhs).getOrElse {
+          findInSplitSet(rhs, lhs.getBase)
+        }
       }
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ast, BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, PadSide, RegexFlag, RegexProgram, Scalar, Table}
+import ai.rapids.cudf.ColumnView.FindOptions
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -2200,6 +2201,51 @@ case class GpuStringInstr(str: Expression, substr: Expression)
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
     withResource(GpuColumnVector.from(lhs, numRows)) { expandedLhs =>
       doColumnar(expandedLhs, rhs)
+    }
+  }
+}
+
+case class GpuFindInSet(left: Expression, right: Expression)
+  extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
+  override def dataType: DataType = IntegerType
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
+  override def prettyName: String = "find_in_set"
+
+  private def findInSplitSet(set: GpuColumnVector, word: Scalar): ColumnVector = {
+    withResource(set.getBase.stringSplitRecord(",", -1)) { splitSet =>
+      withResource(splitSet.listIndexOf(word, FindOptions.FIND_FIRST)) { zeroBasedPos =>
+        withResource(Scalar.fromInt(1)) { one =>
+          zeroBasedPos.add(one)
+        }
+      }
+    }
+  }
+
+  private def findInSplitSet(set: GpuColumnVector, word: ColumnView): ColumnVector = {
+    withResource(set.getBase.stringSplitRecord(",", -1)) { splitSet =>
+      withResource(splitSet.listIndexOf(word, FindOptions.FIND_FIRST)) { zeroBasedPos =>
+        withResource(Scalar.fromInt(1)) { one =>
+          zeroBasedPos.add(one)
+        }
+      }
+    }
+  }
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector =
+    findInSplitSet(rhs, lhs.getBase)
+
+  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector =
+    findInSplitSet(rhs, lhs.getBase)
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
+    withResource(GpuColumnVector.from(rhs, lhs.getRowCount.toInt)) { expandedRhs =>
+      findInSplitSet(expandedRhs, lhs.getBase)
+    }
+  }
+
+  override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
+    withResource(GpuColumnVector.from(rhs, numRows)) { expandedRhs =>
+      findInSplitSet(expandedRhs, lhs.getBase)
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ast, BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, PadSide, RegexFlag, RegexProgram, Scalar, Table}
+import ai.rapids.cudf.{ast, BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, OutOfBoundsPolicy, PadSide, RegexFlag, RegexProgram, Scalar, Table}
 import ai.rapids.cudf.ColumnView.FindOptions
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
@@ -2211,6 +2211,99 @@ case class GpuFindInSet(left: Expression, right: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
   override def prettyName: String = "find_in_set"
 
+  private def stringFromScalar(s: GpuScalar): String = s.getValue match {
+    case utf8: UTF8String => utf8.toString
+    case str: String => str
+    case other =>
+      throw new IllegalArgumentException(s"Unexpected string scalar value: $other")
+  }
+
+  private def nullIntColumn(numRows: Int): ColumnVector = {
+    withResource(Scalar.fromNull(DType.INT32)) { nullScalar =>
+      ColumnVector.fromScalar(nullScalar, numRows)
+    }
+  }
+
+  private def findInSetOnHost(word: String, set: String): Int = {
+    if (word.indexOf(',') >= 0) {
+      0
+    } else {
+      val tokens = set.split(",", -1)
+      var i = 0
+      while (i < tokens.length) {
+        if (tokens(i) == word) {
+          return i + 1
+        }
+        i += 1
+      }
+      0
+    }
+  }
+
+  private def buildDictionaryColumns(set: String): (ColumnVector, ColumnVector) = {
+    val firstPositions = mutable.LinkedHashMap.empty[String, Int]
+    val tokens = set.split(",", -1)
+    var i = 0
+    while (i < tokens.length) {
+      firstPositions.getOrElseUpdate(tokens(i), i + 1)
+      i += 1
+    }
+
+    closeOnExcept(ColumnVector.fromStrings(firstPositions.keys.toArray: _*)) { tokenCv =>
+      closeOnExcept(ColumnVector.fromInts(firstPositions.values.toArray: _*)) { positionCv =>
+        (tokenCv, positionCv)
+      }
+    }
+  }
+
+  private def zeroOrNullFromSetNulls(set: GpuColumnVector): ColumnVector = {
+    withResource(set.getBase.isNull) { setIsNull =>
+      withResource(Scalar.fromNull(DType.INT32)) { nullInt =>
+        withResource(Scalar.fromInt(0)) { zero =>
+          setIsNull.ifElse(nullInt, zero)
+        }
+      }
+    }
+  }
+
+  private def findInLiteralSet(word: GpuColumnVector, set: String): ColumnVector = {
+    val numRows = word.getRowCount.toInt
+    if (numRows == 0) {
+      nullIntColumn(numRows)
+    } else {
+      val (tokenCv, positionCv) = buildDictionaryColumns(set)
+      withResource(tokenCv) { tokenCv =>
+        withResource(positionCv) { positionCv =>
+          withResource(new Table(word.getBase)) { wordTable =>
+            withResource(new Table(tokenCv)) { tokenTable =>
+              withResource(wordTable.leftDistinctJoinGatherMap(tokenTable, false)) { positionMap =>
+                withResource(positionMap.toColumnView(0, numRows)) { positionMapView =>
+                  val nullablePositions = withResource(new Table(positionCv)) { positionTable =>
+                    withResource(positionTable.gather(positionMapView, OutOfBoundsPolicy.NULLIFY)) {
+                      gatheredTable =>
+                        gatheredTable.getColumn(0).incRefCount()
+                    }
+                  }
+                  withResource(nullablePositions) { nullablePositions =>
+                    withResource(Scalar.fromInt(0)) { zero =>
+                      withResource(nullablePositions.replaceNulls(zero)) { zerosForMissing =>
+                        withResource(word.getBase.isNull) { wordIsNull =>
+                          withResource(Scalar.fromNull(DType.INT32)) { nullInt =>
+                            wordIsNull.ifElse(nullInt, zerosForMissing)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   private def findInSplitSet(set: GpuColumnVector, word: Scalar): ColumnVector = {
     withResource(set.getBase.stringSplitRecord(",", -1)) { splitSet =>
       withResource(splitSet.listIndexOf(word, FindOptions.FIND_FIRST)) { zeroBasedPos =>
@@ -2234,18 +2327,35 @@ case class GpuFindInSet(left: Expression, right: Expression)
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector =
     findInSplitSet(rhs, lhs.getBase)
 
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector =
-    findInSplitSet(rhs, lhs.getBase)
+  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+    if (!lhs.isValid) {
+      nullIntColumn(rhs.getRowCount.toInt)
+    } else {
+      val word = stringFromScalar(lhs)
+      if (word.indexOf(',') >= 0) {
+        zeroOrNullFromSetNulls(rhs)
+      } else {
+        findInSplitSet(rhs, lhs.getBase)
+      }
+    }
+  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
-    withResource(GpuColumnVector.from(rhs, lhs.getRowCount.toInt)) { expandedRhs =>
-      findInSplitSet(expandedRhs, lhs.getBase)
+    if (!rhs.isValid) {
+      nullIntColumn(lhs.getRowCount.toInt)
+    } else {
+      findInLiteralSet(lhs, stringFromScalar(rhs))
     }
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
-    withResource(GpuColumnVector.from(rhs, numRows)) { expandedRhs =>
-      findInSplitSet(expandedRhs, lhs.getBase)
+    if (!lhs.isValid || !rhs.isValid) {
+      nullIntColumn(numRows)
+    } else {
+      val result = findInSetOnHost(stringFromScalar(lhs), stringFromScalar(rhs))
+      withResource(Scalar.fromInt(result)) { resultScalar =>
+        ColumnVector.fromScalar(resultScalar, numRows)
+      }
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2254,8 +2254,9 @@ case class GpuFindInSet(left: Expression, right: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
   override def prettyName: String = "find_in_set"
 
-  // Avoid copying large high-cardinality set columns to the host. The native path can handle more
-  // distinct set strings because it keeps the dictionary and gather work on the GPU.
+  // Prefer the direct native scalar-word path because it scans each RHS row once and avoids
+  // dictionary/distinct/gather setup for short set strings. The repeated-set path remains as a
+  // fallback for JNI builds that do not yet expose the direct native path.
   private val maxHostDistinctSetsForScalarWord = 4096
   private val maxNativeDistinctSetsForScalarWord = 65536
 
@@ -2451,13 +2452,13 @@ case class GpuFindInSet(left: Expression, right: Expression)
       if (word.indexOf(',') >= 0) {
         zeroOrNullFromSetNulls(rhs)
       } else {
-        GpuFindInSet.nativeFindInSetRepeated(
-          word, rhs.getBase, maxNativeDistinctSetsForScalarWord).orElse {
-          // Fall back until Spark RAPIDS depends on a JNI build with the repeated-set path.
-          // This preserves compatibility with older 26.08.0-SNAPSHOT jars.
-          if (GpuFindInSet.hasNativeFindInSetRepeated) None else findInRepeatedSets(word, rhs)
-        }.getOrElse {
-          GpuFindInSet.nativeFindInSet(word, rhs.getBase).getOrElse {
+        GpuFindInSet.nativeFindInSet(word, rhs.getBase).getOrElse {
+          GpuFindInSet.nativeFindInSetRepeated(
+            word, rhs.getBase, maxNativeDistinctSetsForScalarWord).orElse {
+            // Preserve compatibility with older 26.08.0-SNAPSHOT JNI jars that do not expose
+            // either native scalar-word path.
+            if (GpuFindInSet.hasNativeFindInSetRepeated) None else findInRepeatedSets(word, rhs)
+          }.getOrElse {
             findInSplitSet(rhs, lhs.getBase)
           }
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2214,10 +2214,33 @@ object GpuFindInSet {
     case _: ClassNotFoundException | _: NoSuchMethodException => None
   }
 
+  private lazy val nativeFindInSetRepeatedMethod = try {
+    Some(Class.forName("com.nvidia.spark.rapids.jni.StringUtils").getMethod(
+      "findInSetRepeated", classOf[ColumnView], classOf[String], java.lang.Integer.TYPE))
+  } catch {
+    case _: ClassNotFoundException | _: NoSuchMethodException => None
+  }
+
   private def nativeFindInSet(word: String, set: ColumnView): Option[ColumnVector] = {
     nativeFindInSetMethod.map { method =>
       try {
         method.invoke(null, set, word).asInstanceOf[ColumnVector]
+      } catch {
+        case e: InvocationTargetException => throw e.getCause
+      }
+    }
+  }
+
+  def hasNativeFindInSetRepeated: Boolean = nativeFindInSetRepeatedMethod.isDefined
+
+  private def nativeFindInSetRepeated(
+      word: String,
+      set: ColumnView,
+      maxDistinctSets: Int): Option[ColumnVector] = {
+    nativeFindInSetRepeatedMethod.flatMap { method =>
+      try {
+        Option(method.invoke(null, set, word, Integer.valueOf(maxDistinctSets))
+          .asInstanceOf[ColumnVector])
       } catch {
         case e: InvocationTargetException => throw e.getCause
       }
@@ -2231,9 +2254,10 @@ case class GpuFindInSet(left: Expression, right: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
   override def prettyName: String = "find_in_set"
 
-  // Avoid copying large high-cardinality set columns to the host. The split/list fallback is
-  // safer once the number of distinct RHS set strings in a batch is no longer small.
-  private val maxDistinctSetsForScalarWord = 4096
+  // Avoid copying large high-cardinality set columns to the host. The native path can handle more
+  // distinct set strings because it keeps the dictionary and gather work on the GPU.
+  private val maxHostDistinctSetsForScalarWord = 4096
+  private val maxNativeDistinctSetsForScalarWord = 65536
 
   private def stringFromScalar(s: GpuScalar): String = s.getValue match {
     case utf8: UTF8String => utf8.toString
@@ -2366,7 +2390,7 @@ case class GpuFindInSet(left: Expression, right: Expression)
       Some(nullIntColumn(numRows))
     } else {
       val distinctSetCount = set.getBase.distinctCount(NullPolicy.INCLUDE)
-      if (distinctSetCount > maxDistinctSetsForScalarWord) {
+      if (distinctSetCount > maxHostDistinctSetsForScalarWord) {
         None
       } else {
         Some(withResource(new Table(set.getBase)) { setTable =>
@@ -2427,10 +2451,13 @@ case class GpuFindInSet(left: Expression, right: Expression)
       if (word.indexOf(',') >= 0) {
         zeroOrNullFromSetNulls(rhs)
       } else {
-        GpuFindInSet.nativeFindInSet(word, rhs.getBase).getOrElse {
-          // Fall back until Spark RAPIDS depends on a JNI build with native find_in_set.
+        GpuFindInSet.nativeFindInSetRepeated(
+          word, rhs.getBase, maxNativeDistinctSetsForScalarWord).orElse {
+          // Fall back until Spark RAPIDS depends on a JNI build with the repeated-set path.
           // This preserves compatibility with older 26.08.0-SNAPSHOT jars.
-          findInRepeatedSets(word, rhs).getOrElse {
+          if (GpuFindInSet.hasNativeFindInSetRepeated) None else findInRepeatedSets(word, rhs)
+        }.getOrElse {
+          GpuFindInSet.nativeFindInSet(word, rhs.getBase).getOrElse {
             findInSplitSet(rhs, lhs.getBase)
           }
         }

--- a/tools/generated_files/320/operatorsScore.csv
+++ b/tools/generated_files/320/operatorsScore.csv
@@ -122,6 +122,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/320/supportedExprs.csv
+++ b/tools/generated_files/320/supportedExprs.csv
@@ -224,6 +224,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S,`floor`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/321/operatorsScore.csv
+++ b/tools/generated_files/321/operatorsScore.csv
@@ -122,6 +122,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/321/supportedExprs.csv
+++ b/tools/generated_files/321/supportedExprs.csv
@@ -224,6 +224,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S,`floor`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/321cdh/operatorsScore.csv
+++ b/tools/generated_files/321cdh/operatorsScore.csv
@@ -122,6 +122,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/321cdh/supportedExprs.csv
+++ b/tools/generated_files/321cdh/supportedExprs.csv
@@ -224,6 +224,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S,`floor`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/322/operatorsScore.csv
+++ b/tools/generated_files/322/operatorsScore.csv
@@ -122,6 +122,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/322/supportedExprs.csv
+++ b/tools/generated_files/322/supportedExprs.csv
@@ -224,6 +224,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S,`floor`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/323/operatorsScore.csv
+++ b/tools/generated_files/323/operatorsScore.csv
@@ -122,6 +122,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/323/supportedExprs.csv
+++ b/tools/generated_files/323/supportedExprs.csv
@@ -224,6 +224,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S,`floor`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/324/operatorsScore.csv
+++ b/tools/generated_files/324/operatorsScore.csv
@@ -122,6 +122,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/324/supportedExprs.csv
+++ b/tools/generated_files/324/supportedExprs.csv
@@ -224,6 +224,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S,`floor`,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/330/operatorsScore.csv
+++ b/tools/generated_files/330/operatorsScore.csv
@@ -128,6 +128,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/330/supportedExprs.csv
+++ b/tools/generated_files/330/supportedExprs.csv
@@ -238,6 +238,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/330cdh/operatorsScore.csv
+++ b/tools/generated_files/330cdh/operatorsScore.csv
@@ -127,6 +127,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/330cdh/supportedExprs.csv
+++ b/tools/generated_files/330cdh/supportedExprs.csv
@@ -233,6 +233,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/331/operatorsScore.csv
+++ b/tools/generated_files/331/operatorsScore.csv
@@ -129,6 +129,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/331/supportedExprs.csv
+++ b/tools/generated_files/331/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/332/operatorsScore.csv
+++ b/tools/generated_files/332/operatorsScore.csv
@@ -129,6 +129,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/332/supportedExprs.csv
+++ b/tools/generated_files/332/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/332cdh/operatorsScore.csv
+++ b/tools/generated_files/332cdh/operatorsScore.csv
@@ -128,6 +128,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/332cdh/supportedExprs.csv
+++ b/tools/generated_files/332cdh/supportedExprs.csv
@@ -235,6 +235,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/333/operatorsScore.csv
+++ b/tools/generated_files/333/operatorsScore.csv
@@ -129,6 +129,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/333/supportedExprs.csv
+++ b/tools/generated_files/333/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/334/operatorsScore.csv
+++ b/tools/generated_files/334/operatorsScore.csv
@@ -129,6 +129,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/334/supportedExprs.csv
+++ b/tools/generated_files/334/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/340/operatorsScore.csv
+++ b/tools/generated_files/340/operatorsScore.csv
@@ -130,6 +130,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/340/supportedExprs.csv
+++ b/tools/generated_files/340/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/341/operatorsScore.csv
+++ b/tools/generated_files/341/operatorsScore.csv
@@ -130,6 +130,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/341/supportedExprs.csv
+++ b/tools/generated_files/341/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/342/operatorsScore.csv
+++ b/tools/generated_files/342/operatorsScore.csv
@@ -130,6 +130,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/342/supportedExprs.csv
+++ b/tools/generated_files/342/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/343/operatorsScore.csv
+++ b/tools/generated_files/343/operatorsScore.csv
@@ -130,6 +130,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/343/supportedExprs.csv
+++ b/tools/generated_files/343/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/344/operatorsScore.csv
+++ b/tools/generated_files/344/operatorsScore.csv
@@ -130,6 +130,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/344/supportedExprs.csv
+++ b/tools/generated_files/344/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/350/operatorsScore.csv
+++ b/tools/generated_files/350/operatorsScore.csv
@@ -138,6 +138,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/350/supportedExprs.csv
+++ b/tools/generated_files/350/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/351/operatorsScore.csv
+++ b/tools/generated_files/351/operatorsScore.csv
@@ -138,6 +138,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/351/supportedExprs.csv
+++ b/tools/generated_files/351/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/352/operatorsScore.csv
+++ b/tools/generated_files/352/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/352/supportedExprs.csv
+++ b/tools/generated_files/352/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/353/operatorsScore.csv
+++ b/tools/generated_files/353/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/353/supportedExprs.csv
+++ b/tools/generated_files/353/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/354/operatorsScore.csv
+++ b/tools/generated_files/354/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/354/supportedExprs.csv
+++ b/tools/generated_files/354/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/355/operatorsScore.csv
+++ b/tools/generated_files/355/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/355/supportedExprs.csv
+++ b/tools/generated_files/355/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/356/operatorsScore.csv
+++ b/tools/generated_files/356/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/356/supportedExprs.csv
+++ b/tools/generated_files/356/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/357/operatorsScore.csv
+++ b/tools/generated_files/357/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/357/supportedExprs.csv
+++ b/tools/generated_files/357/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/358/operatorsScore.csv
+++ b/tools/generated_files/358/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/358/supportedExprs.csv
+++ b/tools/generated_files/358/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/400/operatorsScore.csv
+++ b/tools/generated_files/400/operatorsScore.csv
@@ -139,6 +139,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/400/supportedExprs.csv
+++ b/tools/generated_files/400/supportedExprs.csv
@@ -240,6 +240,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/401/operatorsScore.csv
+++ b/tools/generated_files/401/operatorsScore.csv
@@ -141,6 +141,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/401/supportedExprs.csv
+++ b/tools/generated_files/401/supportedExprs.csv
@@ -244,6 +244,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/402/operatorsScore.csv
+++ b/tools/generated_files/402/operatorsScore.csv
@@ -141,6 +141,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/402/supportedExprs.csv
+++ b/tools/generated_files/402/supportedExprs.csv
@@ -244,6 +244,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/411/operatorsScore.csv
+++ b/tools/generated_files/411/operatorsScore.csv
@@ -142,6 +142,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/411/supportedExprs.csv
+++ b/tools/generated_files/411/supportedExprs.csv
@@ -244,6 +244,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/operatorsScore.csv
+++ b/tools/generated_files/operatorsScore.csv
@@ -128,6 +128,7 @@ EqualTo,4
 Exp,4
 Explode,4
 Expm1,4
+FindInSet,4
 First,4
 Flatten,4
 Floor,4

--- a/tools/generated_files/supportedExprs.csv
+++ b/tools/generated_files/supportedExprs.csv
@@ -238,6 +238,9 @@ Expm1,S,`expm1`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,N
 Expm1,S,`expm1`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Expm1,S,`expm1`,None,AST,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,strArray,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+FindInSet,S,`find_in_set`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Flatten,S,`flatten`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA
 Floor,S, ,None,project,input,NA,NA,NA,NA,S,NA,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA


### PR DESCRIPTION
Fixes #8627.

### Description

This adds GPU support for Spark `find_in_set`, which previously fell back because the accelerator did not register a GPU expression for `org.apache.spark.sql.catalyst.expressions.FindInSet`.

The implementation registers `FindInSet` in `GpuOverrides` and adds `GpuFindInSet`. For a columnar set argument, the implementation splits the comma-delimited set string, looks up the left-hand string in the resulting list, and returns Spark's 1-based index result as an integer.

For a scalar/literal set argument, the implementation avoids expanding and splitting the same set once per input row. Instead, it builds a small token-to-first-position dictionary for the set and maps the word column through that dictionary on the GPU. Scalar/scalar inputs are evaluated once and expanded to the batch size.

For a scalar word and columnar set argument, the implementation now has two GPU paths. When a Spark RAPIDS JNI build exposes `StringUtils.findInSet`, it calls that native single-pass GPU implementation for the dynamic RHS column. Until that JNI dependency is available, the code falls back to the low-cardinality repeated RHS path added here: it computes distinct RHS set strings per batch, evaluates the scalar word position once per distinct set on the host, and gathers the row results back on the GPU. A single-distinct RHS batch fills the output from one scalar position. High-cardinality RHS batches fall back to the generic split/list implementation to avoid copying large set columns to the host.

The native JNI follow-up is https://github.com/NVIDIA/spark-rapids-jni/pull/4636. It keeps the Spark-specific `find_in_set` semantics in Spark RAPIDS JNI: null RHS rows remain null, missing values return 0, duplicate tokens return the first position, empty tokens are preserved, and words containing commas return 0. This is the preferred best-performance path for dynamic RHS columns. A cuDF PR is not filed yet because the current API is Spark-specific; the implementation can be promoted to libcudf if JNI review asks for a reusable cuDF string primitive.

The implementation handles scalar and columnar input combinations and preserves null-intolerant behavior, empty-token behavior, duplicate-token first-match behavior, and Spark's rule that words containing commas return 0.

This is a user-facing support change, so the generated supported-operator documentation and advanced configuration metadata are updated to include `find_in_set`.

### Testing and performance

Test coverage adds `test_find_in_set` in `string_test.py`, covering literal and column inputs, missing values, empty strings, words containing commas, nulls, duplicate-token first-match behavior, and multibyte characters.

Validation:

- `git diff --check`
- Spark 3.5.3 / Scala 2.12 dist jar built from this branch with `build/buildall --profile=353 --module=dist --parallel=1`
- Spark-side compile after direct-native dispatch change: `JAVA_HOME=/opt/homebrew/opt/openjdk@17 mvn -pl sql-plugin -am -Dbuildver=353 -DskipTests -Dmaven.scaladoc.skip compile`
- Jenkins Spark RAPIDS dev jar build #243 from commit `f0e723efb0a7d65060996f7f5a266cef2088284f` with RAPIDS JNI jar from https://github.com/NVIDIA/spark-rapids-jni/pull/4636 commit `42847fdb0720163c71453ffcd12c65b288fea488`
- Dataproc GPU correctness sanity on a single-node T4 cluster with Dataproc 2.2 / Spark 3.5.3 / Scala 2.12, covering nulls, empty tokens, duplicate tokens, and words containing commas
- Dataproc CPU/GPU benchmark on the same single-node T4 cluster shape
- Spark RAPIDS JNI draft PR validation for https://github.com/NVIDIA/spark-rapids-jni/pull/4636: signoff, license header, shell check, and pre-commit passed

Dataproc benchmark resources:

- Single-node Dataproc 2.2-debian12 cluster, no workers
- Master machine type: `n1-standard-16` with 16 vCPU, 60 GB memory, and a 200 GB pd-standard boot disk
- GPU mode used 1 NVIDIA T4 attached to the same node
- CPU mode used the same `n1-standard-16` node with `spark.rapids.sql.enabled=false`; it was not a multi-node CPU cluster
- Spark physical plans for these synthetic `range` benchmarks used 64 input partitions

Literal RHS benchmark shape:

- Expression: `find_in_set(cast(pmod(id, 64) as string), '0,1,...,63')`
- Rows: 10,000,000
- Result aggregate: `sum(pos), count(1)`
- Correctness: GPU and CPU both produced `row_count=10000000` and `sum_pos=325000000`
- GPU executed plan included `GpuProject [find_in_set(...)]`, `GpuHashAggregate`, and `GpuRange`

| Mode | Iteration 1 | Iteration 2 | Iteration 3 | Warm avg |
| --- | ---: | ---: | ---: | ---: |
| GPU enabled | 31.547s | 0.578s | 0.481s | 0.530s |
| RAPIDS SQL disabled | 28.651s | 0.943s | 0.840s | 0.892s |

The literal-RHS optimized path shows about 1.7x speedup over CPU for warm iterations in this 1 T4 vs 16 vCPU operator-level benchmark.

Dynamic RHS column benchmark shape:

- Expression: `find_in_set('32', token_set)`
- Rows: 20,000,000
- Partitions: 64
- Warmup iterations: 2
- Measured iterations: 5
- Result aggregate: `sum(pos)`
- RHS column cached before the measured loop to keep `token_set` as a real column and avoid Catalyst folding into a literal result
- GPU executed plan included `GpuProject [find_in_set(32, token_set)]`
- GPU mode used `spark.plugins=com.nvidia.spark.SQLPlugin`, 1 executor, 15 executor cores, 32 GB executor memory, and 1 T4
- CPU mode used RAPIDS disabled, 2 executors x 8 cores, and 18 GB executor memory per executor on the same `n1-standard-16` node

| Case | GPU warm avg | CPU warm avg | GPU vs CPU |
| --- | ---: | ---: | ---: |
| 1 distinct RHS set string | 0.792s | 0.588s | 0.74x |
| 2 distinct RHS set strings | 0.655s | 0.450s | 0.69x |
| 5,000 distinct RHS strings | 0.663s | 0.439s | 0.66x |
| 60,000 distinct RHS strings | 0.818s | 0.420s | 0.51x |

Measured GPU iteration seconds:

| Case | Iteration 1 | Iteration 2 | Iteration 3 | Iteration 4 | Iteration 5 |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 distinct RHS set string | 0.944s | 0.777s | 0.706s | 0.742s | 0.790s |
| 2 distinct RHS set strings | 0.745s | 0.629s | 0.611s | 0.582s | 0.708s |
| 5,000 distinct RHS strings | 0.654s | 0.669s | 0.722s | 0.625s | 0.642s |
| 60,000 distinct RHS strings | 0.852s | 0.809s | 0.807s | 0.802s | 0.822s |

Measured CPU iteration seconds:

| Case | Iteration 1 | Iteration 2 | Iteration 3 | Iteration 4 | Iteration 5 |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 distinct RHS set string | 0.665s | 0.518s | 0.580s | 0.581s | 0.597s |
| 2 distinct RHS set strings | 0.476s | 0.441s | 0.431s | 0.453s | 0.448s |
| 5,000 distinct RHS strings | 0.433s | 0.453s | 0.455s | 0.422s | 0.434s |
| 60,000 distinct RHS strings | 0.414s | 0.422s | 0.366s | 0.473s | 0.424s |

The dynamic RHS native path is dramatically faster than the earlier generic split/list fallback, but it is still slower than the 16-vCPU CPU baseline on this cached operator-level benchmark. The direct native path also improves the low-cardinality/repeated RHS path by avoiding per-batch distinct/dictionary setup, but the remaining gap suggests further native-side work is needed, likely a lower-overhead libcudf string primitive or kernel path specialized for scalar word search in comma-delimited strings.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
