### PR TITLE
[Coverage] Exercise uncovered CPU bridge paths

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -15,7 +15,7 @@
 from logging import exception
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql, assert_cpu_and_gpu_are_equal_collect_with_capture
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql
 from data_gen import *
 from marks import ignore_order, incompat, approximate_float, allow_non_gpu, allow_non_gpu_conditional, datagen_overrides, disable_ansi_mode
 from pyspark.sql.types import *
@@ -1594,49 +1594,4 @@ def test_try_multiply_fallback_to_cpu(data_gen):
     assert_gpu_fallback_collect(
         lambda spark: binary_op_df(spark, data_gen).selectExpr(
             "try_multiply(a, b) as result"), "Multiply")
-
-
-# csc has no GPU implementation in spark-rapids and is a deterministic UnaryMathExpression
-# (1/sin(x)), so it is an ideal candidate for spark.rapids.sql.expression.cpuBridge.enabled.
-# With the conf enabled, Csc is wrapped by GpuCpuBridgeExpression and the surrounding
-# Project stays GPU-resident; with the conf disabled (default) the entire Project falls
-# back to CPU. `@allow_non_gpu("Csc", "BoundReference")` is required because the IT strict-columnar check
-# in GpuTransitionOverrides.assertIsOnTheGpu recurses into a GpuCpuBridgeExpression's
-# cpu child subtree (Csc) and would otherwise reject Csc as non-GPU; allowing it as a
-# non-GPU expression matches what the bridge does in practice.
-@allow_non_gpu("Csc", "BoundReference")
-@pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-def test_cpu_bridge_csc_select(aqe_enabled):
-    conf = {
-        'spark.rapids.sql.expression.cpuBridge.enabled': 'true',
-        'spark.sql.adaptive.enabled': aqe_enabled,
-    }
-    # Plan-level assertContains(GpuCpuBridgeExpression) guards against silent
-    # coverage regression if Csc ever gains a GPU implementation (the bridge
-    # would no longer fire and result-equality alone would mask the change).
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
-        lambda spark: gen_df(spark,
-            [('x', DoubleGen(min_exp=-3, max_exp=5, no_nans=True))],
-            length=100
-        ).selectExpr("x", "csc(x) AS csc_x", "x * 2 AS x2", "abs(x) AS abs_x"),
-        exist_classes='GpuCpuBridgeExpression',
-        conf=conf)
-
-
-@allow_non_gpu("Csc", "BoundReference")
-@pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-def test_cpu_bridge_csc_filter(aqe_enabled):
-    conf = {
-        'spark.rapids.sql.expression.cpuBridge.enabled': 'true',
-        'spark.sql.adaptive.enabled': aqe_enabled,
-    }
-    # csc(x) in a filter predicate exercises the bridge in a Filter (not Project)
-    # context. Result rows are reduced to those where csc(x) > 1.5.
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
-        lambda spark: gen_df(spark,
-            [('x', DoubleGen(min_exp=-1, max_exp=2, no_nans=True))],
-            length=200
-        ).filter("csc(x) > 1.5").selectExpr("x", "csc(x) AS csc_x"),
-        exist_classes='GpuCpuBridgeExpression',
-        conf=conf)
 

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1595,3 +1595,43 @@ def test_try_multiply_fallback_to_cpu(data_gen):
         lambda spark: binary_op_df(spark, data_gen).selectExpr(
             "try_multiply(a, b) as result"), "Multiply")
 
