### PR TITLE
[BUG] Skip skewed BHJ marker test on DB 17.x[databricks]

### DIFF
--- a/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
+++ b/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
@@ -19,10 +19,16 @@ from private_optimizer_common import (
     private_optimizer_conf,
     require_private_optimizer,
 )
+from spark_session import is_databricks173_or_later
 
 
 @pytest.mark.private_optimizer
 @require_private_optimizer
+@pytest.mark.skipif(
+    is_databricks173_or_later(),
+    reason="DB 17.3+ executor-broadcast AQE can put the materialized shuffle on the "
+           "BHJ build side; this marker test covers streamed-side skew split. "
+           "See https://github.com/NVIDIA/cudf-spark/issues/15136")
 def test_optimize_skewed_bhj_join(spark_tmp_path):
     """OptimizeSkewedBHJJoinRule splits a skewed partition on the streamed side
     of an AQE broadcast hash join. Needs a runtime broadcast (static


### PR DESCRIPTION
contributes to #15136

This skips the private optimizer skewed-BHJ marker test on DB 17.3+.

DB executor-broadcast AQE can materialize the shuffle on the BHJ build side. The test is asserting the streamed-side skew split marker (`coalesced and skewed`), so the marker is not stable for that DB-only plan shape even though the private optimizer rule itself did not regress.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Validation:
- `python3 -m py_compile integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py`
- `git diff --check`
- `mvn package -DskipTests -pl dist,integration_tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm`
- `SPARK_HOME=/home/allxu/Downloads/spark-3.3.0-bin-hadoop3 TEST=test_optimize_skewed_bhj_join TEST_PARALLEL=1 DATAGEN_SEED=1782263667 ./integration_tests/run_pyspark_from_build.sh` (`1 passed, 39102 deselected`)

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
