### PR TITLE
[Coverage] Add YearMonthInterval multiply/divide IT parallel to DayTime

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1433,7 +1433,8 @@ def test_year_month_interval_division_number_no_overflow(data_gen):
     # Cast result to BIGINT (same reason as test_year_month_interval_multiply_number).
     gen_list = [('_c2', data_gen)]
     assert_gpu_and_cpu_are_equal_collect(
-        # divisor min_val starts at 1 for integer gens; DoubleGen min_exp=0 keeps it >=1
+        # divisor min_val starts at 1 for integer gens; DoubleGen min_exp=0 keeps |divisor| >= 1
+        # (sign bit is random). case-when guards the 0 case for completeness.
         lambda spark: gen_df(spark, gen_list).selectExpr(
             "CAST(INTERVAL '5-3' YEAR TO MONTH / case when _c2 = 0 then cast(1 as {}) else _c2 end AS BIGINT)".format(to_cast_string(data_gen.data_type)),
             "CAST(INTERVAL '100-0' YEAR TO MONTH / case when _c2 = 0 then cast(1 as {}) else _c2 end AS BIGINT)".format(to_cast_string(data_gen.data_type))))

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1413,6 +1413,31 @@ def test_day_time_interval_division_number_no_overflow2(data_gen):
         # avoid dividing by 0
         lambda spark: gen_df(spark, gen_list).selectExpr("_c1 / case when _c2 = 0 then cast(1 as {}) else _c2 end".format(to_cast_string(data_gen.data_type))))
 
+@pytest.mark.skipif(is_before_spark_330(), reason='YearMonthInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=-3, max_exp=5, special_cases=[0.0])], ids=idfn)
+def test_year_month_interval_multiply_number(data_gen):
+    # Cast result to BIGINT (months count) so the final schema is LongType.
+    # YearMonthIntervalType schema is not deserializable by PySpark 3.3.0
+    # client-side, and CAST(YM AS STRING) is not GPU-supported (would force
+    # the multiply onto CPU). CAST(YM AS BIGINT) is GPU-supported.
+    gen_list = [('_c2', data_gen)]
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, gen_list).selectExpr(
+            "CAST(INTERVAL '0-3' YEAR TO MONTH * _c2 AS BIGINT)",
+            "CAST(INTERVAL '5-7' YEAR TO MONTH * _c2 AS BIGINT)",
+            "CAST(_c2 * INTERVAL '100-0' YEAR TO MONTH AS BIGINT)"))
+
+@pytest.mark.skipif(is_before_spark_330(), reason='YearMonthInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=0, max_exp=5, special_cases=[])], ids=idfn)
+def test_year_month_interval_division_number_no_overflow(data_gen):
+    # Cast result to BIGINT (same reason as test_year_month_interval_multiply_number).
+    gen_list = [('_c2', data_gen)]
+    assert_gpu_and_cpu_are_equal_collect(
+        # divisor min_val starts at 1 for integer gens; DoubleGen min_exp=0 keeps it >=1
+        lambda spark: gen_df(spark, gen_list).selectExpr(
+            "CAST(INTERVAL '5-3' YEAR TO MONTH / case when _c2 = 0 then cast(1 as {}) else _c2 end AS BIGINT)".format(to_cast_string(data_gen.data_type)),
+            "CAST(INTERVAL '100-0' YEAR TO MONTH / case when _c2 = 0 then cast(1 as {}) else _c2 end AS BIGINT)".format(to_cast_string(data_gen.data_type))))
+
 def _get_overflow_df_1col(spark, data_type, value, expr):
     return spark.createDataFrame(
         SparkContext.getOrCreate().parallelize([value]),

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1413,7 +1413,6 @@ def test_day_time_interval_division_number_no_overflow2(data_gen):
         # avoid dividing by 0
         lambda spark: gen_df(spark, gen_list).selectExpr("_c1 / case when _c2 = 0 then cast(1 as {}) else _c2 end".format(to_cast_string(data_gen.data_type))))
 
-@pytest.mark.skipif(is_before_spark_330(), reason='YearMonthInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=-3, max_exp=5, special_cases=[0.0])], ids=idfn)
 def test_year_month_interval_multiply_number(data_gen):
     # Cast result to BIGINT (months count) so the final schema is LongType.
@@ -1427,17 +1426,14 @@ def test_year_month_interval_multiply_number(data_gen):
             "CAST(INTERVAL '5-7' YEAR TO MONTH * _c2 AS BIGINT)",
             "CAST(_c2 * INTERVAL '100-0' YEAR TO MONTH AS BIGINT)"))
 