+
+# csc has no GPU implementation in spark-rapids and is a deterministic UnaryMathExpression
+# (1/sin(x)), so it is an ideal candidate for spark.rapids.sql.expression.cpuBridge.enabled.
+# With the conf enabled, Csc is wrapped by GpuCpuBridgeExpression and the surrounding
+# Project stays GPU-resident; with the conf disabled (default) the entire Project falls
+# back to CPU. `@allow_non_gpu("Csc", "BoundReference")` is required because the IT strict-columnar check
+# in GpuTransitionOverrides.assertIsOnTheGpu recurses into a GpuCpuBridgeExpression's
+# cpu child subtree (Csc) and would otherwise reject Csc as non-GPU; allowing it as a
+# non-GPU expression matches what the bridge does in practice.
+@allow_non_gpu("Csc", "BoundReference")
+@pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
+def test_cpu_bridge_csc_select(aqe_enabled):
+    conf = {
+        'spark.rapids.sql.expression.cpuBridge.enabled': 'true',
+        'spark.sql.adaptive.enabled': aqe_enabled,
+    }
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark,
+            [('x', DoubleGen(min_exp=-3, max_exp=5, no_nans=True))],
+            length=100
+        ).selectExpr("x", "csc(x) AS csc_x", "x * 2 AS x2", "abs(x) AS abs_x"),
+        conf=conf)
+
+
+@allow_non_gpu("Csc", "BoundReference")
+@pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
+def test_cpu_bridge_csc_filter(aqe_enabled):
+    conf = {
+        'spark.rapids.sql.expression.cpuBridge.enabled': 'true',
+        'spark.sql.adaptive.enabled': aqe_enabled,
+    }
+    # csc(x) in a filter predicate exercises the bridge in a Filter (not Project)
+    # context. Result rows are reduced to those where csc(x) > 1.5.
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark,
+            [('x', DoubleGen(min_exp=-1, max_exp=2, no_nans=True))],
+            length=200
+        ).filter("csc(x) > 1.5").selectExpr("x", "csc(x) AS csc_x"),
+        conf=conf)
+

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -15,7 +15,7 @@
 from logging import exception
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql, assert_cpu_and_gpu_are_equal_collect_with_capture
 from data_gen import *
 from marks import ignore_order, incompat, approximate_float, allow_non_gpu, allow_non_gpu_conditional, datagen_overrides, disable_ansi_mode
 from pyspark.sql.types import *
@@ -1611,11 +1611,15 @@ def test_cpu_bridge_csc_select(aqe_enabled):
         'spark.rapids.sql.expression.cpuBridge.enabled': 'true',
         'spark.sql.adaptive.enabled': aqe_enabled,
     }
-    assert_gpu_and_cpu_are_equal_collect(
+    # Plan-level assertContains(GpuCpuBridgeExpression) guards against silent
+    # coverage regression if Csc ever gains a GPU implementation (the bridge
+    # would no longer fire and result-equality alone would mask the change).
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: gen_df(spark,
             [('x', DoubleGen(min_exp=-3, max_exp=5, no_nans=True))],
             length=100
         ).selectExpr("x", "csc(x) AS csc_x", "x * 2 AS x2", "abs(x) AS abs_x"),
+        exist_classes='GpuCpuBridgeExpression',
         conf=conf)
 
 
@@ -1628,10 +1632,11 @@ def test_cpu_bridge_csc_filter(aqe_enabled):
     }
     # csc(x) in a filter predicate exercises the bridge in a Filter (not Project)
     # context. Result rows are reduced to those where csc(x) > 1.5.
-    assert_gpu_and_cpu_are_equal_collect(
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: gen_df(spark,
             [('x', DoubleGen(min_exp=-1, max_exp=2, no_nans=True))],
             length=200
         ).filter("csc(x) > 1.5").selectExpr("x", "csc(x) AS csc_x"),
+        exist_classes='GpuCpuBridgeExpression',
         conf=conf)
 

--- a/integration_tests/src/main/python/cpu_bridge_test.py
+++ b/integration_tests/src/main/python/cpu_bridge_test.py
@@ -46,8 +46,7 @@ def create_cpu_bridge_fallback_conf(disabled_gpu_expressions, disallowed_bridge_
 def with_columnar_source(df):
     return df.filter(f.monotonically_increasing_id() >= f.lit(0))
 
-# Only include Add and Boundreference Expressions to verify that the CPU bridge is working
-# as expected.
+# Allow only Add to fall back so this test isolates the CPU bridge path.
 @allow_non_gpu('Add')
 def test_cpu_bridge_add_fallback():
     """Test CPU bridge when Add expression is forced to fall back to CPU"""
@@ -85,8 +84,7 @@ def test_cpu_bridge_stateful_map_large_batch_parallel_path():
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         test_func, exist_classes="GpuCpuBridgeExpression", conf=conf)
 
