### PR TITLE
[Coverage] Scala UT for RapidsHostColumnBuilder nested-append, restoreState, and GpuExplode elementSchema

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuGenerateSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuGenerateSuite.scala
@@ -28,13 +28,34 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.{GpuSplitAndRetryOOM, RmmSpark}
 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
-import org.apache.spark.sql.types.{ArrayType, DataType, IntegerType, MapType}
+import org.apache.spark.sql.types.{ArrayType, DataType, IntegerType, MapType, StringType, StructType => SparkStructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuGenerateSuite
   extends RmmSparkRetrySuiteBase
     with SparkQueryCompareTestSuite {
   val rapidsConf = new RapidsConf(Map.empty[String, String])
+
+  test("GpuExplode/GpuPosExplode elementSchema for array and map children") {
+    // array element -> "col"; map element -> "key"/"value"; PosExplode prepends "pos"
+    val arr = AttributeReference("a", ArrayType(IntegerType))()
+    val map = AttributeReference("m", MapType(IntegerType, StringType))()
+    assertResult(new SparkStructType().add("col", IntegerType, nullable = true))(
+      GpuExplode(arr).elementSchema)
+    assertResult(new SparkStructType()
+        .add("pos", IntegerType, nullable = false)
+        .add("col", IntegerType, nullable = true))(
+      GpuPosExplode(arr).elementSchema)
+    assertResult(new SparkStructType()
+        .add("key", IntegerType, nullable = false)
+        .add("value", StringType, nullable = true))(
+      GpuExplode(map).elementSchema)
+    assertResult(new SparkStructType()
+        .add("pos", IntegerType, nullable = false)
+        .add("key", IntegerType, nullable = false)
+        .add("value", StringType, nullable = true))(
+      GpuPosExplode(map).elementSchema)
+  }
 
   def makeListColumn(
       numRows: Int,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostColumnBuilderSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostColumnBuilderSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostColumnBuilderSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostColumnBuilderSuite.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.DType
-import ai.rapids.cudf.HostColumnVector.BasicType
+import ai.rapids.cudf.HostColumnVector.{BasicType, ListType, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
 class RapidsHostColumnBuilderSuite extends AnyFunSuite {
@@ -37,5 +37,55 @@ class RapidsHostColumnBuilderSuite extends AnyFunSuite {
     v2.close()
     b1.close()
     b2.close()
+  }
+
+  test("appendLists walks appendChildOrNull for typed and null list elements") {
+    // appendLists -> append(List) -> appendChildOrNull: one arm per element type, plus the null arm
+    def buildList(childType: DType, elems: AnyRef*): Unit = {
+      val lt = new ListType(true, new BasicType(true, childType))
+      val b = new RapidsHostColumnBuilder(lt, 1)
+      try {
+        b.appendLists(java.util.Arrays.asList(elems: _*))
+        val v = b.build()
+        try {
+          assertResult(1L)(v.getRowCount)
+        } finally {
+          v.close()
+        }
+      } finally {
+        b.close()
+      }
+    }
+    buildList(DType.INT32, Integer.valueOf(1), null, Integer.valueOf(3))
+    buildList(DType.INT64, java.lang.Long.valueOf(1L), null)
+    buildList(DType.FLOAT64, java.lang.Double.valueOf(1.0d), null)
+    buildList(DType.FLOAT32, java.lang.Float.valueOf(1.0f), null)
+    buildList(DType.BOOL8, java.lang.Boolean.TRUE, null)
+    buildList(DType.STRING, "a", null)
+  }
+
+  test("captureState then restoreState rolls back appended struct rows including children") {
+    val st = new StructType(true,
+      new BasicType(true, DType.INT32),
+      new BasicType(true, DType.INT32))
+    val b = new RapidsHostColumnBuilder(st, 4)
+    try {
+      b.getChild(0).append(1)
+      b.getChild(1).append(10)
+      b.endStruct()
+      val snapshot = b.captureState()
+      b.getChild(0).append(2)
+      b.getChild(1).append(20)
+      b.endStruct()
+      b.restoreState(snapshot)
+      val v = b.build()
+      try {
+        assertResult(1L)(v.getRowCount)
+      } finally {
+        v.close()
+      }
+    } finally {
+      b.close()
+    }
   }
 }


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +51 lines** (`RapidsHostColumnBuilder` +34, `GpuExplodeBase` +17; shim 350, vs IT-inclusive nightly b22).

## Summary
Adds net-new `sql-plugin` line coverage for three code paths that the **IT-inclusive nightly does not line-cover** — verified by merging this PR's UT `.exec` onto the nightly `final-aggregate.exec` (which already aggregates the Python integration tests) and diffing. Both target classes are already substantially covered by IT (`RapidsHostColumnBuilder` 79%, `GpuExplodeBase` 89%); this PR covers the IT-missed remainder. Both changes extend existing suites.

- `RapidsHostColumnBuilderSuite`: `appendLists` with typed and null list elements drives `appendChildOrNull` (its per-type arms + the null arm); `captureState`/`restoreState` on a struct builder drives `restoreState` including the child-recursion path.
- `GpuGenerateSuite`: `GpuExplode`/`GpuPosExplode` `elementSchema` for array and map children (both position branches).

## Test plan
- [x] Local validation (shim 350): `Tests: succeeded 29, failed 0, canceled 0, ignored 0, pending 0` (`RapidsHostColumnBuilderSuite` + `GpuGenerateSuite`; the 3 new tests pass).

## Coverage impact
Measured net Δ over the IT-inclusive nightly b22 (rig pinned to the nightly commit; base reproduces the published `jacoco.csv` per class):
- `RapidsHostColumnBuilder`: 308 → 342 covered (81 → 47 missed) = **+34** — `restoreState` child-recursion rollback (only reached under OOM/split-and-retry, which IT does not trigger) plus the rare `appendChildOrNull` type/null arms.
- `GpuExplodeBase`: 195 → 212 covered (23 → 6 missed) = **+17** — the `elementSchema` array/map × position arms, which explode/posexplode IT reaches at the class level but never line-covers.

These lines are not covered by the integration tests, so the merge-diff confirms +51 genuinely-new covered lines (not a UT-only-baseline artifact).

Contributes to #14991 (under epic #14899).

## Checklist
Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
