### PR TITLE
Balance Databricks CI test split

### DIFF
--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -45,7 +45,8 @@ set -ex
 # - DELTA_LAKE_ONLY: delta_lake tests only
 # - MULTITHREADED_SHUFFLE: shuffle tests only
 # - PYARROW_ONLY: pyarrow tests only
-# - CI_PART1 or CI_PART2 : part1 or part2 of the tests run in parallel from CI
+# - CI_PART1 or CI_PART2 : part1 or part2 of the tests run in parallel from CI.
+#   CI_PART2 includes nightly resource-consuming tests to keep the split runtimes closer.
 TEST_MODE=${TEST_MODE:-'DEFAULT'}
 
 # CI_PART2 untars the spark-rapids tgz built by C1_PART1 instead of rebuilding it
@@ -104,6 +105,11 @@ run_pyarrow_tests() {
         bash integration_tests/run_pyspark_from_build.sh -m pyarrow_test --pyarrow_test --runtime_env="databricks" --test_type=$TEST_TYPE
 }
 
+# Move selected tests to CI_PART2 so the split CI jobs finish closer together.
+# Keep DEFAULT unchanged so manual/default runs still cover everything in the historical order.
+CI_PART2_BALANCED_TESTS="json_test orc_test parquet_test sort_test window_function_test"
+CI_PART2_BALANCED_TEST_EXPR="${CI_PART2_BALANCED_TESTS// / or }"
+
 ## Separate the integration tests into "CI_PART1" and "CI_PART2", run each part in parallel on separate Databricks clusters to speed up the testing process.
 if [[ $TEST_MODE == "DEFAULT" || $TEST_MODE == "CI_PART1" ]]; then
     # Run two-shim smoke test with the base Spark build
@@ -138,11 +144,23 @@ if [[ $TEST_MODE == "DEFAULT" || $TEST_MODE == "CI_PART1" ]]; then
         PYSP_TEST_spark_shuffle_manager=com.nvidia.spark.rapids.${UPSTREAM_SHIM_VER}.RapidsShuffleManager \
             bash integration_tests/run_pyspark_from_build.sh
     fi
-    bash integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" --test_type=$TEST_TYPE
+    if [[ "$TEST_MODE" == "CI_PART1" ]]; then
+        bash integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" \
+            --test_type=$TEST_TYPE -k "not ($CI_PART2_BALANCED_TEST_EXPR)"
+    else
+        bash integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" --test_type=$TEST_TYPE
+    fi
 fi
 
 ## Run tests with jars building from the spark-rapids source code
 if [[ "$(pwd)" == "$SOURCE_PATH" ]]; then
+    if [[ "$TEST_MODE" == "CI_PART2" ]]; then
+        ## Run the balanced integration tests moved out of CI_PART1
+        TESTS="${CI_PART2_BALANCED_TESTS// /.py }.py" \
+            bash integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" \
+                --test_type=$TEST_TYPE
+    fi
+
     ## Run cache tests
     if [[ "$IS_SPARK_321_OR_LATER" -eq "1" && ("$TEST_MODE" == "DEFAULT" || $TEST_MODE == "CI_PART2") ]]; then
         PYSP_TEST_spark_sql_cache_serializer=${PCBS_CONF} \


### PR DESCRIPTION

fix bug: https://github.com/NVIDIA/cudf-spark/issues/15156

Move the heaviest file-level integration test groups into CI_PART2 so CI_PART1 and CI_PART2 finish closer together.
The selected modules are json_test.py, orc_test.py, parquet_test.py, sort_test.py, and window_function_test.py.

Use TESTS for the CI_PART2 run because these entries are module filenames rather than pytest markers.
Generate a matching pytest -k expression from the same list so CI_PART1 excludes the modules without changing DEFAULT behavior.

Before this change, recent upstream Databricks pre-merge runs were uneven: CI_PART1 took about 5h 15m and CI_PART2 took about 1h 31m, a gap of roughly 3h 44m.
| Build | Mode | Duration | total |
|---|---:|---:|---:|
| `premerge-github #3531` | `CI_PART1` | ~5h 15m | Combined duration |
| `premerge-github #3532`| `CI_PART2` | ~1h 31m | ~6h 46m |

After this change, validation fork runs were much closer: CI_PART1/CI_PART2 took 3h 34m 20s / 3h 09m 14s for one pair, and 3h 36m 30s / 3h 15m 35s for another pair.

| Pair | CI_PART1 | CI_PART2 | Combined duration |
|---|---:|---:|---:|
| `premerge-github` | 3h 34m | 3h 09m 14s | 6h 43m |
| `premerge-github ` | 3h 36m | 3h 15m 35s | 6h 52m |


This split is much closer than the previous upstream `CI_PART1`/`CI_PART2` gap and should reduce idle time in the parallel Databricks integration workflow.


This keeps the historical DEFAULT test coverage intact while allowing parallel CI modes to divide the expensive integration tests more evenly.


Benefits

**By rebalancing the selected integration test suites, `CI_PART1` and `CI_PART2` can finish at about the same time, around 3.5 hours after the two jobs start running. This reduces the Databricks pre-merge critical path from about 5.5 hours to about 3.5 hours.**



Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required


