### PR TITLE
Fix byte position accounting in cached batch output

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetCachedBatchSerializer.scala
@@ -147,7 +147,7 @@ private class ByteArrayOutputFile(stream: ByteArrayOutputStream) extends OutputF
 
       override def write(b: Int): Unit = {
         super.write(b)
-        pos += Integer.BYTES
+        pos += 1
       }
 
       override def write(b: Array[Byte]): Unit = {


### PR DESCRIPTION
No issue filed.

### Description

Fix byte position accounting in the cached batch parquet output stream. `OutputStream.write(int)` writes one byte, so the tracked position should advance by one byte.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required