### PR TITLE
Add stable columnar file format strings

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -193,6 +193,8 @@ object GpuParquetFileFormat {
 }
 
 class GpuParquetFileFormat extends ColumnarFileFormat with Logging {
+  override def toString: String = "Parquet"
+
   /**
    * Prepares a write job and returns an [[ColumnarOutputWriterFactory]].  Client side job
    * preparation can be put here.  For example, user defined output committer can be configured

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveFileFormat.scala
@@ -201,6 +201,8 @@ object GpuHiveFileFormat extends Logging {
 class GpuHiveParquetFileFormat(compType: CompressionType) extends ColumnarFileFormat
     with Logging with Serializable {
 
+  override def toString: String = "Parquet"
+
   override def prepareWrite(sparkSession: SparkSession, job: Job,
       options: Map[String, String], dataSchema: StructType): ColumnarOutputWriterFactory = {
 
@@ -265,6 +267,8 @@ class GpuHiveParquetWriter(override val path: String, dataSchema: StructType,
 }
 
 class GpuHiveTextFileFormat extends ColumnarFileFormat with Logging with Serializable {
+
+  override def toString: String = "HiveText"
 
   override def supportDataType(dataType: DataType): Boolean =
     GpuHiveTextFileUtils.isSupportedType(dataType)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,6 +163,8 @@ object GpuOrcFileFormat extends Logging {
 }
 
 class GpuOrcFileFormat extends ColumnarFileFormat with Logging {
+  override def toString: String = "ORC"
+
   /**
    * Prepares a write job and returns an `ColumnarOutputWriterFactory`.  Client side job
    * preparation can be put here.  For example, user defined output committer can be configured here

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ColumnarFileFormatSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ColumnarFileFormatSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.CompressionType
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.hive.rapids.{GpuHiveParquetFileFormat, GpuHiveTextFileFormat}
+import org.apache.spark.sql.rapids.GpuOrcFileFormat
+
+class ColumnarFileFormatSuite extends AnyFunSuite {
+  test("file formats have stable pretty strings") {
+    assertResult("Parquet") {
+      new GpuParquetFileFormat().toString
+    }
+    assertResult("ORC") {
+      new GpuOrcFileFormat().toString
+    }
+    assertResult("HiveText") {
+      new GpuHiveTextFileFormat().toString
+    }
+    assertResult("Parquet") {
+      new GpuHiveParquetFileFormat(CompressionType.SNAPPY).toString
+    }
+  }
+}


### PR DESCRIPTION
Fixes #12226.

### Description

This adds stable `toString` values for the four GPU `ColumnarFileFormat` implementations called out in the issue. Event logs previously rendered these objects with the JVM default form, such as `com.nvidia.spark.rapids.GpuParquetFileFormat@...`, which made the `format` field noisy and coupled downstream consumers to RAPIDS implementation class names.

After this change, Parquet formats render as `Parquet`, ORC as `ORC`, and Hive text as `HiveText`. These names line up with the existing file-format labels used by the plugin and avoid exposing package/class details in Spark event logs.

I also added a small ScalaTest suite that directly checks the string representation for `GpuParquetFileFormat`, `GpuOrcFileFormat`, `GpuHiveParquetFileFormat`, and `GpuHiveTextFileFormat`.

Local verification:
- `git diff --check`

I could not run the focused ScalaTest command locally because this environment does not have `mvn`, `mvnw`, `scala`, `scalac`, or `sbt` installed.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
