### PR TITLE
Set Iceberg REST write compression defaults

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -561,6 +561,17 @@ and releases memory between partitions. Dedicated fanout-enabled test cases
 (e.g., `test_*_fanout_enabled`) still exercise the fanout writer path with a single
 partition type to keep memory usage manageable.
 
+#### Iceberg REST catalog write compression
+
+Some REST catalog deployments can apply a catalog-side default Parquet compression codec that
+is not supported by the RAPIDS GPU writer. The REST catalog CI sets table defaults for data
+and delete files to use `zstd`, which is supported by the GPU writer:
+
+```shell
+"PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_parquet_compression-codec=zstd"
+"PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_delete_parquet_compression-codec=zstd"
+```
+
 ### Run Apache iceberg s3tables tests
 
 To run iceberg tests against aws s3tables catalog, we need to setup several things:

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -332,6 +332,8 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
           # filecache.enabled is a startup-only config, so it must be set here via
           # PYSP_TEST_ env var rather than as a session-level Spark config, because
           # FileCacheManager is initialized at executor startup time.
+          # Some REST catalog defaults resolve Iceberg Parquet writes to gzip, which
+          # is not supported by the GPU writer, so use a supported default codec.
           env \
             HOST_NAME=$PROJECT_REPO_HOST \
             EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
@@ -350,6 +352,8 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
             "PYSP_TEST_spark_sql_catalog_spark__catalog_oauth2-server-uri=${ICEBERG_REST_OAUTH2_SERVER_URI:-http://localhost:8080/realms/iceberg/protocol/openid-connect/token}" \
             PYSP_TEST_spark_sql_catalog_spark__catalog_scope="${ICEBERG_REST_SCOPE:-lakekeeper}" \
             PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="${ICEBERG_REST_WAREHOUSE:-demo}" \
+            "PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_parquet_compression-codec=zstd" \
+            "PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_delete_parquet_compression-codec=zstd" \
             ./run_pyspark_from_build.sh -m iceberg --iceberg
     elif [[ "$test_type" == "s3tables" ]]; then
       echo "!!! Running iceberg tests with s3tables"


### PR DESCRIPTION
Fixes #15098.

### Description

This is related to #14923, which fixed the Iceberg GPU writer to honor Iceberg's resolved Parquet compression codec instead of accidentally falling back to Spark's `spark.sql.parquet.compression.codec`. That change made GPU writes match CPU Iceberg behavior, but it also exposed REST catalog environments where the catalog-side table default resolves Parquet writes to `gzip`.

`gzip` is valid for Iceberg CPU writes, but it is not supported by the RAPIDS GPU Parquet writer. In the REST catalog test job, Iceberg V2 write execs such as `AppendDataExec`, `ReplaceDataExec`, `WriteDeltaExec`, and `OverwritePartitionsDynamicExec` are therefore tagged as unsupported on GPU and fall back to CPU. Because these tests run in RAPIDS test mode, `GpuTransitionOverrides.assertIsOnTheGpu` rejects the CPU write node and throws `IllegalArgumentException: Part of the plan is not columnar`.

This is separate from #15126, which addresses V2 write AQE/SQL UI metric behavior. The failure here is caused by an unsupported Iceberg-resolved Parquet codec in the REST catalog configuration.

This PR sets REST catalog CI table defaults so Iceberg data files and delete files use `zstd`, which is supported by the GPU writer. The README now documents the REST catalog write-compression defaults.

Testing:
- `git diff --check`
- `bash -n jenkins/spark-tests.sh`
- changed-file copyright header check
- Reproduced the failure locally with the hadoop catalog by setting `spark.sql.catalog.spark_catalog.table-default.write.parquet.compression-codec=gzip` and running existing test `iceberg/iceberg_append_test.py::test_insert_into_aqe[unpartitioned]`; it failed with the expected unsupported `gzip` fallback and `Part of the plan is not columnar`.
- Verified the fix locally with the hadoop catalog by setting data/delete table defaults to `zstd` and running existing tests `iceberg/iceberg_append_test.py::test_insert_into_aqe[unpartitioned]` and `iceberg/iceberg_delete_test.py::test_delete_aqe[merge-on-read-unpartitioned]`.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
