### PR TITLE
[Coverage] Scala UT for CoalescedBatchPartitioner, HostByteBufferIterator, GpuSerializableBatch

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/HostByteBufferIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HostByteBufferIteratorSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.HostMemoryBuffer
+import com.nvidia.spark.rapids.Arm.withResource
+import org.scalatest.funsuite.AnyFunSuite
+
+class HostByteBufferIteratorSuite extends AnyFunSuite {
+
+  test("HostByteBufferIterator emits a ByteBuffer covering the whole host buffer") {
+    withResource(HostMemoryBuffer.allocate(16)) { hmb =>
+      val it = new HostByteBufferIterator(hmb)
+      assert(it.hasNext)
+      val bb = it.next()
+      assertResult(16)(bb.remaining())
+      assert(!it.hasNext)
+    }
+  }
+
+  test("HostByteBufferIterator treats a null buffer as empty") {
+    val it = new HostByteBufferIterator(null)
+    assertResult(0L)(it.totalLength)
+    assert(!it.hasNext)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
@@ -331,16 +331,19 @@ class SerializationSuite extends AnyFunSuite
     // buildBatch() makes a fresh batch each call; GpuSerializableBatch.writeObject consumes
     // (closes) the batch it wraps, so wrap an independent copy and compare against `expected`.
     withResource(buildBatch()) { expected =>
-      val serializable = new org.apache.spark.sql.rapids.GpuSerializableBatch(buildBatch())
       val baos = new ByteArrayOutputStream()
-      withResource(new ObjectOutputStream(baos)) { oos =>
-        oos.writeObject(serializable)
+      withResource(new org.apache.spark.sql.rapids.GpuSerializableBatch(buildBatch())) {
+        serializable =>
+          withResource(new ObjectOutputStream(baos)) { oos =>
+            oos.writeObject(serializable)
+          }
       }
-      val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
-      val deserialized =
-        ois.readObject().asInstanceOf[org.apache.spark.sql.rapids.GpuSerializableBatch]
-      withResource(deserialized) { d =>
-        TestUtils.compareBatches(expected, d.getBatch)
+      withResource(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))) { ois =>
+        val deserialized =
+          ois.readObject().asInstanceOf[org.apache.spark.sql.rapids.GpuSerializableBatch]
+        withResource(deserialized) { d =>
+          TestUtils.compareBatches(expected, d.getBatch)
+        }
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
@@ -326,4 +326,22 @@ class SerializationSuite extends AnyFunSuite
       }
     }
   }
+
+  test("GpuSerializableBatch round-trips a GPU batch through Java serialization") {
+    // buildBatch() makes a fresh batch each call; GpuSerializableBatch.writeObject consumes
+    // (closes) the batch it wraps, so wrap an independent copy and compare against `expected`.
+    withResource(buildBatch()) { expected =>
+      val serializable = new org.apache.spark.sql.rapids.GpuSerializableBatch(buildBatch())
+      val baos = new ByteArrayOutputStream()
+      withResource(new ObjectOutputStream(baos)) { oos =>
+        oos.writeObject(serializable)
+      }
+      val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+      val deserialized =
+        ois.readObject().asInstanceOf[org.apache.spark.sql.rapids.GpuSerializableBatch]
+      withResource(deserialized) { d =>
+        TestUtils.compareBatches(expected, d.getBatch)
+      }
+    }
+  }
 }

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/execution/CoalescedBatchPartitionerSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/execution/CoalescedBatchPartitionerSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.execution
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class CoalescedBatchPartitionerSuite extends AnyFunSuite {
+
+  test("CoalescedBatchPartitioner groups parent partitions by start indices") {
+    // parent with 5 partitions, coalesced into [0,1] [2,3] [4]
+    val parent = new BatchPartitionIdPassthrough(5)
+    val part = new CoalescedBatchPartitioner(parent, Array(0, 2, 4))
+    assertResult(3)(part.numPartitions)
+    // BatchPartitionIdPassthrough.getPartition(k) == k, then mapped into the coalesced group
+    assertResult(0)(part.getPartition(0))
+    assertResult(0)(part.getPartition(1))
+    assertResult(1)(part.getPartition(2))
+    assertResult(1)(part.getPartition(3))
+    assertResult(2)(part.getPartition(4))
+  }
+
+  test("CoalescedBatchPartitioner equals and hashCode honor the partition layout") {
+    val parent = new BatchPartitionIdPassthrough(5)
+    val a = new CoalescedBatchPartitioner(parent, Array(0, 2, 4))
+    val b = new CoalescedBatchPartitioner(parent, Array(0, 2, 4))
+    val c = new CoalescedBatchPartitioner(parent, Array(0, 3))
+    assert(a == b)
+    assertResult(a.hashCode)(b.hashCode)
+    assert(a != c)
+    // a non-partitioner falls through the `case _ => false` arm
+    assert(!a.equals("not a partitioner"))
+  }
+}


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +45 lines** (`GpuSerializableBatch` +20, `CoalescedBatchPartitioner` +18, `HostByteBufferIterator` +7; shim 350, vs IT-inclusive nightly b22).

## Summary
Adds three shim-common Scala unit tests for `sql-plugin` classes that the IT-inclusive shim-350 JaCoCo report leaves uncovered (0% or low Line). The published report merges `nightly-ut` (Scala scalatest) with the Python ITs, so these shim-common suites light the classes up on 350.

- `CoalescedBatchPartitionerSuite` — coalesced parent-partition-id mapping plus `equals`/`hashCode` (pure CPU, no GPU).
- `HostByteBufferIteratorSuite` — host-buffer `ByteBuffer` iteration and the null-buffer guard.
- `GpuSerializableBatch` round-trip added to the existing `SerializationSuite` (Java `writeObject`/`readObject` of a GPU batch).

## Test plan
- [x] Local validation (shim 350): `Tests: succeeded 14, failed 0, canceled 0, ignored 0, pending 0` (all three suites; the three new tests passed).

## Coverage impact
Verified net Delta +45 by merge-diff onto the IT-inclusive nightly b22 (base reproduces the published `jacoco.csv` per class): `CoalescedBatchPartitioner` 0% -> 100% (+18), `HostByteBufferIterator` 0% -> 100% (+7), `GpuSerializableBatch` 21% -> 93% (+20). None is in the suite set widened by the in-flight PR #14907.

Contributes to #14991 (under epic #14899).

## Checklist
Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required


JaCoCo sql-plugin line coverage: +45 lines.

