### PR TITLE
Update NVIDIA Pages links [skip ci]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase.scala
@@ -221,7 +221,7 @@ class GpuDeltaParquetFileFormatBase(
       logWarning("Coalescing is not supported when `delta.enableDeletionVectors=true`, " +
         "using the multi-threaded reader. For more details on the Parquet reader types " +
         "please look at 'spark.rapids.sql.format.parquet.reader.type' config at " +
-        "https://nvidia.github.io/spark-rapids/docs/additional-functionality/advanced_configs.html")
+        "https://nvidia.github.io/cudf-spark/docs/additional-functionality/advanced_configs.html")
     }
 
     new DeltaMultiFileReaderFactory(

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <version>26.08.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <url>https://nvidia.github.io/spark-rapids/</url>
+    <url>https://nvidia.github.io/cudf-spark/</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -26,7 +26,7 @@
     <version>26.08.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <url>https://nvidia.github.io/spark-rapids/</url>
+    <url>https://nvidia.github.io/cudf-spark/</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/skills/README.md
+++ b/skills/README.md
@@ -43,7 +43,7 @@ npx skills add NVIDIA/spark-rapids --skill '*' [--agent <agent>]
 
 - **[Maven](https://maven.apache.org/install.html)** is required to build/compile UDFs.
 - **[JDK](https://docs.oracle.com/en/java/javase/index.html)** must be installed on the system.
-- **Local GPU** with [CUDA toolkit](https://developer.nvidia.com/cuda/toolkit) is required (see [Spark RAPIDS compatibility](https://nvidia.github.io/spark-rapids/docs/download.html) for version requirements).
+- **Local GPU** with [CUDA toolkit](https://developer.nvidia.com/cuda/toolkit) is required (see [Spark RAPIDS compatibility](https://nvidia.github.io/cudf-spark/docs/download.html) for version requirements).
 
 If a local GPU is not available, another option is to run Aether Agent from a cloud instance, such as AWS EC2.
 

--- a/skills/udf-convert-to-cuda/references/NATIVE_BUILD_ENV.md
+++ b/skills/udf-convert-to-cuda/references/NATIVE_BUILD_ENV.md
@@ -30,7 +30,7 @@ The native build compiles against the prebuilt libcudf in the spark-rapids jar, 
 1. Get the CUDA version(s) spark-rapids is built against:
 
 ```bash
-curl -fsSL https://nvidia.github.io/spark-rapids/docs/download.html \
+curl -fsSL https://nvidia.github.io/cudf-spark/docs/download.html \
   | grep -Eo '[^<>]*built against CUDA[^<>]*'
 ```
 

--- a/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -285,7 +285,7 @@ object ShimLoader {
         s"This RAPIDS Plugin build does not support Spark build ${sparkVersion}. " +
           s"Supported Spark versions: ${supportedVersions}. " +
           "Consult the Release documentation at " +
-          "https://nvidia.github.io/spark-rapids/docs/download.html")
+          "https://nvidia.github.io/cudf-spark/docs/download.html")
     }
   }
 


### PR DESCRIPTION
No issue.

### Description

This updates the remaining NVIDIA GitHub Pages links that still point to `https://nvidia.github.io/spark-rapids` so they use the renamed `https://nvidia.github.io/cudf-spark` documentation site.

The change covers root POM project URLs, runtime error/help links, and skills documentation references. It does not change plugin behavior.

Validation performed:
- `git diff --check`
- `rg -l "nvidia\.github\.io/spark-rapids" --hidden --glob "!.git/**"` returned no files
- Verified the updated root, download, advanced configs, and NVTX profiling documentation URLs return HTTP 200

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required