### PR TITLE
Add some RAPIDS migrated SQL core test suites

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsCachedTableSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsCachedTableSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import java.time.LocalDateTime
+
+import org.apache.spark.sql.{CachedTableSuite, Dataset, Row}
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.execution.{ExecSubqueryExpression, SparkPlan}
+import org.apache.spark.sql.execution.columnar.InMemoryRelation
+import org.apache.spark.sql.rapids.GpuInMemoryTableScanExec
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsCachedTableSuite extends CachedTableSuite with RapidsSQLTestsTrait {
+  import testImplicits._
+
+  private def getNumInMemoryRelations(ds: Dataset[_]): Int = {
+    val plan = ds.queryExecution.withCachedData
+    var sum = plan.collect { case _: InMemoryRelation => 1 }.sum
+    plan.transformAllExpressions {
+      case e: SubqueryExpression =>
+        sum += e.plan.collect { case _: InMemoryRelation => 1 }.sum
+        e
+    }
+    sum
+  }
+
+  private def getNumGpuInMemoryTablesInSubquery(plan: SparkPlan): Int = {
+    plan.expressions.flatMap(_.collect {
+      case sub: ExecSubqueryExpression => getNumGpuInMemoryTablesRecursively(sub.plan)
+    }).sum
+  }
+
+  private def getNumGpuInMemoryTablesRecursively(plan: SparkPlan): Int = {
+    collect(plan) {
+      case gpuTable: GpuInMemoryTableScanExec =>
+        getNumGpuInMemoryTablesRecursively(gpuTable.relation.cachedPlan) +
+          getNumGpuInMemoryTablesInSubquery(gpuTable) + 1
+      case p =>
+        getNumGpuInMemoryTablesInSubquery(p)
+    }.sum
+  }
+
+  testRapids("InMemoryRelation statistics") {
+    sql("CACHE TABLE testData")
+
+    val cachedRelations = spark.table("testData").queryExecution.withCachedData.collect {
+      case cached: InMemoryRelation => cached
+    }
+    assert(cachedRelations.size === 1)
+
+    val cached = cachedRelations.head
+    val stats = cached.stats
+    assert(stats.sizeInBytes > 0)
+    assert(stats.sizeInBytes === cached.cacheBuilder.sizeInBytesStats.value)
+    assert(stats.rowCount.contains(cached.cacheBuilder.rowCountStats.value))
+    assert(stats.rowCount.contains(100L))
+
+    val df = spark.table("testData").where("key = 1").select("value")
+    checkAnswer(df, Row("1"))
+
+    val hasGpuCacheScan = collect(df.queryExecution.executedPlan) {
+      case p if p.getClass.getName.contains("GpuInMemoryTableScanExec") => p
+    }.nonEmpty
+    assert(hasGpuCacheScan,
+      "Expected GpuInMemoryTableScanExec in plan:\n" + df.queryExecution.executedPlan)
+  }
+
+  testRapids("SPARK-19993 subquery with cached underlying relation") {
+    withTempView("t1") {
+      Seq(1).toDF("c1").createOrReplaceTempView("t1")
+      spark.catalog.cacheTable("t1")
+
+      val sqlText =
+        """
+          |SELECT * FROM t1
+          |WHERE
+          |NOT EXISTS (SELECT * FROM t1)
+        """.stripMargin
+      val ds = sql(sqlText)
+      assert(getNumInMemoryRelations(ds) === 2)
+
+      val cachedDs = sql(sqlText).cache()
+      checkAnswer(cachedDs, Nil)
+
+      val numGpuCacheScans =
+        getNumGpuInMemoryTablesRecursively(cachedDs.queryExecution.executedPlan)
+      assert(numGpuCacheScans === 3,
+        "Expected three recursive GpuInMemoryTableScanExec nodes in plan:\n" +
+          cachedDs.queryExecution.executedPlan)
+    }
+  }
+
+  testRapids("SPARK-36120: Support cache/uncache table with TimestampNTZ type") {
+    val tableName = "ntzCache"
+    withTable(tableName) {
+      sql(s"CACHE TABLE $tableName AS SELECT TIMESTAMP_NTZ'2021-01-01 00:00:00'")
+      assert(spark.catalog.isCached(tableName))
+
+      val df = spark.table(tableName)
+      checkAnswer(df, Row(LocalDateTime.parse("2021-01-01T00:00:00")))
+
+      val cachedRelations = df.queryExecution.withCachedData.collect {
+        case cached: InMemoryRelation => cached
+      }
+      assert(cachedRelations.size === 1)
+
+      val cached = cachedRelations.head
+      val stats = cached.stats
+      assert(stats.sizeInBytes > 0)
+      assert(stats.sizeInBytes === cached.cacheBuilder.sizeInBytesStats.value)
+      assert(stats.rowCount.contains(cached.cacheBuilder.rowCountStats.value))
+      assert(stats.rowCount.contains(1L))
+
+      sql(s"UNCACHE TABLE $tableName")
+      assert(!spark.catalog.isCached(tableName))
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetCacheSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetCacheSuite.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.{DataFrame, DatasetCacheSuite, Row}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.rapids.GpuInMemoryTableScanExec
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+import org.apache.spark.storage.StorageLevel
+
+class RapidsDatasetCacheSuite extends DatasetCacheSuite with RapidsSQLTestsTrait {
+  private def getSingleInMemoryRelation(df: DataFrame): InMemoryRelation = {
+    val cachedRelations = df.queryExecution.withCachedData.collect {
+      case cached: InMemoryRelation => cached
+    }
+    assert(cachedRelations.size === 1,
+      "Expected one InMemoryRelation in plan:\n" + df.queryExecution.withCachedData)
+    cachedRelations.head
+  }
+
+  private def getFirstInMemoryRelation(df: DataFrame): InMemoryRelation = {
+    df.queryExecution.withCachedData.collectFirst {
+      case cached: InMemoryRelation => cached
+    }.getOrElse {
+      fail("Expected an InMemoryRelation in plan:\n" + df.queryExecution.withCachedData)
+    }
+  }
+
+  private def cacheScanCount(plan: SparkPlan): Int = {
+    plan.collect {
+      case _: InMemoryTableScanExec => 1
+      case _: GpuInMemoryTableScanExec => 1
+    }.sum
+  }
+
+  private def assertGpuCacheScan(df: DataFrame): Unit = {
+    val plan = df.queryExecution.executedPlan
+    val scans = collect(plan) {
+      case scan if scan.getClass.getName.contains("GpuInMemoryTableScanExec") => scan
+    }
+    assert(scans.nonEmpty,
+      "Expected GpuInMemoryTableScanExec in plan:\n" + plan)
+  }
+
+  testRapids("SPARK-24613 Cache with UDF could not be matched with subsequent dependent caches") {
+    val udf1 = udf { x: Long => x + 1L }
+    val df = spark.range(0, 10).toDF("a").withColumn("b", udf1(col("a")))
+    val df2 = df.agg(sum(df("b")).as("sum_b"))
+
+    df.cache()
+    df.count()
+    df2.cache()
+
+    val cachedDf2 = getSingleInMemoryRelation(df2)
+    assert(cacheScanCount(cachedDf2.cacheBuilder.cachedPlan) === 1,
+      "Expected df2 cache plan to depend on the df cache:\n" +
+        cachedDf2.cacheBuilder.cachedPlan)
+
+    checkAnswer(df2, Row(55L))
+    assertGpuCacheScan(df2)
+
+    df2.unpersist(blocking = true)
+    df.unpersist(blocking = true)
+  }
+
+  testRapids("SPARK-24596 Non-cascading Cache Invalidation - verify cached data reuse") {
+    val udfEvalCount = spark.sparkContext.longAccumulator("SPARK-24596 UDF evaluations")
+    val expensiveUDF = udf { x: Long =>
+      udfEvalCount.add(1L)
+      x
+    }
+    val df = spark.range(0, 5).toDF("a")
+    val df1 = df.withColumn("b", expensiveUDF(col("a")))
+    val df2 = df1.groupBy(col("a")).agg(sum(col("b")).as("sum_b"))
+    val df3 = df.agg(sum(col("a")).as("sum_a"))
+
+    df1.cache()
+    df2.cache()
+    checkAnswer(df2, (0L until 5L).map(i => Row(i, i)))
+    val evalsAfterDf2 = udfEvalCount.value
+    assert(evalsAfterDf2 > 0)
+    df3.cache()
+
+    val cachedDf2 = getSingleInMemoryRelation(df2)
+    assert(cacheScanCount(cachedDf2.cacheBuilder.cachedPlan) === 1,
+      "Expected df2 cache plan to depend on the df1 cache:\n" +
+        cachedDf2.cacheBuilder.cachedPlan)
+
+    df1.unpersist(blocking = true)
+
+    assert(df1.storageLevel === StorageLevel.NONE)
+
+    val df4 = df1.groupBy(col("a")).agg(sum(col("b")).as("sum_b")).agg(sum("sum_b").as("total"))
+    assertCached(df4)
+    checkAnswer(df4, Row(10L))
+    assert(udfEvalCount.value === evalsAfterDf2,
+      "Expected df4 to reuse the loaded df2 cache without re-evaluating the UDF")
+    assertGpuCacheScan(df4)
+
+    val df5 = df.agg(sum(col("a")).as("sum_a")).filter(col("sum_a") > 1)
+    assertCached(df5)
+    checkAnswer(df5, Row(10L))
+  }
+
+  testRapids("SPARK-26708 Cache data and cached plan should stay consistent") {
+    val df = spark.range(0, 5).toDF("a")
+    val df1 = df.withColumn("b", col("a") + 1)
+    val df2 = df.filter(col("a") > 1)
+
+    df.cache()
+    df1.cache()
+    df1.collect()
+    df2.cache()
+
+    val cachedDf1 = getSingleInMemoryRelation(df1)
+    val df1InnerPlan = cachedDf1.cacheBuilder.cachedPlan
+    assert(cacheScanCount(df1InnerPlan) === 1,
+      "Expected df1 cache plan to depend on the df cache:\n" + df1InnerPlan)
+
+    val cachedDf2 = getSingleInMemoryRelation(df2)
+    assert(cacheScanCount(cachedDf2.cacheBuilder.cachedPlan) === 1,
+      "Expected df2 cache plan to initially depend on the df cache:\n" +
+        cachedDf2.cacheBuilder.cachedPlan)
+
+    df.unpersist(blocking = true)
+
+    val df1Limit = df1.limit(2)
+    val df1LimitInnerPlan = getFirstInMemoryRelation(df1Limit).cacheBuilder.cachedPlan
+    assert(df1LimitInnerPlan == df1InnerPlan,
+      "Expected loaded df1 cache to keep the original cached plan")
+    checkAnswer(df1Limit, Row(0L, 1L) :: Row(1L, 2L) :: Nil)
+    assertGpuCacheScan(df1Limit)
+
+    val df2Limit = df2.limit(2)
+    val df2LimitInnerPlan = getFirstInMemoryRelation(df2Limit).cacheBuilder.cachedPlan
+    assert(cacheScanCount(df2LimitInnerPlan) === 0,
+      "Expected unloaded df2 cache to be re-cached without depending on df cache:\n" +
+        df2LimitInnerPlan)
+    checkAnswer(df2Limit, Row(2L) :: Row(3L) :: Nil)
+    assertGpuCacheScan(df2Limit)
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetPrimitiveSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetPrimitiveSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DatasetPrimitiveSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDatasetPrimitiveSuite extends DatasetPrimitiveSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileBasedDataSourceSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileBasedDataSourceSuite.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.{GpuCSVScan, GpuOrcScan}
+import com.nvidia.spark.rapids.parquet.GpuParquetScan
+import com.nvidia.spark.rapids.shims.GpuBatchScanExec
+
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.sql.{DataFrame, FileBasedDataSourceSuite, Row}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.json.rapids.GpuJsonScan
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+import org.apache.spark.sql.execution.datasources.FilePartition
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsFileBasedDataSourceSuite extends FileBasedDataSourceSuite with RapidsSQLTestsTrait {
+  import testImplicits._
+
+  private val rapidsV2FileBasedDataSources = Seq("orc", "parquet", "csv", "json")
+
+  private def gpuScanFilters(
+      scan: GpuBatchScanExec): Option[(Seq[Expression], Seq[Expression])] = scan.scan match {
+    case s: GpuOrcScan => Some((s.partitionFilters, s.dataFilters))
+    case s: GpuParquetScan => Some((s.partitionFilters, s.dataFilters))
+    case s: GpuCSVScan => Some((s.partitionFilters, s.dataFilters))
+    case s: GpuJsonScan => Some((s.partitionFilters, s.dataFilters))
+    case _ => None
+  }
+
+  private def getGpuBatchFileScan(df: DataFrame): GpuBatchScanExec = {
+    val scans = collect(df.queryExecution.executedPlan) {
+      case scan: GpuBatchScanExec if gpuScanFilters(scan).isDefined => scan
+    }
+    scans.headOption.getOrElse(
+      fail(s"Expected a GPU file scan in plan:\n${df.queryExecution.executedPlan}"))
+  }
+
+  private def assertPartitionFiltersAreNotReevaluated(df: DataFrame): Unit = {
+    val filterCondition = df.queryExecution.optimizedPlan.collectFirst {
+      case f: Filter => f.condition
+    }
+    assert(filterCondition.isDefined)
+    assert(!filterCondition.get.exists {
+      case a: AttributeReference => a.name == "p1" || a.name == "p2"
+      case _ => false
+    })
+  }
+
+  private def assertGpuScanReadsOnlySelectedPartitions(scan: GpuBatchScanExec): Unit = {
+    val files = scan.inputPartitions.flatMap {
+      case partition: FilePartition => partition.files
+      case other => fail(s"Expected FilePartition from GPU scan, got ${other.getClass}")
+    }
+    assert(files.nonEmpty)
+    assert(files.forall { file =>
+      file.filePath.contains("p1=1") && file.filePath.contains("p2=2")
+    }, s"Unexpected file list: ${files.map(_.filePath).mkString(", ")}")
+  }
+
+  testRapids("SPARK-25237 compute correct input metrics in FileScanRDD") {
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "csv") {
+      withTempPath { p =>
+        val path = p.getAbsolutePath
+        spark.range(1000).repartition(1).write.csv(path)
+        val bytesReads = new mutable.ArrayBuffer[Long]()
+        val bytesReadListener = new SparkListener() {
+          override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+            bytesReads += taskEnd.taskMetrics.inputMetrics.bytesRead
+          }
+        }
+        sparkContext.addSparkListener(bytesReadListener)
+        try {
+          val df = spark.read.csv(path).limit(1)
+          df.collect()
+          sparkContext.listenerBus.waitUntilEmpty()
+          assert(bytesReads.sum > 0)
+
+          val scans = collect(df.queryExecution.executedPlan) {
+            case scan: GpuFileSourceScanExec => scan
+          }
+          assert(scans.nonEmpty, s"Expected GpuFileSourceScanExec in plan:\n${df.queryExecution}")
+          val scan = scans.head
+          assert(scan.metrics("numFiles").value === 1)
+          assert(scan.metrics("filesSize").value > 0)
+        } finally {
+          sparkContext.removeSparkListener(bytesReadListener)
+        }
+      }
+    }
+  }
+
+  testRapids("Option recursiveFileLookup: disable partition inferring") {
+    val dataPath = testFile("test-data/text-partitioned")
+
+    val df = spark.read.format("binaryFile")
+      .option("recursiveFileLookup", true)
+      .load(dataPath)
+
+    assert(!df.columns.contains("year"), "Expect partition inferring disabled")
+    val fileList = df.select("path").collect().map(_.getString(0))
+
+    val expectedFileList = Array(
+      new java.io.File(dataPath, "year=2014/data.txt").toURI.toString,
+      new java.io.File(dataPath, "year=2015/data.txt").toURI.toString)
+
+    assert(fileList.toSet === expectedFileList.toSet)
+  }
+
+  testRapids("SPARK-22790,SPARK-27668: spark.sql.sources.compressionFactor takes effect") {
+    withTempPath { workDir =>
+      val workDirPath = workDir.getAbsolutePath
+      val data1Path = workDirPath + "/data1"
+      val data2Path = workDirPath + "/data2"
+      Seq(100, 200, 300, 400).toDF("count").write.orc(data1Path)
+      Seq(100, 200, 300, 400).toDF("count").write.orc(data2Path)
+
+      var baseSize = BigInt(0)
+      withSQLConf(
+        SQLConf.FILE_COMPRESSION_FACTOR.key -> "1.0",
+        SQLConf.USE_V1_SOURCE_LIST.key -> "orc") {
+        baseSize = spark.read.orc(data1Path).queryExecution.optimizedPlan.stats.sizeInBytes
+      }
+      assert(baseSize > 0)
+      val broadcastThreshold = (baseSize * 3 / 4).toString
+
+      Seq(1.0, 0.5).foreach { compressionFactor =>
+        withSQLConf(
+          SQLConf.FILE_COMPRESSION_FACTOR.key -> compressionFactor.toString,
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> broadcastThreshold,
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.USE_V1_SOURCE_LIST.key -> "orc") {
+          val df1FromFile = spark.read.orc(data1Path)
+          val df2FromFile = spark.read.orc(data2Path)
+          val estimatedSize = df1FromFile.queryExecution.optimizedPlan.stats.sizeInBytes
+          val joinedDF = df1FromFile.join(df2FromFile, Seq("count"))
+          checkAnswer(joinedDF, Seq(Row(100), Row(200), Row(300), Row(400)))
+
+          val hasGpuBroadcastHashJoin = collect(joinedDF.queryExecution.executedPlan) {
+            case p if p.getClass.getName.contains("GpuBroadcastHashJoinExec") => p
+          }.nonEmpty
+          val hasGpuShuffledSymmetricHashJoin = collect(joinedDF.queryExecution.executedPlan) {
+            case p if p.getClass.getName.contains("GpuShuffledSymmetricHashJoinExec") => p
+          }.nonEmpty
+
+          if (compressionFactor == 0.5) {
+            assert(estimatedSize <= BigInt(broadcastThreshold))
+            assert(hasGpuBroadcastHashJoin,
+              "Expected GpuBroadcastHashJoinExec in plan:\n" +
+                joinedDF.queryExecution.executedPlan)
+            assert(!hasGpuShuffledSymmetricHashJoin,
+              s"Did not expect GpuShuffledSymmetricHashJoinExec in plan:\n" +
+                joinedDF.queryExecution.executedPlan)
+          } else {
+            assert(estimatedSize > BigInt(broadcastThreshold))
+            assert(!hasGpuBroadcastHashJoin,
+              s"Did not expect GpuBroadcastHashJoinExec in plan:\n" +
+                joinedDF.queryExecution.executedPlan)
+            assert(hasGpuShuffledSymmetricHashJoin,
+              "Expected GpuShuffledSymmetricHashJoinExec in plan:\n" +
+                joinedDF.queryExecution.executedPlan)
+          }
+        }
+      }
+    }
+  }
+
+  testRapids("File source v2: support partition pruning") {
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+      rapidsV2FileBasedDataSources.foreach { format =>
+        withTempPath { dir =>
+          Seq(("a", 1, 2), ("b", 1, 2), ("c", 2, 1))
+            .toDF("value", "p1", "p2")
+            .write
+            .format(format)
+            .partitionBy("p1", "p2")
+            .option("header", true)
+            .save(dir.getCanonicalPath)
+          val df = spark
+            .read
+            .format(format)
+            .option("header", true)
+            .load(dir.getCanonicalPath)
+            .where("p1 = 1 and p2 = 2 and value != \"a\"")
+
+          assertPartitionFiltersAreNotReevaluated(df)
+          val gpuScan = getGpuBatchFileScan(df)
+          val (partitionFilters, dataFilters) = gpuScanFilters(gpuScan).get
+          assert(partitionFilters.nonEmpty)
+          assert(dataFilters.nonEmpty)
+          assertGpuScanReadsOnlySelectedPartitions(gpuScan)
+          checkAnswer(df, Row("b", 1, 2) :: Nil)
+        }
+      }
+    }
+  }
+
+  testRapids("File source v2: support passing data filters to FileScan without partitionFilters") {
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+      rapidsV2FileBasedDataSources.foreach { format =>
+        withTempPath { dir =>
+          Seq(("a", 1, 2), ("b", 1, 2), ("c", 2, 1))
+            .toDF("value", "p1", "p2")
+            .write
+            .format(format)
+            .partitionBy("p1", "p2")
+            .option("header", true)
+            .save(dir.getCanonicalPath)
+          val df = spark
+            .read
+            .format(format)
+            .option("header", true)
+            .load(dir.getCanonicalPath)
+            .where("value = \"a\"")
+
+          val filterCondition = df.queryExecution.optimizedPlan.collectFirst {
+            case f: Filter => f.condition
+          }
+          assert(filterCondition.isDefined)
+
+          val gpuScan = getGpuBatchFileScan(df)
+          val (partitionFilters, dataFilters) = gpuScanFilters(gpuScan).get
+          assert(partitionFilters.isEmpty)
+          assert(dataFilters.nonEmpty)
+          checkAnswer(df, Row("a", 1, 2) :: Nil)
+        }
+      }
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -126,6 +126,22 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsDataFrameSetOperationsSuite]
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar", ADJUST_UT("CPU test uses CPU-specific node checks (InMemoryTableScanExec, UnionExec); GPU version implemented as testRapids() in RapidsDataFrameSetOperationsSuite"))
   enableSuite[RapidsDataFrameRangeSuite]
+  enableSuite[RapidsFileBasedDataSourceSuite]
+    .exclude("Enabling/disabling ignoreMissingFiles using orc", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15100"))
+    .exclude("SPARK-25237 compute correct input metrics in FileScanRDD", ADJUST_UT("Replaced by testRapids version that checks GpuFileSourceScanExec file metrics and populated Spark input metrics."))
+    .exclude("Option recursiveFileLookup: disable partition inferring", ADJUST_UT("Replaced by testRapids version that uses testFile() to expand Spark test resources from the tests jar before reading with binaryFile."))
+    .exclude("SPARK-22790,SPARK-27668: spark.sql.sources.compressionFactor takes effect", ADJUST_UT("Replaced by testRapids version that checks file-compression statistics with GpuBroadcastHashJoinExec and GpuShuffledSymmetricHashJoinExec."))
+    .exclude("File source v2: support partition pruning", ADJUST_UT("Replaced by testRapids version that checks GpuBatchScanExec file filters and selected partitions."))
+    .exclude("File source v2: support passing data filters to FileScan without partitionFilters", ADJUST_UT("Replaced by testRapids version that checks GpuBatchScanExec file filters and selected partitions."))
+  enableSuite[RapidsCachedTableSuite]
+    .exclude("InMemoryRelation statistics", ADJUST_UT("Replaced by testRapids version that checks cache statistics with RAPIDS cache serializer and GpuInMemoryTableScanExec."))
+    .exclude("SPARK-19993 subquery with cached underlying relation", ADJUST_UT("Replaced by testRapids version that checks cached subquery reuse with recursive GpuInMemoryTableScanExec nodes."))
+    .exclude("SPARK-36120: Support cache/uncache table with TimestampNTZ type", ADJUST_UT("Replaced by testRapids version that checks TimestampNTZ cache correctness with RAPIDS cache stats."))
+  enableSuite[RapidsDatasetCacheSuite]
+    .exclude("SPARK-24613 Cache with UDF could not be matched with subsequent dependent caches", ADJUST_UT("Replaced by testRapids version that checks dependent cache matching with RAPIDS cache scans."))
+    .exclude("SPARK-24596 Non-cascading Cache Invalidation - verify cached data reuse", ADJUST_UT("Replaced by testRapids version that checks non-cascading cache invalidation reuses loaded cached data without re-evaluating the UDF."))
+    .exclude("SPARK-26708 Cache data and cached plan should stay consistent", ADJUST_UT("Replaced by testRapids version that checks loaded and unloaded dependent caches keep consistent cached plans under RAPIDS."))
+  enableSuite[RapidsDatasetPrimitiveSuite]
   enableSuite[RapidsDataFrameWindowFunctionsSuite]
     .exclude("Window spill with more than the inMemoryThreshold and spillThreshold", WONT_FIX_ISSUE("GPU implementation doesn't respect the inMemoryThreshold and spillThreshold"))
     .exclude("SPARK-21258: complex object in combination with spilling", WONT_FIX_ISSUE("GPU implementation doesn't respect the inMemoryThreshold and spillThreshold"))


### PR DESCRIPTION
Fixes #15105.

### Description
Add below suites from Spark 330 UT.
- RapidsFileBasedDataSourceSuite
- RapidsCachedTableSuite
- RapidsDatasetCacheSuite
- RapidsDatasetPrimitiveSuite

### Checklists
Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [X] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