-# Only include Multiply and Boundreference Expressions to verify that the CPU bridge is working
-# as expected.
+# Allow only Multiply to fall back so this test isolates the CPU bridge path.
 @allow_non_gpu('Multiply')
 def test_cpu_bridge_multiply_fallback():
     """Test CPU bridge when Multiply expression is forced to fall back to CPU"""
@@ -98,6 +96,42 @@ def test_cpu_bridge_multiply_fallback():
     # Force Multiply to fall back to CPU bridge
     conf = create_cpu_bridge_fallback_conf(['Multiply'])
     assert_gpu_and_cpu_are_equal_collect(test_func, conf=conf)
+
+
+# Csc has no GPU implementation and is a deterministic UnaryMathExpression, so unlike the
+# Add/Multiply tests above it covers the RuleNotFoundExprMeta -> CPU bridge path. Keep the bridge
+# explicitly enabled so this remains a targeted bridge test even if the default changes again.
+@allow_non_gpu('Csc')
+@pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
+def test_cpu_bridge_csc_select(aqe_enabled):
+    conf = {
+        'spark.rapids.sql.expression.cpuBridge.enabled': True,
+        'spark.sql.adaptive.enabled': aqe_enabled,
+    }
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: gen_df(spark,
+            [('x', DoubleGen(min_exp=-3, max_exp=5, no_nans=True))],
+            length=100
+        ).selectExpr("x", "csc(x) AS csc_x", "x * 2 AS x2", "abs(x) AS abs_x"),
+        exist_classes='GpuCpuBridgeExpression',
+        conf=conf)
+
+
+@allow_non_gpu('Csc')
+@pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
+def test_cpu_bridge_csc_filter(aqe_enabled):
+    conf = {
+        'spark.rapids.sql.expression.cpuBridge.enabled': True,
+        'spark.sql.adaptive.enabled': aqe_enabled,
+    }
+    # Keep Csc only in the predicate so a Project bridge cannot mask a Filter bridge regression.
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: gen_df(spark,
+            [('x', DoubleGen(min_exp=-1, max_exp=2, no_nans=True))],
+            length=200
+        ).filter("csc(x) > 1.5").select("x"),
+        exist_classes='GpuCpuBridgeExpression',
+        conf=conf)
 
 @allow_non_gpu('ProjectExec')
 @pytest.mark.skipif(not is_spark_341_or_later(),

--- a/integration_tests/src/main/python/cpu_bridge_test.py
+++ b/integration_tests/src/main/python/cpu_bridge_test.py
@@ -60,10 +60,12 @@ def test_cpu_bridge_add_fallback():
     assert_gpu_and_cpu_are_equal_collect(test_func, conf=conf)
 
 
+# MIN_ROWS_PER_SUBBATCH is 500,000: these values exercise one and two sub-batch results.
 @allow_non_gpu('Add')
-def test_cpu_bridge_add_large_batch_parallel_path():
+@pytest.mark.parametrize('row_count', [500000, 500001], ids=idfn)
+def test_cpu_bridge_add_large_batch_parallel_path(row_count):
     def test_func(spark):
-        return spark.range(0, 500001, 1, 1) \
+        return spark.range(0, row_count, 1, 1) \
             .selectExpr("id + 1 as bridged") \
             .agg(f.sum("bridged"))
 
@@ -112,7 +114,7 @@ def test_cpu_bridge_csc_select(aqe_enabled):
         lambda spark: gen_df(spark,
             [('x', DoubleGen(min_exp=-3, max_exp=5, no_nans=True))],
             length=100
-        ).selectExpr("x", "csc(x) AS csc_x", "x * 2 AS x2", "abs(x) AS abs_x"),
+        ).selectExpr("x", "csc(x) AS csc_x"),
         exist_classes='GpuCpuBridgeExpression',
         conf=conf)
 

--- a/integration_tests/src/main/python/cpu_bridge_test.py
+++ b/integration_tests/src/main/python/cpu_bridge_test.py
@@ -133,6 +133,7 @@ def test_cpu_bridge_csc_filter(aqe_enabled):
         exist_classes='GpuCpuBridgeExpression',
         conf=conf)
 
