### PR TITLE
Add explicit Delta storage dependency to tests[databricks]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -245,10 +245,13 @@ run_delta_lake_tests() {
     for v in $DELTA_LAKE_VERSIONS; do
       echo "Running Delta Lake tests for Delta Lake version $v"
       if [[ "$v" == "3.3.0" || "$v" == "4.0.0" ]]; then
-        DELTA_JAR="io.delta:delta-spark_${SCALA_BINARY_VER}:$v"
-      else 
-        DELTA_JAR="io.delta:delta-core_${SCALA_BINARY_VER}:$v"
-      fi 
+        DELTA_MAIN_JAR="io.delta:delta-spark_${SCALA_BINARY_VER}:$v"
+      else
+        DELTA_MAIN_JAR="io.delta:delta-core_${SCALA_BINARY_VER}:$v"
+      fi
+      # Delta Lake 1.2+ moved LogStore implementations into delta-storage.
+      # All versions tested here are 2.0+, so include it explicitly.
+      DELTA_JAR="${DELTA_MAIN_JAR},io.delta:delta-storage:$v"
       HOST_NAME=$PROJECT_REPO_HOST \
         PYSP_TEST_spark_jars_packages=${DELTA_JAR} \
         PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \


### PR DESCRIPTION
Fixes #15093.

### Description

- Add `io.delta:delta-storage` as a direct Delta Lake integration test package because Delta Lake 1.2+ stores LogStore implementations there and CI should not rely on transitive dependency metadata to populate Spark runtime classpaths.
- Keep the existing `delta-core` versus `delta-spark` selection while composing the final package list from the main Delta artifact and the matching `delta-storage` version, so the existing Delta 2.x, 3.x, and 4.x integration tests use consistent artifacts.
- Validated with `bash -n jenkins/spark-tests.sh` and a local Spark 3.3.0 smoke test using `--packages io.delta:delta-core_2.12:2.3.0,io.delta:delta-storage:2.3.0` that wrote a Delta table successfully.
- Existing `delta_lake_write_test.py` and `delta_lake_merge_test.py` coverage exercises the affected Delta Lake package setup in CI.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required