### PR TITLE
Fix PyArrow timestamp inference for Spark 3.3.4 [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_pyarrow_test.py
+++ b/integration_tests/src/main/python/parquet_pyarrow_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
+import pyarrow as pa
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
@@ -115,9 +116,11 @@ _common_rebase_conf = {
     'spark.sql.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
     'spark.sql.parquet.datetimeRebaseModeInRead': 'CORRECTED',
 
-    # Disable timestampNTZ inference for timezone-less PyArrow timestamps on Spark 3.4+.
+    # Disable timestampNTZ inference for timezone-less PyArrow timestamps on
+    # Spark 3.4+.
     # Spark 3.3.4 can also infer those as TimestampNTZType in testing mode, so
-    # pyarrow_utils writes normal TimestampGen values as UTC-adjusted timestamps.
+    # pyarrow_utils writes normal TimestampGen values as UTC-adjusted
+    # timestamps.
     # Refer to Spark link: https://github.com/apache/spark/blob/v3.5.0/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L1163
     'spark.sql.parquet.inferTimestampNTZ.enabled': 'false'
 }

--- a/integration_tests/src/main/python/parquet_pyarrow_test.py
+++ b/integration_tests/src/main/python/parquet_pyarrow_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,17 +115,19 @@ _common_rebase_conf = {
     'spark.sql.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
     'spark.sql.parquet.datetimeRebaseModeInRead': 'CORRECTED',
 
-    # disable timestampNTZ for parquet for 3.4+ tests to pass
-    # pyarrow write parquet with isAdjustedToUTC = true
-    #   ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(new Configuration(), new Path(filePath));
-    #   MessageType schema = parquetMetadata.getFileMetaData().getSchema();
-    #   Type timestampColumn = schema.getType("_c9");
-    #   System.out.println(timestampColumn);
-    #       optional int64 _c9 (TIMESTAMP(MICROS,false))
-    #       isAdjustedToUTC: true
+    # Disable timestampNTZ inference for timezone-less PyArrow timestamps on Spark 3.4+.
+    # Spark 3.3.4 can also infer those as TimestampNTZType in testing mode, so
+    # pyarrow_utils writes normal TimestampGen values as UTC-adjusted timestamps.
     # Refer to Spark link: https://github.com/apache/spark/blob/v3.5.0/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L1163
     'spark.sql.parquet.inferTimestampNTZ.enabled': 'false'
 }
+
+
+@pyarrow_test
+def test_pyarrow_timestamp_gen_type_preserves_timestamp_and_ntz_metadata():
+    assert get_pyarrow_type(TimestampGen()) == pa.timestamp('us', tz='UTC')
+    assert get_pyarrow_type(TimestampGen(tzinfo=None)) == pa.timestamp('us')
+
 
 #
 # test read/write by pyarrow/GPU

--- a/integration_tests/src/main/python/pyarrow_utils.py
+++ b/integration_tests/src/main/python/pyarrow_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +76,10 @@ def get_pyarrow_type(data_gen):
         return pa.date32()
     elif isinstance(data_gen, TimestampGen):
         # use us, because Spark does not support ns
-        return pa.timestamp('us')
+        # Use UTC-adjusted timestamps for Spark TimestampType to avoid TimestampNTZ inference.
+        if data_gen._tzinfo is None:
+            return pa.timestamp('us')
+        return pa.timestamp('us', tz='UTC')
     elif isinstance(data_gen, BinaryGen):
         return pa.binary()
     elif isinstance(data_gen, StringGen):

--- a/integration_tests/src/main/python/pyarrow_utils.py
+++ b/integration_tests/src/main/python/pyarrow_utils.py
@@ -76,7 +76,8 @@ def get_pyarrow_type(data_gen):
         return pa.date32()
     elif isinstance(data_gen, TimestampGen):
         # use us, because Spark does not support ns
-        # Use UTC-adjusted timestamps for Spark TimestampType to avoid TimestampNTZ inference.
+        # Use UTC-adjusted timestamps for Spark TimestampType to avoid
+        # TimestampNTZ inference.
         if data_gen._tzinfo is None:
             return pa.timestamp('us')
         return pa.timestamp('us', tz='UTC')


### PR DESCRIPTION
Fixes #15117.

### Description

After #15022 enabled Spark testing mode for Python integration test runs, Spark 3.3.4 started inferring PyArrow-written timezone-less Parquet timestamps as `TimestampNTZType`. The affected PyArrow Parquet tests use default `TimestampGen()` values, which model Spark `TimestampType`, but `pyarrow_utils.get_pyarrow_type()` wrote them as `pa.timestamp('us')`. That produces Parquet timestamp metadata with `isAdjustedToUTC=false`, which Spark 3.3.4 can infer as `TimestampNTZType` in testing mode.

The RAPIDS Parquet read path used by these tests does not support that `TimestampNTZType` output, so the scan fell back to CPU and GPU assertions failed with `Part of the plan is not columnar`.

This change writes normal `TimestampGen()` values as `pa.timestamp('us', tz='UTC')`, so PyArrow emits UTC-adjusted timestamp metadata and Spark keeps the column as `TimestampType`. `TimestampGen(tzinfo=None)` still maps to timezone-less `pa.timestamp('us')` to preserve NTZ coverage. A direct PyArrow type assertion covers both branches.

Verification:

- Reproduced on Spark 3.3.4 with Python 3.10 and `SPARK_TESTING_ENABLED=1`: `origin/main` plus #15022 fails with `TimestampNTZType` and `Part of the plan is not columnar`.
- Reverted #15022 on `origin/main`: targeted reproduction passes.
- Current fix plus #15022: targeted reproduction passes.
- `python3 -m py_compile integration_tests/src/main/python/pyarrow_utils.py integration_tests/src/main/python/parquet_pyarrow_test.py`
- `git diff --check`
- Focused new test on Spark 3.3.4/Python 3.10: `test_pyarrow_timestamp_gen_type_preserves_timestamp_and_ntz_metadata` passed.
- Full affected PyArrow Parquet file on Spark 3.3.4/Python 3.10 with `SPARK_TESTING_ENABLED=1`: `143 passed, 1 xpassed, 3 warnings in 1232.45s`.
- `$my-code-review` loop: final run reported `0 must-fix, 0 should-fix`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
