### PR TITLE
Add skipped-path coverage for skewed BHJ private optimizer [databricks]

### DIFF
--- a/integration_tests/src/main/python/private_optimizer_README.md
+++ b/integration_tests/src/main/python/private_optimizer_README.md
@@ -16,7 +16,9 @@ do **two** things:
    the rule.
 2. Assert a **per-rule plan marker** that appears only when the rule fires, so
    the test FAILS if the conf flip is a no-op (wrong conf, wrong query shape, or
-   the private jar is not loaded).
+   the private jar is not loaded). A runtime-specific no-op path instead uses
+   `assert_rule_skipped` with a required marker proving that the guarded plan
+   shape was reached.
 
 ## Layout
 
@@ -51,7 +53,12 @@ All modules carry `@pytest.mark.private_optimizer`, so the whole area runs with:
      such as broadcast thresholds or AQE toggles).
    - `assert_rule_fires(fn, on_conf, off_conf, marker, physical=False)`
      — runs the OFF-CPU vs ON-GPU comparison and the plan-marker check.
-3. **Decorate** the test with `@pytest.mark.private_optimizer`. Add `@approximate_float` only when the rule
+   - `assert_rule_skipped(fn, on_conf, off_conf, marker, physical=False,
+     required_on_markers=())`
+     — runs the same comparison but asserts a runtime-specific no-op path where
+     the marker is absent from both plans.
+3. **Decorate** the test with `@pytest.mark.private_optimizer`. Add
+   `@approximate_float` only when the rule
    changes floating-point evaluation order — that is enough for floating-point
    tolerance, since `assert_rule_fires` routes result comparison through
    `assert_equal_with_local_sort`, whose `get_float_check()` honors it.
@@ -95,6 +102,12 @@ executed plan); otherwise the optimized plan is checked. Examples in this area:
 `named_struct(c_0,` (merged subquery scan), `coalesced and skewed` (skew
 reader).
 
+When a known runtime or plan shape intentionally skips a rule, add a separate
+test with `assert_rule_skipped` instead of weakening the positive marker test.
+That skipped-path test must explain the runtime/shape reason, still compare
+OFF-CPU vs ON-GPU results, and use `required_on_markers` to prove the expected
+plan shape was reached.
+
 ### When a row-count / aggregate-only check is acceptable
 
 The default is a full row-by-row `OFF-CPU == ON-GPU` comparison. A reduced check
@@ -109,8 +122,13 @@ rule actually ran. Do **not** weaken the marker check to make a test pass.
 ### Compatibility across Spark versions and runtimes
 
 The private plugin is built for **Spark 3.3.0 and later** (private core build
-matrix: 330..411 plus the `400db173` Databricks buildver). Within that matrix all four current rules apply on every
-runtime, including Databricks, so we do **not** add per-runtime skips.
+matrix: 330..411 plus Databricks buildvers). The rules are loaded throughout
+that matrix, but a rule can intentionally guard a specific runtime plan shape.
+For example, `OptimizeSkewedBHJJoinRule` skips Databricks executor-broadcast
+joins because its streamed-side skew rewrite does not apply to that shape.
+Keep positive rule-fire coverage on supported shapes and add a separate
+`assert_rule_skipped` test for an intentional guard; do not skip the runtime's
+coverage entirely.
 
 If a future rule is genuinely unsupported on some runtime/version, express it
 where the source actually gates it:

