### PR TITLE
Use supported sort_array expr instead of array_sort in UDF example [skip ci]

### DIFF
--- a/skills/udf-convert-to-sql/examples/normalize_tags.sql
+++ b/skills/udf-convert-to-sql/examples/normalize_tags.sql
@@ -5,7 +5,7 @@ SELECT
   CASE
     WHEN tags IS NULL THEN NULL
     WHEN SIZE(FILTER(tags, x -> x IS NOT NULL AND TRIM(x) != '')) = 0 THEN NULL
-    ELSE ARRAY_SORT(ARRAY_DISTINCT(
+    ELSE SORT_ARRAY(ARRAY_DISTINCT(
       TRANSFORM(
         FILTER(tags, x -> x IS NOT NULL AND TRIM(x) != ''),
         x -> LOWER(TRIM(x))


### PR DESCRIPTION
### Description

This SQL file is provided as an example conversion for agents converting UDFs to SQL, where the ground truth is e.g. [NormalizeTags.scala](https://github.com/NVIDIA/cudf-spark/blob/main/skills/udf-convert-to-sql/examples/NormalizeTags.scala). However, `ARRAY_SORT` used in this context with a lambda is not actually supported on GPU, so this was a bad example. I've replaced it with `SORT_ARRAY`, which does run on GPU. Semantically they have differences in null placement, but that doesn't surface in this query since we filter nulls.

### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