+
 @allow_non_gpu('ProjectExec')
 @pytest.mark.skipif(not is_spark_341_or_later(),
                     reason='TimestampNTZType is only supported in PySpark 3.4.1+')

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ConvertForGpuCpuBridgeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ConvertForGpuCpuBridgeSuite.scala
@@ -354,6 +354,26 @@ class ConvertForGpuCpuBridgeSuite extends AnyFunSuite {
       "Bridge conversion requires deterministic expressions"))
   }
 
+  test("requireAstForGpu rolls back CPU bridge state") {
+    val col = AttributeReference("a", IntegerType, nullable = false)()
+    val exprMeta = createExprMeta(Add(col, Literal(10)))
+
+    exprMeta.moveToCpuBridge()
+    assert(exprMeta.willUseGpuCpuBridge)
+    assert(exprMeta.replaceMessage === "run on GPU via CPU bridge")
+
+    exprMeta.willNotWorkInAst("test AST incompatibility")
+    exprMeta.requireAstForGpu()
+
+    assert(exprMeta.mustBeAstExpression)
+    assert(!exprMeta.willUseGpuCpuBridge)
+    assert(!exprMeta.canThisBeReplaced)
+    assert(exprMeta.childExprs.forall(_.mustBeAstExpression))
+
+    exprMeta.undoBridgeOptimization()
+    assert(!exprMeta.willUseGpuCpuBridge)
+  }
+
   // ============================================================================
   // Regression Tests for the Specific Review Concern
   // ============================================================================

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ConvertForGpuCpuBridgeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ConvertForGpuCpuBridgeSuite.scala
@@ -341,6 +341,17 @@ class ConvertForGpuCpuBridgeSuite extends AnyFunSuite {
     // Non-deterministic expressions should not be allowed to move to bridge
     assert(!exprMeta.canMoveToCpuBridge,
       "Non-deterministic expressions should not be bridge-compatible")
+
+    val moveError = intercept[IllegalStateException] {
+      exprMeta.moveToCpuBridge()
+    }
+    assert(moveError.getMessage.contains("trying to move to bridge when not allowed"))
+
+    val conversionError = intercept[IllegalArgumentException] {
+      exprMeta.convertForGpuCpuBridge()
+    }
+    assert(conversionError.getMessage.contains(
+      "Bridge conversion requires deterministic expressions"))
   }
 
   // ============================================================================

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeOptimizerUnitSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeOptimizerUnitSuite.scala
@@ -18,8 +18,9 @@ package com.nvidia.spark.rapids
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.spark.sql.catalyst.expressions.{Add, And, AttributeReference, CaseWhen,
-  GreaterThan, Literal, MonotonicallyIncreasingID, Multiply, ScalaUDF, XxHash64}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Add, And, AttributeReference,
+  BoundReference, CaseWhen, GreaterThan, Literal, MonotonicallyIncreasingID, Multiply, ScalaUDF,
+  XxHash64}
 import org.apache.spark.sql.types.LongType
 
 class GpuCpuBridgeOptimizerUnitSuite extends AnyFunSuite {
@@ -28,8 +29,10 @@ class GpuCpuBridgeOptimizerUnitSuite extends AnyFunSuite {
     RapidsConf.ENABLE_CPU_BRIDGE.key -> "true"
   ))
 