-@pytest.mark.skipif(is_before_spark_330(), reason='YearMonthInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=0, max_exp=5, special_cases=[])], ids=idfn)
 def test_year_month_interval_division_number_no_overflow(data_gen):
     # Cast result to BIGINT (same reason as test_year_month_interval_multiply_number).
     gen_list = [('_c2', data_gen)]
     assert_gpu_and_cpu_are_equal_collect(
-        # divisor min_val starts at 1 for integer gens; DoubleGen min_exp=0 keeps |divisor| >= 1
-        # (sign bit is random). case-when guards the 0 case for completeness.
         lambda spark: gen_df(spark, gen_list).selectExpr(
-            "CAST(INTERVAL '5-3' YEAR TO MONTH / case when _c2 = 0 then cast(1 as {}) else _c2 end AS BIGINT)".format(to_cast_string(data_gen.data_type)),
-            "CAST(INTERVAL '100-0' YEAR TO MONTH / case when _c2 = 0 then cast(1 as {}) else _c2 end AS BIGINT)".format(to_cast_string(data_gen.data_type))))
+            "CAST(INTERVAL '5-3' YEAR TO MONTH / _c2 AS BIGINT)",
+            "CAST(INTERVAL '100-0' YEAR TO MONTH / _c2 AS BIGINT)"))
 
 def _get_overflow_df_1col(spark, data_type, value, expr):
     return spark.createDataFrame(
@@ -1602,4 +1598,3 @@ def test_try_multiply_fallback_to_cpu(data_gen):
     assert_gpu_fallback_collect(
         lambda spark: binary_op_df(spark, data_gen).selectExpr(
             "try_multiply(a, b) as result"), "Multiply")
-


### PR DESCRIPTION
## Summary

- Adds 2 parametrized tests to `integration_tests/src/main/python/arithmetic_ops_test.py` covering `INTERVAL '...' YEAR TO MONTH * <number>` and `INTERVAL '...' YEAR TO MONTH / <number>` against `Byte`/`Short`/`Int`/`Long`/`Double` multipliers/divisors. Mirrors the existing `test_day_time_interval_multiply_number` / `test_day_time_interval_division_number_no_overflow{1,2}` patterns immediately above the diff.
- Both `GpuMultiplyYMInterval` (27 LM) and `GpuDivideYMInterval` (30 LM) were at 0% line coverage in the JaCoCo W0 nightly baseline despite being shim-330+ compiled into shim 350. No public IT touched them.
- JaCoCo Δ vs nightly W0 baseline (`972be678_20260525`): Δ `LINE_COVERED` = **+43** on the two target classes (Multiply 0→21, Divide 0→22), plus ~+174 incidental LC across `GpuIntervalUtils$`, `IntervalUtils$`, `DecimalArithmeticOverrides$`.

Contributes to #14911 (under epic #14899).

## Why this increases coverage

`GpuMultiplyYMInterval` and `GpuDivideYMInterval` were defined and shim-routed into the shim 350 build target (the production-side header at `sql-plugin/src/main/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala` lists shim 330+), but no existing public Python IT query invoked them. The W0 baseline therefore reports both at 0/27 and 0/30 LC respectively. The DayTime siblings (`GpuMultiplyDTInterval` / `GpuDivideDTInterval`) are heavily exercised by `test_day_time_interval_multiply_number` and `test_day_time_interval_division_number_no_overflow{1,2}`. This PR fills the symmetric gap.

The parametrize variants (Byte/Short/Int/Long + Double) exercise all three Multiply branches (BSI / Long / Float-Double) and both Divide branches (BSILong / Float-Double) inside `intervalExpressions.scala:347-368` and `:495-508`. The `_c2` column drives the per-row code path, so each parametrize value hits one Multiply/Divide kernel arm end-to-end.

The cast to `BIGINT` keeps the final schema as `LongType` instead of `YearMonthIntervalType`. This is required because (1) PySpark 3.3.0's client cannot deserialize `YearMonthIntervalType` (it raises `ValueError: Could not parse datatype: interval year to month` during `.collect()`), and (2) `CAST(YM AS STRING)` is not GPU-supported by `GpuCast`, which would force the multiply onto CPU and trip the strict columnar-plan check. `CAST(YM AS BIGINT)` *is* GPU-supported (`GpuCast.scala:615-628`) and preserves the underlying INT months value, so CPU and GPU produce identical Long outputs.

## Test plan

- [x] Local validation: `TEST_PARALLEL=0 ./run_pyspark_from_build.sh -k 'test_year_month_interval'` — `10 passed, 0 failed in 14.68s`.
- [x] GPU plan check: `spark.rapids.sql.explain=ALL` confirms `*Expression <MultiplyYMInterval> ... will run on GPU` for both Multiply and Divide branches. No CPU fallback.
- [x] JaCoCo net-Δ gate: merged local PR `jacoco.exec` with nightly `final-aggregate.exec`; per-class report confirms Δ `LINE_COVERED` > 0 on the two target classes with 0 fallers.
- [ ] Blossom premerge

## Coverage impact

Δ `LINE_COVERED` from the JaCoCo merge (drift-cleaned across the relevant package):

| Class | Baseline (LM / LC) | Merged (LM / LC) | Δ `LINE_COVERED` |
|---|---|---|---|
| `GpuMultiplyYMInterval` | 27 / 0 | 6 / 21 | **+21** |
| `GpuDivideYMInterval` | 30 / 0 | 8 / 22 | **+22** |
| `GpuIntervalUtils$` (helper, incidental) | — | — | +69 |
| `IntervalUtils$` (helper, incidental) | — | — | +58 |
| `DecimalArithmeticOverrides$` (Divide routes via decimal arith) | — | — | +47 |

Combined: ~+217 LC, of which +43 is on the two target classes. The two targets go from 0% → 73-78% covered.

## Checklist

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required


JaCoCo sql-plugin line coverage: +76 lines.
