### PR TITLE
Fix to_json non-finite floating point output

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1140,6 +1140,40 @@ def test_structs_to_json_without_timestamp_non_utc_timezone(spark_tmp_path, data
         lambda spark : struct_to_json(spark),
         conf=conf)
 
+def test_structs_to_json_non_finite_floating_point():
+    schema = StructType([
+        StructField('d_nan', DoubleType()),
+        StructField('d_pos_inf', DoubleType()),
+        StructField('d_neg_inf', DoubleType()),
+        StructField('f_nan', FloatType()),
+        StructField('f_pos_inf', FloatType()),
+        StructField('f_neg_inf', FloatType()),
+        StructField('s_nan', StringType()),
+    ])
+
+    def struct_to_json(spark):
+        df = spark.createDataFrame([
+            (float('nan'), float('inf'), float('-inf'),
+             float('nan'), float('inf'), float('-inf'), 'NaN')
+        ], schema)
+        return df.select(
+            f.to_json(f.struct(f.col('d_nan').alias('value'))).alias('struct_double_nan'),
+            f.to_json(f.struct(f.col('d_pos_inf').alias('value'))).alias('struct_double_pos_inf'),
+            f.to_json(f.struct(f.col('d_neg_inf').alias('value'))).alias('struct_double_neg_inf'),
+            f.to_json(f.struct(f.col('f_nan').alias('value'))).alias('struct_float_nan'),
+            f.to_json(f.struct(f.col('f_pos_inf').alias('value'))).alias('struct_float_pos_inf'),
+            f.to_json(f.struct(f.col('f_neg_inf').alias('value'))).alias('struct_float_neg_inf'),
+            f.to_json(f.struct(f.col('s_nan').alias('value'))).alias('struct_string_nan'),
+            f.to_json(f.create_map(f.lit('value'), f.col('d_nan'))).alias('map_double_nan'),
+            f.to_json(f.create_map(f.lit('value'), f.col('f_nan'))).alias('map_float_nan'))
+
+    conf = copy_and_update(_enable_all_types_conf,
+        { 'spark.rapids.sql.expression.StructsToJson': True })
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : struct_to_json(spark),
+        conf=conf)
+
 @pytest.mark.parametrize('data_gen', _to_json_datagens, ids=idfn)
 @pytest.mark.parametrize('ignore_null_fields', [True, False])
 @pytest.mark.parametrize('timezone', [

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -755,6 +755,7 @@ object GpuCast {
     case DateType => input.asStrings("%Y-%m-%d")
     case TimestampType if options.castToJsonString => castTimestampToJson(input)
     case TimestampType => castTimestampToString(input)
+    case FloatType | DoubleType if options.castToJsonString => castFloatToJson(input)
     case FloatType | DoubleType => CastStrings.fromFloat(input)
     case BinaryType => castBinToString(input, options)
     case _: DecimalType => GpuCastShims.CastDecimalToString(input, options.useDecimalPlainString)
@@ -812,6 +813,32 @@ object GpuCast {
     // We also need to quote and escape the result.
     withResource(input.asStrings("%Y-%m-%dT%H:%M:%S.%3fZ")) { tmp =>
       escapeAndQuoteJsonString(tmp)
+    }
+  }
+
+  private def castFloatToJson(input: ColumnView): ColumnVector = {
+    withResource(CastStrings.fromFloat(input)) { asString =>
+      withResource(escapeAndQuoteJsonString(asString)) { quotedString =>
+        withResource(input.isNan) { isNan =>
+          withResource(FloatUtils.getPositiveInfinityScalar(input.getType)) { posInf =>
+            withResource(input.equalTo(posInf)) { isPosInf =>
+              withResource(FloatUtils.getNegativeInfinityScalar(input.getType)) { negInf =>
+                withResource(input.equalTo(negInf)) { isNegInf =>
+                  withResource(isNan.or(isPosInf)) { isNanOrPosInf =>
+                    withResource(isNanOrPosInf.or(isNegInf)) { isNonFinite =>
+                      withResource(input.isNotNull) { isNotNull =>
+                        withResource(isNonFinite.and(isNotNull)) { shouldQuote =>
+                          shouldQuote.ifElse(quotedString, asString)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #15118.

### Description

When GPU `StructsToJson` is enabled, `to_json` currently serializes floating-point `NaN` values as bare JSON tokens, e.g. `{"value":NaN}`, while Spark CPU quotes non-finite floating-point values as JSON strings, e.g. `{"value":"NaN"}`. Strict downstream JSON parsers can reject the GPU output.

This PR updates the JSON cast path for `FloatType` and `DoubleType` so that when `castToJsonString=true`:
- finite values continue to be emitted as JSON numbers
- `NaN`, `Infinity`, and `-Infinity` are emitted as quoted JSON strings, matching Spark CPU behavior
- regular non-JSON casts from float/double to string keep the existing behavior

It also adds an integration test covering `to_json` over structs and maps with `FloatType`/`DoubleType` `NaN`, `Infinity`, and `-Infinity` values, plus a string `"NaN"` control case.


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required