### PR TITLE
Validate cached batch input seek bounds

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetCachedBatchSerializer.scala
@@ -125,7 +125,7 @@ class ByteArrayInputFile(buff: Array[Byte]) extends InputFile {
       override def getPos: Long = byteBuffer.position()
 
       override def seek(newPos: Long): Unit = {
-        if (newPos > Int.MaxValue || newPos < Int.MinValue) {
+        if (newPos < 0 || newPos > buff.length) {
           throw new IllegalStateException("seek value is out of supported range " + newPos)
         }
         byteBuffer.position(newPos.toInt)


### PR DESCRIPTION
No issue filed.

### Description

Tighten the cached batch parquet input stream seek validation so it accepts only positions within the backing byte array. This gives a clear error before calling into `ByteBuffer.position`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required