### PR TITLE
Skip test_bit_count[Boolean] under Spark testing mode before Spark 4.0.0 (SPARK-48128)

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -908,7 +908,12 @@ def test_bit_not(data_gen):
             lambda spark : unary_op_df(spark, data_gen).selectExpr('~a'))
 
 
-@pytest.mark.parametrize('data_gen', integral_gens + boolean_gens, ids=idfn)
+# SPARK-48128: bit_count(boolean) CPU whole-stage codegen is broken before Spark 4.0.0 and only
+# fails when spark.testing disables the codegen->interpreted fallback (see #15022, #15097).
+@pytest.mark.parametrize('data_gen', integral_gens + [pytest.param(boolean_gen,
+    marks=pytest.mark.skipif(is_before_spark_400() and is_spark_testing_enabled(),
+        reason='SPARK-48128 bit_count(boolean) codegen bug exposed by spark.testing; fixed in Spark 4.0.0'))],
+    ids=idfn)
 def test_bit_count(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('bit_count(a)'))

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -219,14 +219,6 @@ def is_spark_350_or_351():
 def is_before_spark_400():
     return spark_version() < "4.0.0"
 
-def is_spark_testing_enabled():
-    # True when Spark testing mode is on (-Dspark.testing or the SPARK_TESTING env var), mirroring
-    # org.apache.spark.util.Utils.isTesting. NVIDIA/spark-rapids#15022 enables it for the nightly,
-    # which disables WholeStageCodegenExec's fallback from a codegen CompileException to interpreted
-    # execution, so latent Spark codegen bugs become hard failures instead of being swallowed.
-    return (_spark.sparkContext._jvm.System.getProperty("spark.testing") is not None
-            or _spark.sparkContext._jvm.System.getenv("SPARK_TESTING") is not None)
-
 def is_spark_320_or_later():
     return spark_version() >= "3.2.0"
 
@@ -342,6 +334,14 @@ def supports_delta_lake_deletion_vectors():
 def is_support_default_values_in_schema():
     # Spark 340 + and Databricks 330 + support
     return is_spark_340_or_later() or is_databricks113_or_later()
+
+def is_spark_testing_enabled():
+    # True when Spark testing mode is on (-Dspark.testing or the SPARK_TESTING env var), mirroring
+    # org.apache.spark.util.Utils.isTesting. NVIDIA/spark-rapids#15022 enables it for the nightly,
+    # which disables WholeStageCodegenExec's fallback from a codegen CompileException to interpreted
+    # execution, so latent Spark codegen bugs become hard failures instead of being swallowed.
+    return (_spark.sparkContext._jvm.System.getProperty("spark.testing") is not None
+            or _spark.sparkContext._jvm.System.getenv("SPARK_TESTING") is not None)
 
 def get_java_major_version():
     ver = _spark.sparkContext._jvm.System.getProperty("java.version")

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -219,6 +219,14 @@ def is_spark_350_or_351():
 def is_before_spark_400():
     return spark_version() < "4.0.0"
 
+def is_spark_testing_enabled():
+    # True when Spark testing mode is on (-Dspark.testing or the SPARK_TESTING env var), mirroring
+    # org.apache.spark.util.Utils.isTesting. NVIDIA/spark-rapids#15022 enables it for the nightly,
+    # which disables WholeStageCodegenExec's fallback from a codegen CompileException to interpreted
+    # execution, so latent Spark codegen bugs become hard failures instead of being swallowed.
+    return (_spark.sparkContext._jvm.System.getProperty("spark.testing") is not None
+            or _spark.sparkContext._jvm.System.getenv("SPARK_TESTING") is not None)
+
 def is_spark_320_or_later():
     return spark_version() >= "3.2.0"
 


### PR DESCRIPTION
Closes #15097

Root cause — SPARK-48128 (CPU-side Spark codegen bug, surfaced by #15022 enabling `spark.testing` for the nightly; fixed in Spark 4.0.0): https://github.com/NVIDIA/spark-rapids/issues/15097#issuecomment-4725377882

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
