### PR TITLE
[AutoSparkUT] Fix ORC coalescing ignoreMissingFiles

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -652,19 +652,24 @@ case class GpuOrcMultiFilePartitionReaderFactory(
 
     metrics.getOrElse(FILTER_TIME, NoopMetric).ns {
       metrics.getOrElse(SCAN_TIME, NoopMetric).ns {
-        files.map { file =>
-          val orcPartitionReaderContext = filterHandler.filterStripes(file, dataSchema,
-            readDataSchema, partitionSchema)
-          compressionAndStripes.getOrElseUpdate(orcPartitionReaderContext.compressionKind,
-            new ArrayBuffer[OrcSingleStripeMeta]) ++=
-            orcPartitionReaderContext.blockIterator.map(block =>
-              OrcSingleStripeMeta(
-                orcPartitionReaderContext.filePath,
-                OrcDataStripe(OrcStripeWithMeta(block, orcPartitionReaderContext)),
-                file.partitionValues,
-                OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
-                readDataSchema,
-                OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
+        files.foreach { file =>
+          try {
+            val orcPartitionReaderContext = filterHandler.filterStripes(file, dataSchema,
+              readDataSchema, partitionSchema)
+            compressionAndStripes.getOrElseUpdate(orcPartitionReaderContext.compressionKind,
+              new ArrayBuffer[OrcSingleStripeMeta]) ++=
+              orcPartitionReaderContext.blockIterator.map(block =>
+                OrcSingleStripeMeta(
+                  orcPartitionReaderContext.filePath,
+                  OrcDataStripe(OrcStripeWithMeta(block, orcPartitionReaderContext)),
+                  file.partitionValues,
+                  OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
+                  readDataSchema,
+                  OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
+          } catch {
+            case e: FileNotFoundException if ignoreMissingFiles =>
+              logWarning(s"Skipped missing file: ${file.filePath}", e)
+          }
         }
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -656,16 +656,20 @@ case class GpuOrcMultiFilePartitionReaderFactory(
           try {
             val orcPartitionReaderContext = filterHandler.filterStripes(file, dataSchema,
               readDataSchema, partitionSchema)
-            compressionAndStripes.getOrElseUpdate(orcPartitionReaderContext.compressionKind,
-              new ArrayBuffer[OrcSingleStripeMeta]) ++=
-              orcPartitionReaderContext.blockIterator.map(block =>
-                OrcSingleStripeMeta(
-                  orcPartitionReaderContext.filePath,
-                  OrcDataStripe(OrcStripeWithMeta(block, orcPartitionReaderContext)),
-                  file.partitionValues,
-                  OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
-                  readDataSchema,
-                  OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
+            // filterStripes returns null for an empty ORC file; it has no stripes to
+            // contribute, so skip it (the single-file path uses an EmptyPartitionReader).
+            if (orcPartitionReaderContext != null) {
+              compressionAndStripes.getOrElseUpdate(orcPartitionReaderContext.compressionKind,
+                new ArrayBuffer[OrcSingleStripeMeta]) ++=
+                orcPartitionReaderContext.blockIterator.map(block =>
+                  OrcSingleStripeMeta(
+                    orcPartitionReaderContext.filePath,
+                    OrcDataStripe(OrcStripeWithMeta(block, orcPartitionReaderContext)),
+                    file.partitionValues,
+                    OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
+                    readDataSchema,
+                    OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
+            }
           } catch {
             case e: FileNotFoundException if ignoreMissingFiles =>
               logWarning(s"Skipped missing file: ${file.filePath}", e)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -19,8 +19,9 @@ package com.nvidia.spark.rapids
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
 import org.apache.spark.sql.types.{DateType, IntegerType, LongType, StringType, StructField, StructType}
@@ -107,12 +108,17 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
           new Path(basePath, "second").toString,
           thirdPath.toString,
           new Path(basePath, "fourth").toString)
-
+        val hasGpuScan = df.queryExecution.executedPlan.collect {
+          case scan: GpuFileSourceScanExec =>
+            scan.selectedPartitions
+            true
+          case scan: FileSourceScanExec =>
+            scan.selectedPartitions
+            false
+        }
+        assert(hasGpuScan.nonEmpty, "ORC read does not have a file source scan")
         if (checkGpu) {
-          val gpuScans = df.queryExecution.executedPlan.collect {
-            case _: GpuFileSourceScanExec => true
-          }
-          assert(gpuScans.nonEmpty, "ORC read is not running on GPU")
+          assert(hasGpuScan.contains(true), "ORC read is not running on GPU")
         }
 
         filesToDelete.foreach(file => fs.delete(file, false))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import java.io.FileNotFoundException
+
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
@@ -138,6 +140,68 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
 
     assertResult(Seq("0", "1"))(cpuResult)
     assertResult(cpuResult)(gpuResult)
+  }
+
+  private def causedByFileNotFound(t: Throwable): Boolean =
+    Iterator.iterate(t)(_.getCause).takeWhile(_ != null)
+      .exists(_.isInstanceOf[FileNotFoundException])
+
+  test("ORC coalescing reader throws FileNotFoundException when ignoreMissingFiles is false") {
+    def collectAfterDeletingPlannedFiles(spark: SparkSession, checkGpu: Boolean): Unit = {
+      import spark.implicits._
+
+      withTempPath { base =>
+        val basePath = base.getCanonicalPath
+
+        Seq("0").toDF("a").write.mode("overwrite").format("orc")
+          .save(new Path(basePath, "second").toString)
+        Seq("1").toDF("a").write.mode("overwrite").format("orc")
+          .save(new Path(basePath, "fourth").toString)
+
+        val firstPath = new Path(basePath, "first")
+        val thirdPath = new Path(basePath, "third")
+        val fs = thirdPath.getFileSystem(spark.sessionState.newHadoopConf())
+
+        Seq("2").toDF("a").write.mode("overwrite").format("orc").save(firstPath.toString)
+        Seq("3").toDF("a").write.mode("overwrite").format("orc").save(thirdPath.toString)
+
+        val filesToDelete = Seq(firstPath, thirdPath).flatMap { path =>
+          fs.listStatus(path).filter(_.isFile).map(_.getPath)
+        }
+        val df = spark.read.format("orc").load(
+          firstPath.toString,
+          new Path(basePath, "second").toString,
+          thirdPath.toString,
+          new Path(basePath, "fourth").toString)
+        val hasGpuScan = df.queryExecution.executedPlan.collect {
+          case scan: GpuFileSourceScanExec =>
+            scan.selectedPartitions
+            true
+          case scan: FileSourceScanExec =>
+            scan.selectedPartitions
+            false
+        }
+        assert(hasGpuScan.nonEmpty, "ORC read does not have a file source scan")
+        if (checkGpu) {
+          assert(hasGpuScan.contains(true), "ORC read is not running on GPU")
+        }
+
+        filesToDelete.foreach(file => fs.delete(file, false))
+        assert(fs.delete(thirdPath, true))
+
+        val e = intercept[Exception](df.collect())
+        assert(causedByFileNotFound(e),
+          s"Expected a FileNotFoundException when ignoreMissingFiles=false, but got: $e")
+      }
+    }
+
+    val conf = new SparkConf()
+      .set(SQLConf.USE_V1_SOURCE_LIST.key, "orc")
+      .set(SQLConf.IGNORE_MISSING_FILES.key, "false")
+      .set(RapidsConf.ORC_READER_TYPE.key, RapidsReaderType.COALESCING.toString)
+
+    withCpuSparkSession(collectAfterDeletingPlannedFiles(_, checkGpu = false), conf)
+    withGpuSparkSession(collectAfterDeletingPlannedFiles(_, checkGpu = true), conf)
   }
 
   /**

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 
 package com.nvidia.spark.rapids
 
+import org.apache.hadoop.fs.Path
+
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
 import org.apache.spark.sql.types.{DateType, IntegerType, LongType, StringType, StructField, StructType}
 
@@ -75,6 +79,60 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
           StructField("_col3", LongType),
           StructField("_col2", StringType),
           StructField("_col1", LongType))))) { frame => frame }
+
+  test("ORC coalescing reader honors ignoreMissingFiles") {
+    def collectAfterDeletingPlannedFiles(spark: SparkSession, checkGpu: Boolean): Seq[String] = {
+      import spark.implicits._
+
+      withTempPath { base =>
+        val basePath = base.getCanonicalPath
+
+        Seq("0").toDF("a").write.mode("overwrite").format("orc")
+          .save(new Path(basePath, "second").toString)
+        Seq("1").toDF("a").write.mode("overwrite").format("orc")
+          .save(new Path(basePath, "fourth").toString)
+
+        val firstPath = new Path(basePath, "first")
+        val thirdPath = new Path(basePath, "third")
+        val fs = thirdPath.getFileSystem(spark.sessionState.newHadoopConf())
+
+        Seq("2").toDF("a").write.mode("overwrite").format("orc").save(firstPath.toString)
+        Seq("3").toDF("a").write.mode("overwrite").format("orc").save(thirdPath.toString)
+
+        val filesToDelete = Seq(firstPath, thirdPath).flatMap { path =>
+          fs.listStatus(path).filter(_.isFile).map(_.getPath)
+        }
+        val df = spark.read.format("orc").load(
+          firstPath.toString,
+          new Path(basePath, "second").toString,
+          thirdPath.toString,
+          new Path(basePath, "fourth").toString)
+
+        if (checkGpu) {
+          val gpuScans = df.queryExecution.executedPlan.collect {
+            case _: GpuFileSourceScanExec => true
+          }
+          assert(gpuScans.nonEmpty, "ORC read is not running on GPU")
+        }
+
+        filesToDelete.foreach(file => fs.delete(file, false))
+        assert(fs.delete(thirdPath, true))
+
+        df.collect().map(_.getString(0)).sorted.toSeq
+      }
+    }
+
+    val conf = new SparkConf()
+      .set(SQLConf.USE_V1_SOURCE_LIST.key, "orc")
+      .set(SQLConf.IGNORE_MISSING_FILES.key, "true")
+      .set(RapidsConf.ORC_READER_TYPE.key, RapidsReaderType.COALESCING.toString)
+
+    val cpuResult = withCpuSparkSession(collectAfterDeletingPlannedFiles(_, checkGpu = false), conf)
+    val gpuResult = withGpuSparkSession(collectAfterDeletingPlannedFiles(_, checkGpu = true), conf)
+
+    assertResult(Seq("0", "1"))(cpuResult)
+    assertResult(cpuResult)(gpuResult)
+  }
 
   /**
    *


### PR DESCRIPTION
Closes #15100.

This fixes the ORC coalescing reader path so it honors `spark.files.ignoreMissingFiles` / `spark.sql.files.ignoreMissingFiles` during the metadata filtering step.

Root cause: the coalescing ORC reader reads ORC tail metadata in `filterStripes` before the later partition reader layer can apply the existing missing-file handling. If a planned ORC file disappears after planning, `filterStripes` throws `FileNotFoundException` and the GPU path fails even when Spark is configured to ignore missing files.

Changes:
- Catch `FileNotFoundException` during ORC coalescing stripe filtering only when `ignoreMissingFiles` is enabled.
- Keep all other ORC/schema/corruption errors unchanged.
- Add a regression test that plans an ORC scan, deletes a subset of planned files, forces the coalescing reader, and compares CPU/GPU results.

Validation:
```bash
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=com.nvidia.spark.rapids.OrcScanSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm
```

Result:
```text
BUILD SUCCESS
Tests: succeeded 11, failed 0, canceled 0, ignored 1, pending 0
```

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required



JaCoCo sql-plugin line coverage: +16 lines.
