### PR TITLE
Fix deadlock of RMM pool waits for task threads

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TaskRegistryTracker.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TaskRegistryTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TaskRegistryTracker.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TaskRegistryTracker.scala
@@ -32,6 +32,7 @@ import org.apache.spark.TaskContext
 object TaskRegistryTracker {
   private val taskToThread = new util.HashMap[Long, ArrayBuffer[Long]]()
   private val registeredThreads = new util.HashSet[Long]()
+  private val dedicatedTaskThreads = new util.HashSet[Long]()
 
   /**
    * Clear the registry. This is used for tests
@@ -46,7 +47,10 @@ object TaskRegistryTracker {
   private def taskIsDone(taskId: Long): Unit = synchronized {
     val threads = taskToThread.remove(taskId)
     if (threads != null) {
-      threads.foreach(registeredThreads.remove)
+      threads.foreach { threadId =>
+        registeredThreads.remove(threadId)
+        dedicatedTaskThreads.remove(threadId)
+      }
       RmmSpark.taskDone(taskId)
     }
   }
@@ -78,6 +82,7 @@ object TaskRegistryTracker {
       if (registeredThreads.add(threadId)) {
         if (addDedicatedThread) {
           RmmSpark.currentThreadIsDedicatedToTask(taskId)
+          dedicatedTaskThreads.add(threadId)
         }
         if (!taskToThread.containsKey(taskId)) {
           taskToThread.put(taskId, ArrayBuffer(threadId))
@@ -87,7 +92,35 @@ object TaskRegistryTracker {
         } else {
           taskToThread.get(taskId) += threadId
         }
+      } else if (addDedicatedThread && dedicatedTaskThreads.add(threadId)) {
+        RmmSpark.currentThreadIsDedicatedToTask(taskId)
       }
+    }
+  }
+
+  /**
+   * Returns true only when the current thread was registered as Spark's dedicated task thread.
+   */
+  def isCurrentThreadRegisteredAsDedicatedTaskThread: Boolean = synchronized {
+    dedicatedTaskThreads.contains(RmmSpark.getCurrentThreadId)
+  }
+
+  /**
+   * Mark this dedicated task thread as waiting on another pool while executing the body.
+   *
+   * RmmSpark throws if pool-wait APIs are called from a pool thread, so callers that can
+   * run from either task or helper threads should go through this guard.
+   */
+  def withRmmPoolWait[T](body: => T): T = {
+    if (isCurrentThreadRegisteredAsDedicatedTaskThread) {
+      RmmSpark.waitingOnPool()
+      try {
+        body
+      } finally {
+        RmmSpark.doneWaitingOnPool()
+      }
+    } else {
+      body
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.Callable
 import java.util.concurrent.locks.ReentrantLock
 import javax.annotation.concurrent.GuardedBy
 
-import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.{RapidsConf, TaskRegistryTracker}
 
 /**
  * Simple wrapper around a [[Callable]] that also keeps track of the host memory bytes used by
@@ -102,7 +102,9 @@ class TrafficController protected[rapids] (@GuardedBy("lock") throttle: Throttle
     lock.lockInterruptibly()
     try {
       while (numTasks > 0 && !throttle.canAccept(task)) {
-        canBeScheduled.await()
+        TaskRegistryTracker.withRmmPoolWait {
+          canBeScheduled.await()
+        }
       }
       numTasks += 1
       throttle.taskScheduled(task)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
@@ -27,7 +27,10 @@ import java.util.concurrent.ArrayBlockingQueue
 import scala.collection.mutable
 
 import ai.rapids.cudf._
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuColumnVectorFromBuffer, GpuCompressedColumnVector, GpuDeviceManager, HashedPriorityQueue, HostAlloc, HostMemoryOutputStream, MemoryBufferToHostByteBufferIterator, NvtxId, NvtxRegistry, RapidsConf, RapidsHostColumnVector}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuColumnVectorFromBuffer,
+  GpuCompressedColumnVector, GpuDeviceManager, HashedPriorityQueue, HostAlloc,
+  HostMemoryOutputStream, MemoryBufferToHostByteBufferIterator, NvtxId, NvtxRegistry,
+  RapidsConf, RapidsHostColumnVector, TaskRegistryTracker}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableSeq
 import com.nvidia.spark.rapids.format.TableMeta
@@ -2225,13 +2228,19 @@ class BounceBufferPool[T <: AutoCloseable](private val bufSize: Long,
         "pool has been closed!")
     }
     while (pool.size() <= 0) {
-      wait()
+      waitForBuffer()
       if (closed) {
         throw new IllegalStateException("tried to acquire a bounce buffer after the" +
           "pool has been closed!")
       }
     }
     pool.take()
+  }
+
+  private def waitForBuffer(): Unit = {
+    TaskRegistryTracker.withRmmPoolWait {
+      wait()
+    }
   }
 
   def returnBuffer(buffer: BounceBuffer[T]): Unit = synchronized {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorRmmSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorRmmSuite.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.io.async
+
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import ai.rapids.cudf.{DeviceMemoryBuffer, Rmm, RmmAllocationMode, RmmCudaMemoryResource,
+  RmmDeviceMemoryResource, RmmEventHandler, RmmLimitingResourceAdaptor, RmmTrackingResourceAdaptor}
+import com.nvidia.spark.rapids.{Arm, RmmSparkRetrySuiteBase, ScalableTaskCompletion,
+  TaskRegistryTracker}
+import com.nvidia.spark.rapids.jni.{GpuRetryOOM, RmmSpark, TaskPriority}
+import com.nvidia.spark.rapids.spill.SpillFramework
+import org.scalatest.concurrent.{Signaler, TimeLimits}
+import org.scalatest.time.{Seconds, Span}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.rapids.metrics.source.MockTaskContext
+
+class ThrottlingExecutorRmmSuite extends RmmSparkRetrySuiteBase with TimeLimits {
+  private val rmmAllocationAlignment = 256L
+
+  object ThreadDumpSignaler extends Signaler {
+    override def apply(testThread: Thread): Unit = {
+      System.err.println("\n\n\t\tTEST THREAD APPEARS TO BE STUCK")
+      Thread.getAllStackTraces.forEach {
+        case (thread, trace) =>
+          val name = if (thread.getId == testThread.getId) {
+            s"TEST THREAD ${thread.getName}"
+          } else {
+            thread.getName
+          }
+          System.err.println(name + "\n\t" + trace.mkString("\n\t"))
+      }
+    }
+  }
+
+  implicit val signaler: Signaler = ThreadDumpSignaler
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ScalableTaskCompletion.reset()
+    TaskRegistryTracker.clearRegistry()
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      ScalableTaskCompletion.reset()
+      TaskRegistryTracker.clearRegistry()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  private def registerTaskThread(taskAttemptId: Long): Unit = {
+    TrampolineUtil.setTaskContext(new MockTaskContext(taskAttemptId, partitionId = 0))
+    TaskPriority.getTaskPriority(taskAttemptId)
+    TaskRegistryTracker.registerDedicatedThreadForRetry()
+  }
+
+  private def withRmmPoolWaitIfAvailable(body: => Unit): Unit = {
+    val waitBody: Function0[Unit] = () => body
+    try {
+      TaskRegistryTracker.getClass
+          .getMethod("withRmmPoolWait", classOf[Function0[_]])
+          .invoke(TaskRegistryTracker, waitBody)
+    } catch {
+      case _: NoSuchMethodException =>
+        body
+      case e: InvocationTargetException =>
+        throw e.getCause
+    }
+  }
+
+  private def assertNoFailure(failure: AtomicReference[Throwable]): Unit = {
+    val t = failure.get()
+    if (t != null) {
+      throw t
+    }
+  }
+
+  private def useLimitedRmmPool(limit: Long): Unit = {
+    SpillFramework.shutdown()
+    if (Rmm.isInitialized) {
+      Rmm.shutdown()
+    }
+    var resource: RmmDeviceMemoryResource = null
+    var succeeded = false
+    try {
+      resource = new RmmCudaMemoryResource()
+      resource = new RmmLimitingResourceAdaptor[RmmDeviceMemoryResource](
+        resource, limit, rmmAllocationAlignment)
+      resource = new RmmTrackingResourceAdaptor[RmmDeviceMemoryResource](
+        resource, rmmAllocationAlignment)
+      Rmm.setCurrentDeviceResource(resource, null, false)
+      succeeded = true
+    } finally {
+      if (!succeeded && resource != null) {
+        resource.close()
+      }
+    }
+    RmmSpark.setEventHandler(new TestRmmEventHandler, "stderr")
+  }
+
+  private def restoreDefaultRmm(): Unit = {
+    RmmSpark.clearEventHandler()
+    if (Rmm.isInitialized) {
+      Rmm.shutdown()
+    }
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512L * 1024 * 1024)
+    RmmSpark.setEventHandler(new TestRmmEventHandler)
+  }
+
+  private class TestRmmEventHandler extends RmmEventHandler {
+    override def getAllocThresholds: Array[Long] = null
+    override def getDeallocThresholds: Array[Long] = null
+    override def onAllocThreshold(totalAllocSize: Long): Unit = {}
+    override def onDeallocThreshold(totalAllocSize: Long): Unit = {}
+    override def onAllocFailure(sizeRequested: Long, retryCount: Int): Boolean = false
+  }
+
+  test("throttled submit can wait from a dedicated task thread") {
+    val spark = SparkSession.builder()
+        .master("local[1]")
+        .appName("ThrottlingExecutorRmmSuite")
+        .getOrCreate()
+
+    try {
+      spark.sparkContext.parallelize(Seq(1), 1).foreachPartition { _ =>
+        TaskRegistryTracker.clearRegistry()
+        TaskRegistryTracker.registerDedicatedThreadForRetry()
+
+        val throttle = new HostMemoryThrottle(100)
+        val trafficController = new TrafficController(throttle)
+        val executor = new ThrottlingExecutor(
+          Executors.newSingleThreadExecutor(),
+          trafficController,
+          _ => ())
+
+        val firstStarted = new CountDownLatch(1)
+        val releaseFirst = new CountDownLatch(1)
+        val releaserFailure = new AtomicReference[Throwable]()
+        val releaserDone = new CountDownLatch(1)
+
+        val releaser = new Thread("throttling-executor-rmm-test-releaser") {
+          override def run(): Unit = {
+            try {
+              Thread.sleep(100)
+              releaseFirst.countDown()
+            } catch {
+              case t: Throwable => releaserFailure.set(t)
+            } finally {
+              releaserDone.countDown()
+            }
+          }
+        }
+
+        try {
+          val first = executor.submit(new Callable[Unit] {
+            override def call(): Unit = {
+              firstStarted.countDown()
+              assert(releaseFirst.await(5, TimeUnit.SECONDS))
+            }
+          }, 100)
+          assert(firstStarted.await(5, TimeUnit.SECONDS))
+
+          releaser.start()
+          val second = executor.submit(new Callable[Unit] {
+            override def call(): Unit = {}
+          }, 100)
+
+          second.get(5, TimeUnit.SECONDS)
+          first.get(5, TimeUnit.SECONDS)
+          assert(releaserDone.await(5, TimeUnit.SECONDS))
+          val failure = releaserFailure.get()
+          if (failure != null) {
+            throw failure
+          }
+        } finally {
+          executor.shutdownNow(5, TimeUnit.SECONDS)
+          TaskRegistryTracker.clearRegistry()
+        }
+      }
+    } finally {
+      spark.stop()
+      SparkSession.clearActiveSession()
+    }
+  }
+
+  test("RMM retry can proceed while another task waits on a non-RMM pool") {
+    useLimitedRmmPool(10L * 1024 * 1024)
+
+    val firstAllocationSize = 5L * 1024 * 1024
+    val secondAllocationSize = 6L * 1024 * 1024
+    val releasePoolWait = new AtomicBoolean(false)
+    val task1InPoolWait = new CountDownLatch(1)
+    val task1Done = new CountDownLatch(1)
+    val task2Done = new CountDownLatch(1)
+    val task2SawRetry = new AtomicBoolean(false)
+    val task1Failure = new AtomicReference[Throwable]()
+    val task2Failure = new AtomicReference[Throwable]()
+
+    val task1 = new Thread("traffic-controller-rmm-task-1") {
+      override def run(): Unit = {
+        var task1Buffer: DeviceMemoryBuffer = null
+        try {
+          registerTaskThread(taskAttemptId = 101)
+          task1Buffer = DeviceMemoryBuffer.allocate(firstAllocationSize)
+
+          withRmmPoolWaitIfAvailable {
+            task1InPoolWait.countDown()
+            while (!releasePoolWait.get()) {
+              Thread.`yield`()
+            }
+          }
+        } catch {
+          case t: Throwable => task1Failure.set(t)
+        } finally {
+          if (task1Buffer != null) {
+            task1Buffer.close()
+          }
+          task1Done.countDown()
+        }
+      }
+    }
+
+    val task2 = new Thread("traffic-controller-rmm-task-2") {
+      override def run(): Unit = {
+        try {
+          registerTaskThread(taskAttemptId = 202)
+          assert(task1InPoolWait.await(5, TimeUnit.SECONDS))
+
+          try {
+            Arm.withResource(DeviceMemoryBuffer.allocate(secondAllocationSize)) { _ =>
+              throw new AssertionError("second allocation unexpectedly succeeded")
+            }
+          } catch {
+            case _: GpuRetryOOM =>
+              task2SawRetry.set(true)
+              releasePoolWait.set(true)
+          }
+        } catch {
+          case t: Throwable => task2Failure.set(t)
+        } finally {
+          releasePoolWait.set(true)
+          task2Done.countDown()
+        }
+      }
+    }
+
+    task1.setDaemon(true)
+    task2.setDaemon(true)
+
+    try {
+      failAfter(Span(20, Seconds)) {
+        task1.start()
+        task2.start()
+
+        assert(task2Done.await(20, TimeUnit.SECONDS))
+        assert(task1Done.await(20, TimeUnit.SECONDS))
+        assertNoFailure(task1Failure)
+        assertNoFailure(task2Failure)
+        assert(task2SawRetry.get())
+      }
+    } finally {
+      releasePoolWait.set(true)
+      TaskRegistryTracker.clearRegistry()
+      if (task1Done.getCount == 0 && task2Done.getCount == 0) {
+        restoreDefaultRmm()
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorRmmSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorRmmSuite.scala
@@ -280,8 +280,11 @@ class ThrottlingExecutorRmmSuite extends RmmSparkRetrySuiteBase with TimeLimits 
       }
     } finally {
       releasePoolWait.set(true)
-      TaskRegistryTracker.clearRegistry()
-      if (task1Done.getCount == 0 && task2Done.getCount == 0) {
+      try {
+        task1.join(TimeUnit.SECONDS.toMillis(5))
+        task2.join(TimeUnit.SECONDS.toMillis(5))
+      } finally {
+        TaskRegistryTracker.clearRegistry()
         restoreDefaultRmm()
       }
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/spill/BounceBufferPoolSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/spill/BounceBufferPoolSuite.scala
@@ -17,13 +17,39 @@
 package com.nvidia.spark.rapids.spill
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import com.nvidia.spark.rapids.{RmmSparkRetrySuiteBase, ScalableTaskCompletion, TaskRegistryTracker}
+import ai.rapids.cudf.{DeviceMemoryBuffer, Rmm, RmmAllocationMode, RmmCudaMemoryResource,
+  RmmDeviceMemoryResource, RmmEventHandler, RmmLimitingResourceAdaptor, RmmTrackingResourceAdaptor}
+import com.nvidia.spark.rapids.{Arm, RmmSparkRetrySuiteBase, ScalableTaskCompletion,
+  TaskRegistryTracker}
+import com.nvidia.spark.rapids.jni.{GpuRetryOOM, RmmSpark, TaskPriority}
+import org.scalatest.concurrent.{Signaler, TimeLimits}
+import org.scalatest.time.{Seconds, Span}
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.rapids.metrics.source.MockTaskContext
 
-class BounceBufferPoolSuite extends RmmSparkRetrySuiteBase {
+class BounceBufferPoolSuite extends RmmSparkRetrySuiteBase with TimeLimits {
+  private val rmmAllocationAlignment = 256L
+
+  object ThreadDumpSignaler extends Signaler {
+    override def apply(testThread: Thread): Unit = {
+      System.err.println("\n\n\t\tTEST THREAD APPEARS TO BE STUCK")
+      Thread.getAllStackTraces.forEach {
+        case (thread, trace) =>
+          val name = if (thread.getId == testThread.getId) {
+            s"TEST THREAD ${thread.getName}"
+          } else {
+            thread.getName
+          }
+          System.err.println(name + "\n\t" + trace.mkString("\n\t"))
+      }
+    }
+  }
+
+  implicit val signaler: Signaler = ThreadDumpSignaler
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -38,6 +64,52 @@ class BounceBufferPoolSuite extends RmmSparkRetrySuiteBase {
     } finally {
       super.afterEach()
     }
+  }
+
+  private def registerTaskThread(taskAttemptId: Long): Unit = {
+    TrampolineUtil.setTaskContext(new MockTaskContext(taskAttemptId, partitionId = 0))
+    TaskPriority.getTaskPriority(taskAttemptId)
+    TaskRegistryTracker.registerDedicatedThreadForRetry()
+  }
+
+  private def useLimitedRmmPool(limit: Long): Unit = {
+    SpillFramework.shutdown()
+    if (Rmm.isInitialized) {
+      Rmm.shutdown()
+    }
+    var resource: RmmDeviceMemoryResource = null
+    var succeeded = false
+    try {
+      resource = new RmmCudaMemoryResource()
+      resource = new RmmLimitingResourceAdaptor[RmmDeviceMemoryResource](
+        resource, limit, rmmAllocationAlignment)
+      resource = new RmmTrackingResourceAdaptor[RmmDeviceMemoryResource](
+        resource, rmmAllocationAlignment)
+      Rmm.setCurrentDeviceResource(resource, null, false)
+      succeeded = true
+    } finally {
+      if (!succeeded && resource != null) {
+        resource.close()
+      }
+    }
+    RmmSpark.setEventHandler(new TestRmmEventHandler, "stderr")
+  }
+
+  private def restoreDefaultRmm(): Unit = {
+    RmmSpark.clearEventHandler()
+    if (Rmm.isInitialized) {
+      Rmm.shutdown()
+    }
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512L * 1024 * 1024)
+    RmmSpark.setEventHandler(new TestRmmEventHandler)
+  }
+
+  private class TestRmmEventHandler extends RmmEventHandler {
+    override def getAllocThresholds: Array[Long] = null
+    override def getDeallocThresholds: Array[Long] = null
+    override def onAllocThreshold(totalAllocSize: Long): Unit = {}
+    override def onDeallocThreshold(totalAllocSize: Long): Unit = {}
+    override def onAllocFailure(sizeRequested: Long, retryCount: Int): Boolean = false
   }
 
   test("TaskRegistryTracker identifies dedicated task threads") {
@@ -112,6 +184,103 @@ class BounceBufferPoolSuite extends RmmSparkRetrySuiteBase {
     }
   }
 
+  test("RMM retry can proceed while a task waits for a bounce buffer") {
+    useLimitedRmmPool(10L * 1024 * 1024)
+
+    val firstAllocationSize = 5L * 1024 * 1024
+    val secondAllocationSize = 6L * 1024 * 1024
+    val pool = new BounceBufferPool[TestBuffer](1L, 1, _ => new TestBuffer)
+    val firstBounceBuffer = new AtomicReference[BounceBuffer[TestBuffer]]()
+    val task1AboutToWait = new CountDownLatch(1)
+    val task1Done = new CountDownLatch(1)
+    val task2Done = new CountDownLatch(1)
+    val task2SawRetry = new AtomicBoolean(false)
+    val task1Failure = new AtomicReference[Throwable]()
+    val task2Failure = new AtomicReference[Throwable]()
+
+    val task1 = new Thread("bounce-buffer-rmm-task-1") {
+      override def run(): Unit = {
+        var deviceBuffer: DeviceMemoryBuffer = null
+        var secondBounceBuffer: BounceBuffer[TestBuffer] = null
+        try {
+          registerTaskThread(taskAttemptId = 101)
+          deviceBuffer = DeviceMemoryBuffer.allocate(firstAllocationSize)
+          firstBounceBuffer.set(pool.nextBuffer())
+          task1AboutToWait.countDown()
+          secondBounceBuffer = pool.nextBuffer()
+        } catch {
+          case t: Throwable => task1Failure.set(t)
+        } finally {
+          if (secondBounceBuffer != null) {
+            secondBounceBuffer.close()
+          }
+          val first = firstBounceBuffer.getAndSet(null)
+          if (first != null) {
+            first.close()
+          }
+          if (deviceBuffer != null) {
+            deviceBuffer.close()
+          }
+          task1Done.countDown()
+        }
+      }
+    }
+
+    val task2 = new Thread("bounce-buffer-rmm-task-2") {
+      override def run(): Unit = {
+        try {
+          registerTaskThread(taskAttemptId = 202)
+          try {
+            Arm.withResource(DeviceMemoryBuffer.allocate(secondAllocationSize)) { _ =>
+              throw new AssertionError("second allocation unexpectedly succeeded")
+            }
+          } catch {
+            case _: GpuRetryOOM =>
+              task2SawRetry.set(true)
+          }
+        } catch {
+          case t: Throwable => task2Failure.set(t)
+        } finally {
+          val first = firstBounceBuffer.getAndSet(null)
+          if (first != null) {
+            first.close()
+          }
+          task2Done.countDown()
+        }
+      }
+    }
+
+    task1.setDaemon(true)
+    task2.setDaemon(true)
+
+    try {
+      failAfter(Span(20, Seconds)) {
+        task1.start()
+        assert(task1AboutToWait.await(5, TimeUnit.SECONDS))
+        waitUntilBlockedOrDone(task1, task1Failure)
+        assertNoFailure(task1Failure)
+
+        task2.start()
+
+        assert(task2Done.await(20, TimeUnit.SECONDS))
+        assert(task1Done.await(20, TimeUnit.SECONDS))
+        assertNoFailure(task1Failure)
+        assertNoFailure(task2Failure)
+        assert(task2SawRetry.get())
+      }
+    } finally {
+      val first = firstBounceBuffer.getAndSet(null)
+      if (first != null) {
+        first.close()
+      }
+      task1.join(TimeUnit.SECONDS.toMillis(5))
+      task2.join(TimeUnit.SECONDS.toMillis(5))
+      pool.close()
+      TaskRegistryTracker.clearRegistry()
+      restoreDefaultRmm()
+    }
+  }
+
   private def waitUntilBlockedOrDone(
       thread: Thread,
       failure: AtomicReference[Throwable]): Unit = {
@@ -121,6 +290,9 @@ class BounceBufferPoolSuite extends RmmSparkRetrySuiteBase {
         thread.getState != Thread.State.WAITING &&
         System.nanoTime() < deadline) {
       Thread.sleep(10)
+    }
+    if (thread.isAlive && failure.get() == null && thread.getState != Thread.State.WAITING) {
+      throw new AssertionError(s"${thread.getName} did not block waiting for a bounce buffer")
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/spill/BounceBufferPoolSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/spill/BounceBufferPoolSuite.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.spill
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
+import com.nvidia.spark.rapids.{RmmSparkRetrySuiteBase, ScalableTaskCompletion, TaskRegistryTracker}
+
+import org.apache.spark.sql.SparkSession
+
+class BounceBufferPoolSuite extends RmmSparkRetrySuiteBase {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ScalableTaskCompletion.reset()
+    TaskRegistryTracker.clearRegistry()
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      ScalableTaskCompletion.reset()
+      TaskRegistryTracker.clearRegistry()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("TaskRegistryTracker identifies dedicated task threads") {
+    val spark = SparkSession.builder()
+        .master("local[1]")
+        .appName("BounceBufferPoolSuite")
+        .getOrCreate()
+
+    try {
+      spark.sparkContext.parallelize(Seq(1), 1).foreachPartition { _ =>
+        TaskRegistryTracker.clearRegistry()
+        assert(!TaskRegistryTracker.isCurrentThreadRegisteredAsDedicatedTaskThread)
+
+        TaskRegistryTracker.registerThreadForRetry()
+        assert(!TaskRegistryTracker.isCurrentThreadRegisteredAsDedicatedTaskThread)
+
+        TaskRegistryTracker.registerDedicatedThreadForRetry()
+        assert(TaskRegistryTracker.isCurrentThreadRegisteredAsDedicatedTaskThread)
+
+        TaskRegistryTracker.clearRegistry()
+        assert(!TaskRegistryTracker.isCurrentThreadRegisteredAsDedicatedTaskThread)
+      }
+    } finally {
+      spark.stop()
+      SparkSession.clearActiveSession()
+    }
+  }
+
+  test("nextBuffer does not mark unregistered threads as waiting on the RMM pool") {
+    val pool = new BounceBufferPool[TestBuffer](1L, 1, _ => new TestBuffer)
+    val firstBuffer = pool.nextBuffer()
+    var firstBufferReturned = false
+    val started = new CountDownLatch(1)
+    val acquired = new AtomicReference[BounceBuffer[TestBuffer]]()
+    val failure = new AtomicReference[Throwable]()
+    val waiter = new Thread("bounce-buffer-pool-test-waiter") {
+      override def run(): Unit = {
+        started.countDown()
+        try {
+          acquired.set(pool.nextBuffer())
+        } catch {
+          case t: Throwable => failure.set(t)
+        }
+      }
+    }
+
+    try {
+      waiter.start()
+      assert(started.await(5, TimeUnit.SECONDS))
+      waitUntilBlockedOrDone(waiter, failure)
+      assertNoFailure(failure)
+
+      firstBuffer.close()
+      firstBufferReturned = true
+      waiter.join(TimeUnit.SECONDS.toMillis(5))
+
+      assert(!waiter.isAlive)
+      assertNoFailure(failure)
+      assert(acquired.get() != null)
+    } finally {
+      if (!firstBufferReturned) {
+        firstBuffer.close()
+      }
+      val acquiredBuffer = acquired.get()
+      if (acquiredBuffer != null) {
+        acquiredBuffer.close()
+      }
+      pool.close()
+      if (waiter.isAlive) {
+        waiter.join(TimeUnit.SECONDS.toMillis(5))
+      }
+    }
+  }
+
+  private def waitUntilBlockedOrDone(
+      thread: Thread,
+      failure: AtomicReference[Throwable]): Unit = {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (thread.isAlive &&
+        failure.get() == null &&
+        thread.getState != Thread.State.WAITING &&
+        System.nanoTime() < deadline) {
+      Thread.sleep(10)
+    }
+  }
+
+  private def assertNoFailure(failure: AtomicReference[Throwable]): Unit = {
+    val error = failure.get()
+    if (error != null) {
+      throw error
+    }
+  }
+
+  private class TestBuffer extends AutoCloseable {
+    override def close(): Unit = {}
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/15005

Fix deadlock of RMM pool waits for task threads

### Description

This fixes a hang in RMM retry/deadlock detection when a dedicated Spark task thread waits on a non-RMM pool while holding GPU memory.

Problem:
- A dedicated task thread can hold RMM memory and block in a non-RMM pool, such as the bounce buffer pool.
- Before this change, that wait was invisible to the RMM task state machine, so the task could still be treated as runnable/running.
- If another task then blocked in RMM allocation, the deadlock detector could miss that all relevant tasks were blocked and fail to trigger a retry OOM.

Change:
- Add `TaskRegistryTracker.withRmmPoolWait` to mark dedicated task threads as waiting on a pool for RMM deadlock detection.
- Wire non-RMM pool waits in `TrafficController` and `SpillFramework` through that marker.
- Add regression coverage for bounce buffer pool waits and a synthetic non-RMM pool/RMM allocation deadlock.

Testing:
- `git diff --check origin/main..HEAD`
- `mvn package -pl tests -am -Dbuildver=356 -DwildcardSuites=com.nvidia.spark.rapids.io.async.ThrottlingExecutorRmmSuite,com.nvidia.spark.rapids.spill.BounceBufferPoolSuite`
  - ScalaTest ran 4 tests: `ThrottlingExecutorRmmSuite` and `BounceBufferPoolSuite`
  - Result: `BUILD SUCCESS`
  - Log: `/tmp/rapids-rmm-pool-wait-pr-20260617T101557Z.log`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
