### PR TITLE
Quote non-finite floating point values in to_json [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1227,6 +1227,25 @@ def test_maps_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
         lambda spark : struct_to_json(spark),
         conf=conf)
 
+@pytest.mark.parametrize('data_type', [FloatType(), DoubleType()], ids=idfn)
+def test_to_json_non_finite_floating_point(data_type):
+    schema = StructType([StructField('value', data_type)])
+    data = [(float('nan'),), (float('inf'),), (float('-inf'),), (1.5,), (None,)]
+
+    def to_json(spark):
+        df = spark.createDataFrame(data, schema)
+        return df.select(
+            f.to_json(f.struct(f.col('value'))).alias('struct_json'),
+            f.to_json(f.array(f.col('value'))).alias('array_json'),
+            f.to_json(f.create_map(f.lit('value'), f.col('value'))).alias('map_json'))
+
+    conf = copy_and_update(_enable_all_types_conf,
+        { 'spark.rapids.sql.expression.StructsToJson': True })
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : to_json(spark),
+        conf=conf)
+
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
 @pytest.mark.parametrize('timestamp_format', [
     'yyyy-MM-dd\'T\'HH:mm:ss[.SSS][XXX]'

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1232,7 +1232,7 @@ def test_to_json_non_finite_floating_point(data_type):
     schema = StructType([StructField('value', data_type)])
     data = [(float('nan'),), (float('inf'),), (float('-inf'),), (1.5,), (None,)]
 
-    def to_json(spark):
+    def struct_to_json(spark):
         df = spark.createDataFrame(data, schema)
         return df.select(
             f.to_json(f.struct(f.col('value'))).alias('struct_json'),
@@ -1243,7 +1243,7 @@ def test_to_json_non_finite_floating_point(data_type):
         { 'spark.rapids.sql.expression.StructsToJson': True })
 
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : to_json(spark),
+        lambda spark : struct_to_json(spark),
         conf=conf)
 
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -755,6 +755,8 @@ object GpuCast {
     case DateType => input.asStrings("%Y-%m-%d")
     case TimestampType if options.castToJsonString => castTimestampToJson(input)
     case TimestampType => castTimestampToString(input)
+    case FloatType | DoubleType if options.castToJsonString =>
+      CastStrings.fromFloat(input, true)
     case FloatType | DoubleType => CastStrings.fromFloat(input)
     case BinaryType => castBinToString(input, options)
     case _: DecimalType => GpuCastShims.CastDecimalToString(input, options.useDecimalPlainString)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -755,9 +755,7 @@ object GpuCast {
     case DateType => input.asStrings("%Y-%m-%d")
     case TimestampType if options.castToJsonString => castTimestampToJson(input)
     case TimestampType => castTimestampToString(input)
-    case FloatType | DoubleType if options.castToJsonString =>
-      CastStrings.fromFloat(input, true)
-    case FloatType | DoubleType => CastStrings.fromFloat(input)
+    case FloatType | DoubleType => CastStrings.fromFloat(input, options.castToJsonString)
     case BinaryType => castBinToString(input, options)
     case _: DecimalType => GpuCastShims.CastDecimalToString(input, options.useDecimalPlainString)
     case StructType(fields) => castStructToString(input, fields, options)


### PR DESCRIPTION
Fixes #15118.

### Description

Spark `to_json` serializes non-finite floating point values as JSON strings, for example `"NaN"`, `"Infinity"`, and `"-Infinity"`. The GPU path was using the regular float-to-string cast, which emits bare `NaN`/`Infinity` tokens and can produce JSON output that does not match Spark.

This PR routes float and double casts through the JSON float-to-string mode when the cast is used by JSON serialization. Regular float-to-string casts continue to use the existing path.

This depends on NVIDIA/cudf-spark-jni#4734, which adds the `CastStrings.fromFloat(input, jsonString)` JNI API and the native JSON float-to-string mode. This PR should stay draft until that dependency is available in the cudf-spark build.

Testing added:
- `test_to_json_non_finite_floating_point` in `integration_tests/src/main/python/json_test.py`, covering `FloatType` and `DoubleType` values inside struct, array, and map JSON output.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
