### PR TITLE
Remove deprecated Table.readJSON usage

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -319,10 +319,7 @@ object JsonPartitionReader {
       RmmRapidsRetryIterator.withRetryNoSplit(dataBufferer.getBufferAndRelease) { dataBuffer =>
         NvtxIdWithMetrics(NvtxRegistry.JSON_DECODE_SCAN, decodeTime) {
           try {
-            Table.readJSON(cudfSchema, jsonOpts, dataBuffer, 0, dataSize, dataBufferer.getNumLines):
-              @scala.annotation.nowarn(
-                "cat=deprecation&msg=method readJSON in class Table is deprecated"
-              )
+            Table.readJSON(cudfSchema, jsonOpts, dataBuffer, 0, dataSize)
           } catch {
             case e: AssertionError if e.getMessage == "CudfColumns can't be null or empty" =>
               // this happens when every row in a JSON file is invalid (or we are


### PR DESCRIPTION
Fixes #14121.

### Description

This replaces the deprecated `Table.readJSON(..., HostMemoryBuffer, offset, len, emptyRowCount)` call in `GpuJsonScan` with the non-deprecated overload that omits `emptyRowCount`, then removes the local `@nowarn` suppression that was only needed for the deprecated signature.

The cuDF Java API documents the `emptyRowCount` overload as deprecated because the parameter is unused, so this is intended to preserve behavior while cleaning up the tracked deprecated call.

### Current status

This PR is still draft. The branch has been rebased onto current `main` (`1d7b1e485`), but I am not marking it ready until full compile validation is available.

Validation so far:
- `git diff --check origin/main...HEAD`
- `rg` confirmed the deprecated `@nowarn` suppression is gone and `GpuJsonScan.scala` now calls the non-deprecated `Table.readJSON(cudfSchema, jsonOpts, dataBuffer, 0, dataSize)` overload
- Installed workspace-local JDK 17 + Maven 3.9.11 and ran `mvn -Dbuildver=330 -pl sql-plugin-api -am -DskipTests -Drat.skip=true install` successfully

Attempted full scoped compile:
- `mvn -U -Dbuildver=330 -pl sql-plugin -am -DskipTests -Drat.skip=true compile`

That compile is currently blocked in this Windows checkout before the touched Scala file is compiled: the repo's Jython `shimplify` generate-sources step parses LF shim comments with Windows `os.linesep`, failing with `ValueError: Extra data` while processing `sql-plugin/src/main/spark330/java/com/nvidia/spark/rapids/shims/ShimSupportsRuntimeFiltering.java`. Skipping antrun reaches Scala compilation, but then fails with missing generated shim classes, so that is not valid merge evidence.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required