### PR TITLE
Skip skewed BHJ marker test on all Databricks runtimes[databricks] 

### DIFF
--- a/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
+++ b/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
@@ -19,14 +19,14 @@ from private_optimizer_common import (
     private_optimizer_conf,
     require_private_optimizer,
 )
-from spark_session import is_databricks173_or_later
+from spark_session import is_databricks_runtime
 
 
 @pytest.mark.private_optimizer
 @require_private_optimizer
 @pytest.mark.skipif(
-    is_databricks173_or_later(),
-    reason="DB 17.3+ executor-broadcast AQE can put the materialized shuffle on the "
+    is_databricks_runtime(),
+    reason="Databricks executor-broadcast AQE can put the materialized shuffle on the "
            "BHJ build side; this marker test covers streamed-side skew split. "
            "See https://github.com/NVIDIA/cudf-spark/issues/15136")
 def test_optimize_skewed_bhj_join(spark_tmp_path):


### PR DESCRIPTION
This is a WAR for #15136.

### Description

- Broaden the private optimizer skewed BHJ marker test skip from DB 17.3+ to all Databricks runtimes because the executor-broadcast AQE behavior can also reproduce on DB 3.4.1.
- Keep the skip scoped to Databricks runtimes so Apache Spark coverage for the streamed-side skew split marker remains unchanged.
- Validated the change with `ReadLints` on `integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py`; no linter errors were reported.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required