-  private def wrap(e: org.apache.spark.sql.catalyst.expressions.Expression): BaseExprMeta[_] = {
-    val meta = GpuOverrides.wrapExpr(e, conf(), None)
+  private def wrap(
+      e: org.apache.spark.sql.catalyst.expressions.Expression,
+      rapidsConf: RapidsConf = conf()): BaseExprMeta[_] = {
+    val meta = GpuOverrides.wrapExpr(e, rapidsConf, None)
     meta.tagForGpu()
     meta
   }
@@ -236,6 +239,33 @@ class GpuCpuBridgeOptimizerUnitSuite extends AnyFunSuite {
     // Expect all children on GPU in both cases under tie-breaking that prefers GPU
     assert(kids7.forall(_ == false), s"Expected all 7 children on GPU: $kids7")
     assert(kids8.forall(_ == false), s"Expected all 8 children on GPU: $kids8")
+  }
+
+  test("Heuristic handles heterogeneous CPU and GPU child capabilities (unit)") {
+    val rapidsConf = new RapidsConf(Map(
+      RapidsConf.ENABLE_CPU_BRIDGE.key -> "true",
+      RapidsConf.BRIDGE_DISALLOW_LIST.key -> classOf[Abs].getName))
+    val children = Seq(
+      Add(BoundReference(0, LongType, nullable = false), Literal(1L)),
+      Abs(BoundReference(1, LongType, nullable = false))) ++
+      (1L to 6L).map(Literal(_))
+    val rootMeta = wrap(XxHash64(children, 42L), rapidsConf)
+    rootMeta.willNotWorkOnGpu("disabled for test")
+
+    val addMeta = rootMeta.childExprs.head
+    addMeta.willNotWorkOnGpu("disabled for test")
+    val absMeta = rootMeta.childExprs(1)
+
+    assert(!addMeta.canThisBeReplaced && addMeta.canMoveToCpuBridge)
+    assert(absMeta.canThisBeReplaced && !absMeta.canMoveToCpuBridge)
+
+    GpuCpuBridgeOptimizer.optimizeByMinimizingMovement(rootMeta)
+
+    assert(rootMeta.willUseGpuCpuBridge)
+    assert(addMeta.willUseGpuCpuBridge)
+    assert(!absMeta.willUseGpuCpuBridge)
+    assert(rootMeta.childExprs.drop(2).forall(_.willUseGpuCpuBridge),
+      "Scalar literals should co-locate with the CPU parent")
   }
 
   test("Heuristic: 13 mixed Add/Multiply children into XxHash64 under CPU (unit)") {
@@ -502,5 +532,4 @@ class GpuCpuBridgeOptimizerUnitSuite extends AnyFunSuite {
     assert(addMetas.forall(_.willUseGpuCpuBridge), "Both Adds should be on CPU bridge")
   }
 }
-
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeSuite.scala
@@ -40,7 +40,8 @@ class GpuCpuBridgeSuite extends SparkQueryCompareTestSuite {
       Literal(100L)
     )
     
-    val gpuInput = GpuBoundReference(0, LongType, nullable = false)(null, "x")
+    val gpuInput = GpuBoundReference(0, LongType, nullable = false)(
+      NamedExpression.newExprId, "x")
     val bridgeExpr = GpuCpuBridgeExpression(
       gpuInputs = Seq(gpuInput),
       cpuExpression = cpuExpression,
@@ -53,6 +54,10 @@ class GpuCpuBridgeSuite extends SparkQueryCompareTestSuite {
     assert(bridgeExpr.prettyName == "gpu_cpu_bridge")
     assert(bridgeExpr.hasSideEffects) // Bridge always reports hasSideEffects
     assert(bridgeExpr.children.size == 2) // gpuInput + cpuExpression
+    val bridgeSql = bridgeExpr.sql
+    assert(bridgeSql.startsWith("gpu_cpu_bridge("))
+    assert(bridgeSql.contains("gpuInputs=["))
+    assert(bridgeSql.contains("cpuExpression="))
   }
   
   test("GpuCpuBridgeExpression with nullable output") {
@@ -132,6 +137,16 @@ class GpuCpuBridgeSuite extends SparkQueryCompareTestSuite {
     assert(error.getMessage.contains("(Abs) [NOT ALLOWED]"))
     assert(error.getMessage.contains("ALLOWED EXPRESSIONS (for context)"))
     assert(error.getMessage.contains("(Add) [ALLOWED]"))
+  }
+
+  test("GPU assertion rejects an unapproved CPU expression") {
+    val error = intercept[IllegalArgumentException] {
+      new GpuTransitionOverrides().assertIsOnTheGpu(
+        Abs(Literal(1)), new RapidsConf(Map.empty[String, String]))
+    }
+
+    assert(error.getMessage.contains("Abs"))
+    assert(error.getMessage.contains("is not columnar"))
   }
   
   // ============================================================================

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeSuite.scala
@@ -16,7 +16,8 @@
 
 package com.nvidia.spark.rapids
 
-import org.apache.spark.sql.catalyst.expressions.{Add, BoundReference, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Add, BoundReference, Literal,
+  NamedExpression}
 import org.apache.spark.sql.types.{IntegerType, LongType}
 
 /**
@@ -109,6 +110,28 @@ class GpuCpuBridgeSuite extends SparkQueryCompareTestSuite {
     )
     
     assert(bridgeExpr.prettyName == "gpu_cpu_bridge")
+  }
+
+  test("Bridge allow-list error reports allowed and disallowed CPU expressions") {
+    val cpuExpression = Add(
+      Abs(BoundReference(0, IntegerType, nullable = true)),
+      Literal(1))
+    val bridgeExpr = GpuCpuBridgeExpression(
+      gpuInputs = Seq(GpuBoundReference(0, IntegerType, nullable = true)(
+        NamedExpression.newExprId, "x")),
+      cpuExpression = cpuExpression,
+      outputDataType = IntegerType,
+      outputNullable = true)
+    val conf = new RapidsConf(Map(RapidsConf.TEST_ALLOWED_NONGPU.key -> "Add"))
+
+    val error = intercept[IllegalArgumentException] {
+      new GpuTransitionOverrides().assertBridgeExpressionsAllowed(bridgeExpr, conf)
+    }
+
+    assert(error.getMessage.contains("DISALLOWED EXPRESSIONS"))
+    assert(error.getMessage.contains("(Abs) [NOT ALLOWED]"))
+    assert(error.getMessage.contains("ALLOWED EXPRESSIONS (for context)"))
+    assert(error.getMessage.contains("(Add) [ALLOWED]"))
   }
   
   // ============================================================================

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeThreadPoolSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCpuBridgeThreadPoolSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.concurrent.Callable
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class GpuCpuBridgeThreadPoolSuite extends AnyFunSuite {
+
+  private case class TestPriorityRunnable(priority: Long, submitTime: Long)
+      extends Runnable with CpuBridgeTaskPriority {
+    override def run(): Unit = ()
+  }
+
+  test("CPU bridge task comparator orders prioritized tasks before ordinary tasks") {
+    val highPriority = TestPriorityRunnable(priority = 1L, submitTime = 20L)
+    val lowPriority = TestPriorityRunnable(priority = 2L, submitTime = 10L)
+    val earlier = TestPriorityRunnable(priority = 1L, submitTime = 10L)
+    val ordinary = new Runnable {
+      override def run(): Unit = ()
+    }
+
+    assert(CpuBridgeTaskComparator.compare(highPriority, lowPriority) < 0)
+    assert(CpuBridgeTaskComparator.compare(highPriority, earlier) > 0)
+    assert(CpuBridgeTaskComparator.compare(highPriority, ordinary) < 0)
+    assert(CpuBridgeTaskComparator.compare(ordinary, highPriority) > 0)
+    assert(CpuBridgeTaskComparator.compare(ordinary, ordinary) === 0)
+  }
+
+  test("CPU bridge task without TaskContext preserves callable and priority metadata") {
+    val task = PrioritizedCpuBridgeTask(
+      new Callable[Int] {
+        override def call(): Int = 42
+      },
+      taskContext = null,
+      submitTime = 123L)
+
+    assert(task.priority === Long.MaxValue)
+    assert(task.call() === 42)
+
+    val future = new ComparableFutureTask(task)
+    assert(future.priority === Long.MaxValue)
+    assert(future.submitTime === 123L)
+  }
+
+  test("CPU bridge keeps a below-threshold batch sequential") {
+    assert(GpuCpuBridgeThreadPool.getSubBatchCount(499999) === 1)
+  }
+}


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +72 lines** (local same-classfile targeted A/B, shim 350; official nightly marginal pending the first published post-#14132 baseline)

## Summary

- Adds focused `Csc` coverage for the automatic `RuleNotFoundExprMeta` CPU-bridge path in both Project and Filter contexts, with AQE enabled and disabled.
- Requires `GpuCpuBridgeExpression` in each Csc GPU plan, preventing silent full-plan CPU fallback.
- Exercises the `MIN_ROWS_PER_SUBBATCH` boundary at 500,000 and 500,001 rows, covering one-result and two-result parallel sub-batch handling.
- Covers stable bridge-state transitions: AST requirements roll back bridge placement, recursively mark child metadata, and keep rollback idempotent.
- Covers the optimizer's heterogeneous `>7`-child heuristic with forced CPU-only, GPU-only, scalar, and `BoundReference` children.
- Covers every CPU-bridge task-comparator shape, null-`TaskContext` task metadata/delegation, and the below-threshold sequential sub-batch path without starting the global thread pool.
- Covers bridge SQL rendering and the non-GPU/non-allowlisted transition rejection path.

Contributes to #14910 (under epic #14899).

## Relationship to #14132

#14132 enabled the full cost-based CPU bridge and added broad bridge coverage after this PR was originally opened. This PR therefore no longer claims to introduce the first CPU-bridge integration tests.

Its focused coverage value is:

- an automatic `RuleNotFoundExprMeta` bridge case that does not disable an existing GPU expression rule;
- exact parallel sub-batch boundary coverage;
- bridge-state rollback and heterogeneous optimizer-heuristic coverage;
- deterministic task scheduling/helper coverage that does not initialize the thread pool;
- explicit rejection-path and allow-list diagnostic coverage.

## Coverage audit

The local audit used identical shim350 production classfiles for the existing-bridge-test baseline and the added-test execution. The PR execution combines the focused GPU IT with the CPU-bridge unit suites. JaCoCo reported:

- covered lines: `20,531 -> 20,603`, or **+72 sql-plugin lines**;
- line denominator: `68,452 -> 68,452` (`+0`);
- line percentage: `29.99% -> 30.10%` (`+0.11pp`);
- covered branches: `+58`;
- covered methods: `+42`;
- class count delta: `0`;
- no covered-line regressions.

Major gains are:

| Area | Added covered lines |
|---|---:|
| `BaseExprMeta` state transitions | +19 |
| `GpuCpuBridgeOptimizer` and `BoundKey` | +13 |
| thread-pool comparator/task/helper classes | +16 |
| `GpuCpuBridgeExpression` | +3 |
| `GpuTransitionOverrides` | +3 |
| expression, shim, and generated-class support reached by these tests | +18 |
| **Total** | **+72** |

The recurring unrelated `MemoryCheckerImpl +2` local GPU-initialization artifact is excluded.

This is a local targeted A/B audit, not the official full-nightly marginal increment. No published shim350 nightly baseline currently contains #14132 with matching classfiles. The result will be re-measured against that nightly baseline when one becomes available; if the nightly already covers any of these lines, the official marginal number may be lower.

## Test plan

- [x] Base contains #14132 and the merged timestamp-fallback fix #15170.
- [x] Shim330 focused bridge unit tests: `Tests: succeeded 47, failed 0, canceled 0, ignored 0, pending 0`; `BUILD SUCCESS`.
- [x] Shim350 focused bridge unit tests: `Tests: succeeded 47, failed 0, canceled 0, ignored 0, pending 0`; `BUILD SUCCESS`.
- [x] Spark 3.3.0 / Python 3.10 focused GPU IT: **7 passed, 0 failed, 3039 deselected in 8.68s**.
- [x] Spark 3.5.0 / Python 3.10 focused GPU IT: **7 passed, 0 failed, 3039 deselected in 10.73s**.
- [x] Captured plans confirm Project and Filter stay on GPU while `Csc` executes through `GpuCpuBridgeExpression`, for AQE on and off.
- [x] Same-classfile JaCoCo A/B audit: **+72 covered lines**, `+0` denominator, no fallers.
- [x] `git diff --check` and independent source review passed.
- [x] Blossom [#13424](https://prod.blsm.nvidia.com/sw-gpu-spark-jenkins/job/rapids_premerge-github/13424/) failed on the old head before #15170 merged; after rebasing, local Spark 3.3 and 3.5 runs both pass `test_to_timestamp_legacy_millisecond_format_fallback`.
- [ ] Fresh Blossom premerge requested via [build comment](https://github.com/NVIDIA/cudf-spark/pull/14940#issuecomment-4863172045); result pending.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
