### PR TITLE
[Coverage] Cover copy shuffle-compression codec in GpuPartitioningSuite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -153,6 +153,10 @@ class GpuPartitioningSuite extends AnyFunSuite with BeforeAndAfterEach {
     testGpuPartitionWithCompression("zstd")
   }
 
+  test("GPU partition with copy compression") {
+    testGpuPartitionWithCompression("copy")
+  }
+
   test("GPU kudo partitioning with serialization") {
     TrampolineUtil.cleanupAnyExistingSession()
     val conf = new SparkConf()


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +27 lines** (`BatchedCopyCompressor` +14, `BatchedCopyDecompressor` +7, `CopyCompressionCodec` +5, `TableCompressionCodec` +1; shim 350, vs IT-inclusive nightly b22; excludes the +2 MemoryCheckerImpl local-init artifact).

## Summary
Adds a `"copy"` codec case to `GpuPartitioningSuite`, parallel to the existing `lz4`/`zstd` cases, exercising `CopyCompressionCodec`, `BatchedCopyCompressor`, and `BatchedCopyDecompressor` (all 0% Line on the shim-350 JaCoCo report) through the existing `testGpuPartitionWithCompression` helper — compress on partition, decompress on read-back.

## Test plan
- [x] Local validation (shim 350): `Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0` — `GpuPartitioningSuite`, with the new "GPU partition with copy compression" test passing alongside lz4/zstd.
- [x] No overlap with in-flight PR #14907 (that widens the shuffle serializer suites; `GpuPartitioningSuite` is not in its set).

## Coverage impact
`CopyCompressionCodec` / `BatchedCopyCompressor` / `BatchedCopyDecompressor` go from 0% to covered (both compress and decompress paths). Net-positive by construction — these classes are 0% in the merged nightly baseline, so nothing else exercises them.

Contributes to #14991 (under epic #14899).

## Checklist
Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required


JaCoCo sql-plugin line coverage: +27 lines.



