### PR TITLE
Drop the regex line-anchor CRLF workaround now that cuDF #22763 landed

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -57,10 +57,9 @@ class GpuRegExpReplaceMeta(
                   replacement)
           // Use the user's Java pattern group count for the greedy-with-backoff parse so that
           // user-authored backref tokens (e.g. `$13` on a 12-group pattern) follow Java's
-          // `Matcher.appendReplacement` spec. The transpiler emits internally-generated
-          // backrefs (e.g. the line-anchor rewrite's captured terminator) in braced
-          // `${N}` form, which `backrefConversion` passes through verbatim and which the
-          // user count therefore does not need to cover.
+          // `Matcher.appendReplacement` spec. Backrefs already emitted in braced `${N}` form
+          // are treated as resolved by the replacement AST and do not need to be covered by
+          // the user pattern's group count.
           val userNumCaptureGroups =
             java.util.regex.Pattern.compile(s.toString).matcher("").groupCount()
           repl.map { r =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1084,8 +1084,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
               throw new RegexUnsupportedException(
                       "Regex sequences with \\b or \\B not supported around $", regex.position)
             case _ =>
-              // LAYER2 PROBE (cudf #22763): cuDF now treats \r\n as one line terminator under
-              // EXT_NEWLINE, so emit the anchor directly instead of the (\r\n)? synthetic group.
+              // cuDF #22763 makes EXT_NEWLINE treat \r\n as one line terminator for $, so emit
+              // the anchor directly instead of the (\r\n)? synthetic group it needed before.
               RegexChar('$')
           }
         case '^' if mode == RegexSplitMode =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -853,20 +853,6 @@ class CudfRegexTranspiler(mode: RegexMode) {
 
   private val lineTerminatorChars = Seq('\n', '\r', '\u0085', '\u2028', '\u2029')
 
-  // from Java 8 documention: a line terminator is a 1 to 2 character sequence that marks
-  // the end of a line of an input character sequence.
-  // this method produces a RegexAST which outputs a regular expression to match any possible
-  // combination of line terminators.
-  // Cudf added support to identify \n, \r, \u0085, \u2028, \u2029 as line break characters
-  // when EXT_NEWLINE flag is set. See issue: https://github.com/NVIDIA/spark-rapids/issues/11554
-  private def lineTerminatorMatcher(excludeCRLF: Boolean, capture: Boolean): RegexAST = {
-    if (excludeCRLF) {
-      RegexEmpty()
-    } else {
-      RegexGroup(capture = capture, RegexSequence(ListBuffer(RegexChar('\r'), RegexChar('\n'))),
-          None)
-    }
-  }
 
   private def negateCharacterClass(
       components: ListBuffer[RegexCharacterClassComponent]): RegexAST = {
@@ -1098,17 +1084,9 @@ class CudfRegexTranspiler(mode: RegexMode) {
               throw new RegexUnsupportedException(
                       "Regex sequences with \\b or \\B not supported around $", regex.position)
             case _ =>
-              // otherwise by default we can match any or none the full set of line terminators
-              if (mode == RegexReplaceMode) {
-                replacement match {
-                  case Some(rr) => rr.appendBackref(rr.numCaptureGroups + 1)
-                  case _ =>
-                }
-              }
-              RegexSequence(ListBuffer(
-                RegexRepetition(lineTerminatorMatcher(excludeCRLF = false,
-                    capture = mode == RegexReplaceMode), SimpleQuantifier('?')),
-                RegexChar('$')))
+              // LAYER2 PROBE (cudf #22763): cuDF now treats \r\n as one line terminator under
+              // EXT_NEWLINE, so emit the anchor directly instead of the (\r\n)? synthetic group.
+              RegexChar('$')
           }
         case '^' if mode == RegexSplitMode =>
           RegexEscaped('A')

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1925,9 +1925,9 @@ sealed case class RegexBackref(num: Int, isNew: Boolean = false) extends RegexAS
     this.position = Some(position)
   }
   override def children(): Seq[RegexAST] = Seq.empty
-  // Internally-generated backrefs (e.g. from line-anchor rewriting) are emitted in braced
-  // `${N}` form so `backrefConversion` can tell them apart from user-authored `$N` tokens
-  // and pass them through verbatim. User-authored backrefs keep the raw `$N` form so the
+  // Backrefs marked as internally generated are emitted in braced `${N}` form so
+  // `backrefConversion` can tell them apart from user-authored `$N` tokens and pass them
+  // through verbatim. User-authored backrefs keep the raw `$N` form so the
   // greedy-with-backoff parser in `backrefConversion` honors the user's pattern group count.
   override def toRegexString: String = if (isNew) s"$${$num}" else s"$$$num"
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1075,11 +1075,6 @@ class CudfRegexTranspiler(mode: RegexMode) {
                 && lineTerminatorChars.contains(ch) =>
                 throw new RegexUnsupportedException("Regex sequences with a line terminator "
                     + "character followed by '$' are not supported in replace mode", regex.position)
-            case Some(RegexChar(ch)) if ch == '\r' =>
-              // when using the the CR (\r), it prevents the line anchor from handling any other
-              // line terminator sequences, so we just output the anchor and we are finished
-              // for example: \r$ -> \r$ (no transpilation)
-              RegexChar('$')
             case Some(RegexEscaped('b')) | Some(RegexEscaped('B')) =>
               throw new RegexUnsupportedException(
                       "Regex sequences with \\b or \\B not supported around $", regex.position)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1097,11 +1097,9 @@ object GpuRegExpUtils {
     var i = 0
     var hasBracedBackref = false
     while (i < rep.length) {
-      // Pass through already-braced `${N}` tokens unchanged. These are emitted by the
-      // transpiler for internally-generated backrefs (e.g. the line-anchor rewrite's
-      // captured line terminator) and must not be re-parsed against the user pattern's
-      // group count, which would mis-resolve them when the user count is less than the
-      // generated index.
+      // Pass through already-braced `${N}` tokens unchanged. The replacement AST uses this
+      // form for backrefs that have already been resolved by the transpiler, so re-parsing
+      // them against the caller-provided group count could change their meaning.
       if (rep.charAt(i) == '$' && i + 2 < rep.length && rep.charAt(i + 1) == '{') {
         val close = rep.indexOf('}', i + 2)
         val allDigits = close > i + 2 &&

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,18 @@ class RegularExpressionSuite extends SparkQueryCompareTestSuite {
     nullableStringsFromCsv, conf = conf) { frame =>
       assume(isUnicodeEnabled())
       frame.selectExpr("regexp_replace(strings,'\\(foo\\)','D')")
+  }
+
+  // #14856 / revans2: anchored alternation with a backref. With the old (\r\n)? workaround the
+  // synthetic group shifted (E) to group 2, so [$1] referenced the wrong group; once the
+  // workaround is dropped (cudf #22763) (E) stays group 1 and GPU must match CPU here.
+  testSparkResultsAreEqual("regexp_replace anchored alternation backref T$|(E)",
+    spark => {
+      import spark.implicits._
+      Seq("T", "E", "TE", "ET", "xExE", "T\r\nE", "E\r\n").toDF("strings")
+    }, conf = conf) { frame =>
+      assume(isUnicodeEnabled())
+      frame.selectExpr("regexp_replace(strings, 'T$|(E)', '[$1]')")
   }
 
   testSparkResultsAreEqual("String regexp_extract regex 1", extractStrings, conf = conf) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -481,6 +481,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
 
   test("transpile \\Z") {
     val expected = "a$"
+    doTranspileTest("a$", expected)
     doTranspileTest("a\\Z", expected)
     doTranspileTest("a\\Z+", expected)
     doTranspileTest("a\\Z{1}", expected)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -466,7 +466,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     doTranspileTest(TIMESTAMP_TRUNCATE_REGEX,
       TIMESTAMP_TRUNCATE_REGEX
         .replaceAll("\\.", "[^\n\r\u0085\u2028\u2029]")
-        .replaceAll("\\\\Z", "(?:\r\n)?\\$"))
+        .replaceAll("\\\\Z", "\\$"))
   }
 
   test("transpile \\A repetitions") {
@@ -480,11 +480,11 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
   }
 
   test("transpile $") {
-    doTranspileTest("a$", "a(?:\r\n)?$")
+    doTranspileTest("a$", "a$")
   }
 
   test("transpile \\Z") {
-    val expected = "a(?:\r\n)?$"
+    val expected = "a$"
     doTranspileTest("a\\Z", expected)
     doTranspileTest("a\\Z+", expected)
     doTranspileTest("a\\Z{1}", expected)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -479,10 +479,6 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     assertUnsupported("abc\\z", RegexFindMode, "")
   }
 
-  test("transpile $") {
-    doTranspileTest("a$", "a$")
-  }
-
   test("transpile \\Z") {
     val expected = "a$"
     doTranspileTest("a\\Z", expected)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -264,36 +264,34 @@ class RegExpUtilsSuite extends AnyFunSuite {
     }
   }
 
-  test("issue-14743: line-anchor rewrite preserves user-vs-generated backref boundary") {
-    // A 12-group user pattern ending in line-anchor `$` causes the transpiler to append an
-    // internally-generated 13th capture group (for the captured line terminator) plus a
-    // matching backref in the replacement. The user-authored replacement tokens must be
-    // parsed against the user's 12-group count (Java spec), while the generated `$13`
-    // must round-trip to cuDF as `${13}`. The transpiler emits the generated backref in
-    // braced form so `backrefConversion` can tell the two apart from a single string.
+  test("line-anchor `$` no longer injects a synthetic capture group or generated backref " +
+      "(#15006, cuDF #22763)") {
+    // cuDF #22763 makes EXT_NEWLINE treat `\r\n` as a single line terminator for `$`, so the
+    // transpiler emits a bare `$` instead of the old synthetic `(\r\n)?$` capture group. With no
+    // synthetic group there is no internally-generated backref appended to the replacement, and a
+    // user pattern ending in `$` no longer shifts backref numbering: user `$N` parses against the
+    // real user group count (Java spec).
     val open = "$" + "{"
     val userPattern = "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$"
     val userNumCaptureGroups =
       java.util.regex.Pattern.compile(userPattern).matcher("").groupCount()
     assert(userNumCaptureGroups == 12)
 
-    // Case 1: user replacement `$123$2` -> `$12` + literal `3` + `$2`, plus generated `${13}`.
+    // user replacement `$123$2` -> `$12` + literal `3` + `$2`, with no trailing generated group.
     val (_, repl1) = new CudfRegexTranspiler(RegexReplaceMode)
       .getTranspiledAST(userPattern, None, Some("$123$2"))
     val (has1, conv1) =
       GpuRegExpUtils.backrefConversion(repl1.get.toRegexString, userNumCaptureGroups)
     assert(has1)
-    assert(conv1 == open + "12}3" + open + "2}" + open + "13}")
+    assert(conv1 == open + "12}3" + open + "2}")
 
-    // Case 2: user replacement `$13` with only 12 user groups MUST parse as `$1` + literal
-    // `3`, NOT as a reference to the internally-generated 13th group. The generated
-    // `${13}` still rides along after the user portion.
+    // user replacement `$13` with only 12 user groups MUST back off to `$1` + literal `3`.
     val (_, repl2) = new CudfRegexTranspiler(RegexReplaceMode)
       .getTranspiledAST(userPattern, None, Some("$13"))
     val (has2, conv2) =
       GpuRegExpUtils.backrefConversion(repl2.get.toRegexString, userNumCaptureGroups)
     assert(has2)
-    assert(conv2 == open + "1}3" + open + "13}",
+    assert(conv2 == open + "1}3",
       s"expected user `$$13` to back off to `$${1}3`, got `$conv2`")
   }
 }


### PR DESCRIPTION
## Summary

cuDF rapidsai/cudf#22763 (merged) makes `EXT_NEWLINE` treat `\r\n` as a single line terminator for `^`/`$`, matching JDK/Spark semantics at the cuDF root. With that in place the transpiler no longer needs to rewrite `$` into the synthetic `(\r\n)?$` group: this PR emits a bare `$` and removes `lineTerminatorMatcher`. Dropping the synthetic capture group removes the cuDF group-index shift that is the documented root cause of the regex backref-renumbering bug class (#14735 / #14855 / #14856 / #14926) — fixing it at the source instead of patching the renumbering.

Supersedes #14856, which patched the renumbering inside the workaround; revans2 noted that approach was still wrong for `T$|(E)` with a `[$1]` replacement. Dropping the synthetic group makes `(E)` group 1 again, so `[$1]` is correct with no renumbering needed.

## Unblocked — cuDF #22763 is now in the consumed JNI

The JNI-bump blocker is cleared. cuDF #22763 (merge `655fca65f6`, merged 2026-06-09) rolled into `spark-rapids-jni` main via the submodule-sync bot on 2026-06-10 06:03 UTC (JNI commit `96eb453879`); every `26.08.0-SNAPSHOT` JNI nightly since bundles it. This PR consumes `spark-rapids-jni.version = 26.08.0-SNAPSHOT`, whose cuDF pin is now ahead of `655fca65f6` (verified via the cuDF compare API). Marking ready and running premerge against the fixed JNI.

## Local validation (against a #22763-enabled JNI)

Built a spark-rapids-jni jar with cuDF #22763 and ran the regex UT suites with this change:

```
Tests: succeeded 136, failed 0, canceled 7, ignored 0, pending 0
```

`RegularExpressionParserSuite`, `RegularExpressionRewriteSuite`, `RegularExpressionSuite`, and `RegularExpressionTranspilerSuite` are all green. The new GPU-vs-CPU regression test `regexp_replace anchored alternation backref T$|(E)` passes — GPU output matches Spark/Java CPU on revans2's exact case, and it runs on GPU (not a CPU fallback).

## Changes

- `RegexParser`: the `$`/`\Z` rewrite emits a bare `$`; remove the now-unused private `lineTerminatorMatcher`.
- `RegularExpressionTranspilerSuite`: update three transpiler-output assertions from `a(?:\r\n)?$` to `a$` (`transpile $`, `transpile \Z`, `transpile complex regex 2`).
- `RegularExpressionSuite`: add the `T$|(E)` + `[$1]` GPU-vs-CPU regression test.

Follow-up (separate, not in this PR), tracked in #15060: remove the now-dead synthetic-group backref machinery (`appendBackref`, `popBackref`, `popBackrefIfNecessary`, `RegexBackref.isNew`) left behind by dropping the synthetic group.

## Performance

Transpilation runs at query-plan time (once per query compile), not per row — cold path. This change shrinks the transpiler AST (drops a `RegexRepetition` group) and skips the backref-append pass; there is no runtime/per-row impact.

Closes #15006

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required





JaCoCo sql-plugin line coverage: +2 lines.