--- a/integration_tests/src/main/python/private_optimizer_common.py
+++ b/integration_tests/src/main/python/private_optimizer_common.py
@@ -111,7 +111,7 @@ def assert_rule_skipped(fn, on_conf, off_conf, marker, physical=False, required_
     assert marker not in on_plan, \
         "runtime skip failed: marker '%s' present with rule ON\n%s" % (marker, on_plan)
     assert marker not in off_plan, \
-        "marker '%s' present with rule OFF, not a valid skipped-path check\n%s" % (
+        "marker '%s' present in OFF-CPU baseline, not a valid skipped-path check\n%s" % (
             marker, off_plan)
     for required_marker in required_on_markers:
         assert required_marker in on_plan, \

--- a/integration_tests/src/main/python/private_optimizer_common.py
+++ b/integration_tests/src/main/python/private_optimizer_common.py
@@ -21,7 +21,7 @@ not collect it as a test file. Each private-optimizer rule lives in its own
 The covered rules are semantics-preserving but default-off or otherwise dormant
 in public IT.
 Comparing a same-conf CPU run against a same-conf GPU run cannot tell whether a
-rule actually fired, so every test built on these helpers does two things:
+rule actually fired, so positive-path tests built on these helpers do two things:
 
   1. Compares an OFF-rule CPU baseline against an ON-rule GPU run. Because the
      rules preserve semantics, OFF-CPU == ON-GPU proves both data correctness
@@ -30,6 +30,10 @@ rule actually fired, so every test built on these helpers does two things:
      the test FAILS if the conf flip is a no-op (wrong conf, wrong query shape,
      or private jar not loaded).
 
+Runtime-specific no-op paths use ``assert_rule_skipped`` instead. Those tests
+require a marker for the guarded plan shape and assert that the rule marker is
+absent while preserving the same OFF-CPU vs ON-GPU result comparison.
+
 See ``private_optimizer_README.md`` for how to add a new rule module.
 """
 
@@ -37,12 +41,10 @@ from asserts import assert_equal_with_local_sort
 from spark_session import with_cpu_session, with_gpu_session
 
 # The private optimizer rules ship in the spark-rapids-private plugin, which is
-# built only for Spark 3.3.0 and later (see the private core pom build matrix:
-# 330..411 plus the Databricks 400db173 buildver). Runtimes within the matrix
-# (including Databricks) are all supported for these four rules, so we do not
-# add per-runtime skips here. A rule that becomes unsupported on some future
-# runtime is caught by the plan-marker assertion below (it fails loudly instead
-# of passing silently), not by guessing a version here.
+# built only for Spark 3.3.0 and later. Rules are loaded across the supported
+# Apache and Databricks build matrix. An intentional runtime-plan guard belongs
+# in the rule itself and is covered here with assert_rule_skipped; do not hide
+# that path with a blanket runtime skip.
 
 PRIVATE_OPTIMIZER_BASE_CONF = {
     "spark.rapids.sql.private.enabled": "true",
@@ -89,5 +91,30 @@ def assert_rule_fires(fn, on_conf, off_conf, marker, physical=False):
         "rule did not fire: marker '%s' absent with rule ON\n%s" % (marker, on_plan)
     assert marker not in off_plan, \
         "marker '%s' present with rule OFF, not a valid discriminator\n%s" % (marker, off_plan)
+
+    assert_equal_with_local_sort(cpu_rows, gpu_rows)
+
+
+def assert_rule_skipped(fn, on_conf, off_conf, marker, physical=False, required_on_markers=()):
+    """OFF-rule CPU baseline vs ON-rule GPU run for a runtime-specific no-op path.
+
+    marker must be absent from both plans; results of the OFF-CPU and ON-GPU
+    runs must match. Use this only when the rule is expected to skip itself for
+    a known runtime or plan shape. Every required_on_markers entry must still be
+    present in the ON plan to prove the test reached the expected shape.
+    """
+    cpu_rows, off_plan = with_cpu_session(
+        lambda s: collect_and_plan(s, fn, physical), conf=off_conf)
+    gpu_rows, on_plan = with_gpu_session(
+        lambda s: collect_and_plan(s, fn, physical), conf=on_conf)
+
+    assert marker not in on_plan, \
+        "runtime skip failed: marker '%s' present with rule ON\n%s" % (marker, on_plan)
+    assert marker not in off_plan, \
+        "marker '%s' present with rule OFF, not a valid skipped-path check\n%s" % (
+            marker, off_plan)
+    for required_marker in required_on_markers:
+        assert required_marker in on_plan, \
+            "required marker '%s' missing from rule ON plan\n%s" % (required_marker, on_plan)
 
     assert_equal_with_local_sort(cpu_rows, gpu_rows)

--- a/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
+++ b/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
@@ -72,8 +72,8 @@ def _skewed_bhj_global_agg(spark):
 @pytest.mark.private_optimizer
 @pytest.mark.skipif(
     is_databricks_runtime(),
-    reason="Databricks executor-broadcast AQE can put the materialized shuffle on the "
-           "BHJ build side; this marker test covers streamed-side skew split. "
+    reason="The positive rule-fire assertion is Apache-only; the Databricks "
+           "executor-broadcast guarded path is covered by the skipped-path test below. "
            "See https://github.com/NVIDIA/cudf-spark/issues/15136")
 def test_optimize_skewed_bhj_join(spark_tmp_path):
     """OptimizeSkewedBHJJoinRule splits a skewed partition on the streamed side

--- a/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
+++ b/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
@@ -27,7 +27,9 @@ SKEWED_BHJ_MARKER = "coalesced and skewed"
 # executorBroadcast. This marker proves the shim guard's exact precondition was
 # reached rather than accepting any broadcast hash join as a skipped-rule path.
 DB_EXECUTOR_BROADCAST_MARKER = "GpuBuildRight, false, true"
-DB_COALESCED_READER_MARKER = "GpuCustomShuffleReader coalesced"
+# The keyed exchange identifies the explicitly repartitioned streamed input.
+# GpuShuffleCoalesce alone is not specific because aggregate stages can add it.
+DB_STREAMED_SHUFFLE_MARKER = "GpuColumnarExchange gpuhashpartitioning(key1"
 
 
 def _skewed_bhj_conf_extra():
@@ -106,9 +108,9 @@ def test_optimize_skewed_bhj_join_skips_on_databricks_executor_broadcast(spark_t
     rewrite, as verified by the positive Apache test above. The streamed-side
     skew marker must remain absent while CPU and GPU results still match. The
     required markers verify a non-null-aware, executor-broadcast build-right join
-    with an ordinary coalesced reader."""
+    whose streamed input retains the expected GPU hash-partitioning exchange."""
     on, off = _skewed_bhj_confs()
     assert_rule_skipped(_skewed_bhj_global_agg, on, off, marker=SKEWED_BHJ_MARKER,
                         physical=True, required_on_markers=(
                             DB_EXECUTOR_BROADCAST_MARKER,
-                            DB_COALESCED_READER_MARKER))
+                            DB_STREAMED_SHUFFLE_MARKER))

--- a/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
+++ b/integration_tests/src/main/python/private_optimizer_skewed_bhj_join_test.py
@@ -16,32 +16,22 @@ import pytest
 
 from private_optimizer_common import (
     assert_rule_fires,
+    assert_rule_skipped,
     private_optimizer_conf,
 )
 from spark_session import is_databricks_runtime
 
 
-@pytest.mark.private_optimizer
-@pytest.mark.skipif(
-    is_databricks_runtime(),
-    reason="Databricks executor-broadcast AQE can put the materialized shuffle on the "
-           "BHJ build side; this marker test covers streamed-side skew split. "
-           "See https://github.com/NVIDIA/cudf-spark/issues/15136")
-def test_optimize_skewed_bhj_join(spark_tmp_path):
-    """OptimizeSkewedBHJJoinRule splits a skewed partition on the streamed side
-    of an AQE broadcast hash join. Needs a runtime broadcast (static
-    autoBroadcastJoinThreshold=-1, adaptive.autoBroadcastJoinThreshold=10m) so
-    the streamed side is a materialized shuffle stage, plus small skew
-    thresholds. Marker: the shuffle reader is 'coalesced and skewed'.
+SKEWED_BHJ_MARKER = "coalesced and skewed"
+# The DB GpuBroadcastHashJoinExec plan ends with isNullAwareAntiJoin and
+# executorBroadcast. This marker proves the shim guard's exact precondition was
+# reached rather than accepting any broadcast hash join as a skipped-rule path.
+DB_EXECUTOR_BROADCAST_MARKER = "GpuBuildRight, false, true"
+DB_COALESCED_READER_MARKER = "GpuCustomShuffleReader coalesced"
 
-    The rule additionally short-circuits in OptimizeSkewedBHJJoinRule.apply when
-    AQEUtils.isOptimizeSkewBHJSupported is false, so if a future Spark/runtime
-    drops support the rule becomes a no-op and the marker assertion below fails
-    loudly rather than passing silently.
 
-    Validated with a small GLOBAL aggregate over the materialized skewed join;
-    a GROUP BY on the skew key is intentionally avoided here."""
-    conf_extra = {
+def _skewed_bhj_conf_extra():
+    return {
         "spark.sql.adaptive.enabled": "true",
         "spark.sql.adaptive.skewJoin.enabled": "true",
         "spark.sql.autoBroadcastJoinThreshold": "-1",
@@ -53,19 +43,72 @@ def test_optimize_skewed_bhj_join(spark_tmp_path):
         "spark.sql.adaptive.localShuffleReader.enabled": "false",
     }
 
-    def fn(spark):
-        spark.range(0, 2000, 1, 10).selectExpr(
-            "CASE WHEN id < 1000 THEN 249 ELSE id END AS key2", "id AS value2"
-        ).createOrReplaceTempView("skewData2")
-        spark.range(0, 1000, 1, 10).selectExpr(
-            "CASE WHEN id < 250 THEN 249 WHEN id >= 750 THEN 1000 ELSE id END AS key1", "id AS value1"
-        ).createOrReplaceTempView("skewData1")
-        return spark.sql(
-            "SELECT count(*) AS cnt, min(value2) AS mn, max(value2) AS mx, sum(value1) AS sm "
-            "FROM skewData1 JOIN skewData2 ON key1 = key2")
 
+def _skewed_bhj_confs():
+    conf_extra = _skewed_bhj_conf_extra()
     on = private_optimizer_conf(
-        {"spark.rapids.sql.adaptive.skewJoin.broadcast.enabled": "true"}, extra_conf=conf_extra)
+        {"spark.rapids.sql.adaptive.skewJoin.broadcast.enabled": "true"},
+        extra_conf=conf_extra)
     off = private_optimizer_conf(
-        {"spark.rapids.sql.adaptive.skewJoin.broadcast.enabled": "false"}, extra_conf=conf_extra)
-    assert_rule_fires(fn, on, off, marker="coalesced and skewed", physical=True)
+        {"spark.rapids.sql.adaptive.skewJoin.broadcast.enabled": "false"},
+        extra_conf=conf_extra)
+    return on, off
+
+
+def _skewed_bhj_global_agg(spark):
+    spark.range(0, 2000, 1, 10).selectExpr(
+        "CASE WHEN id < 1000 THEN 249 ELSE id END AS key2", "id AS value2"
+    ).createOrReplaceTempView("skewData2")
+    spark.range(0, 1000, 1, 10).selectExpr(
+        "CASE WHEN id < 250 THEN 249 WHEN id >= 750 THEN 1000 ELSE id END AS key1",
+        "id AS value1"
+    ).repartition(100, "key1").createOrReplaceTempView("skewData1")
+    return spark.sql(
+        "SELECT /*+ BROADCAST(skewData2) */ "
+        "count(*) AS cnt, min(value2) AS mn, max(value2) AS mx, sum(value1) AS sm "
+        "FROM skewData1 JOIN skewData2 ON key1 = key2")
+
+
+@pytest.mark.private_optimizer
+@pytest.mark.skipif(
+    is_databricks_runtime(),
+    reason="Databricks executor-broadcast AQE can put the materialized shuffle on the "
+           "BHJ build side; this marker test covers streamed-side skew split. "
+           "See https://github.com/NVIDIA/cudf-spark/issues/15136")
+def test_optimize_skewed_bhj_join(spark_tmp_path):
+    """OptimizeSkewedBHJJoinRule splits a skewed partition on the streamed side
+    of an AQE broadcast hash join. The broadcast hint fixes the build side while
+    the explicit key repartition makes the streamed side a materialized shuffle
+    stage; small skew thresholds make the key 249 partition eligible to split.
+    Marker: the shuffle reader is 'coalesced and skewed'.
+
+    The rule additionally short-circuits in OptimizeSkewedBHJJoinRule.apply when
+    AQEUtils.isOptimizeSkewBHJSupported is false, so if a future Spark/runtime
+    drops support the rule becomes a no-op and the marker assertion below fails
+    loudly rather than passing silently.
+
+    Validated with a small GLOBAL aggregate over the materialized skewed join;
+    a GROUP BY on the skew key is intentionally avoided here."""
+    on, off = _skewed_bhj_confs()
+    assert_rule_fires(_skewed_bhj_global_agg, on, off, marker=SKEWED_BHJ_MARKER,
+                      physical=True)
+
+
+@pytest.mark.private_optimizer
+@pytest.mark.skipif(
+    not is_databricks_runtime(),
+    reason="Databricks-only coverage for executor-broadcast AQE fallback. "
+           "Apache runtime coverage is in test_optimize_skewed_bhj_join.")
+def test_optimize_skewed_bhj_join_skips_on_databricks_executor_broadcast(spark_tmp_path):
+    """Databricks executor-broadcast AQE is expected to skip the streamed-side
+    rewrite even when the streamed input is a materialized skewed shuffle stage.
+    Without the executor-broadcast shim guard this shape is eligible for the
+    rewrite, as verified by the positive Apache test above. The streamed-side
+    skew marker must remain absent while CPU and GPU results still match. The
+    required markers verify a non-null-aware, executor-broadcast build-right join
+    with an ordinary coalesced reader."""
+    on, off = _skewed_bhj_confs()
+    assert_rule_skipped(_skewed_bhj_global_agg, on, off, marker=SKEWED_BHJ_MARKER,
+                        physical=True, required_on_markers=(
+                            DB_EXECUTOR_BROADCAST_MARKER,
+                            DB_COALESCED_READER_MARKER))


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: not measurable locally — the new path requires the private optimizer on a Databricks runtime**

