### PR TITLE
[codex] Check UDF skill markdown license headers

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -46,6 +46,7 @@ jobs:
             *.xml,
             *.properties,
             *.scala,
+            skills/udf-*/*.md,
             *.py,
             build/*,
             *.cpp,
@@ -58,4 +59,3 @@ jobs:
             *target/*,
             thirdparty/*,
             sql-plugin/src/main/java/com/nvidia/spark/rapids/format/*
- 


### PR DESCRIPTION
Fixes #15112.

### Description

This adds `skills/udf-*/*.md` to the license-header workflow include patterns so changes to UDF skill markdown files are checked for a current-year NVIDIA copyright/license header. The pattern is scoped to UDF skill content and avoids broad `*.md` coverage, which would include repository docs that do not use skill front matter.

Validation:
- `git diff --check`
- Parsed `.github/workflows/license-header-check.yml` with Ruby YAML
- Locally emulated the license-header action glob for all `skills/udf-*` markdown files
- Confirmed `skills/README.md` and `skills/docs/dev/VERSIONS.md` are not matched by the new pattern

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