Contributes to #15136.

## Summary

The corresponding private optimizer fix has landed. This PR adds public regression coverage for its Databricks executor-broadcast guard:

- keep the positive `coalesced and skewed` rule-fire test on Apache Spark
- add a Databricks-only skipped-path test that requires the exact executor-broadcast plan shape and verifies the skew rewrite stays absent
- preserve OFF-CPU versus ON-GPU result parity in both paths
- document intentional runtime/plan guards without weakening positive marker checks

## Regression shape

The query deliberately combines a right-side `BROADCAST` hint with an explicit key repartition on the streamed left side. On Databricks this reaches a non-null-aware executor-broadcast, build-right join (`GpuBuildRight, false, true`) whose streamed input is a materialized shuffle.

That shape is important: before !377 the shared rule is eligible to rewrite the streamed shuffle and produces `GpuCustomShuffleReader coalesced and skewed`; after !377 the Databricks shim guard skips the rule and leaves a streamed-side `GpuColumnarExchange gpuhashpartitioning(key1...)` below `GpuShuffleCoalesce`. Requiring both Databricks plan markers prevents the skipped-path assertion from passing on an unrelated BHJ shape.

## Validation

- Spark 3.3 / Python 3.10 focused IT: 1 passed, 1 skipped (the Databricks-only case is skipped locally)
- the replacement streamed-shuffle marker is present in the captured DBR 13.3 and 17.3 Blossom final plans; full DBR execution is covered by the new Blossom run

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
