### PR TITLE
Harden plugin shutdown to run all steps on failure

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -436,6 +436,25 @@ object RapidsPluginUtils extends Logging {
         s"Binaries available for architectures $supportedMajorArchStr.")
     }
   }
+
+  /**
+   * Runs each shutdown step even if prior steps fail. The first exception is primary; later
+   * exceptions are added as suppressed. Rethrows the primary exception if any step failed.
+   */
+  def safeShutdown(steps: Seq[() => Unit]): Unit = {
+    var shutdownException: Throwable = null
+    steps.foreach { step =>
+      try {
+        step()
+      } catch {
+        case e: Throwable if shutdownException == null => shutdownException = e
+        case e: Throwable => shutdownException.addSuppressed(e)
+      }
+    }
+    if (shutdownException != null) {
+      throw shutdownException
+    }
+  }
 }
 
 /**
@@ -549,11 +568,13 @@ class RapidsDriverPlugin extends DriverPlugin with Logging {
   }
 
   override def shutdown(): Unit = {
-    extraDriverPlugins.foreach(_.shutdown())
-    FileCacheLocalityManager.shutdown()
-    // Shutdown listener first to trigger cleanup for any remaining jobs
-    Option(shuffleCleanupListener).foreach(_.shutdown())
-    ShuffleCleanupManager.shutdown()
+    RapidsPluginUtils.safeShutdown(
+      extraDriverPlugins.map(plugin => () => plugin.shutdown()) ++
+        Seq(
+          () => FileCacheLocalityManager.shutdown(),
+          // Shutdown listener first to trigger cleanup for any remaining jobs
+          () => Option(shuffleCleanupListener).foreach(_.shutdown()),
+          () => ShuffleCleanupManager.shutdown()))
   }
 }
 
@@ -804,20 +825,23 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   }
 
   override def shutdown(): Unit = {
-    GpuTimeZoneDB.shutdown()
-    GpuSemaphore.shutdown()
-    PythonWorkerSemaphore.shutdown()
-    GpuDeviceManager.shutdown()
-    ProfilerOnExecutor.shutdown()
-    if (isAsyncProfilerEnabled) {
-      AsyncProfilerOnExecutor.shutdown()
-    }
-    Option(rapidsShuffleHeartbeatEndpoint).foreach(_.close())
-    Option(shuffleCleanupEndpoint).foreach(_.close())
-    extraExecutorPlugins.foreach(_.shutdown())
-    FileCache.shutdown()
-    GpuCoreDumpHandler.shutdown()
-    TrafficController.shutdown()
+    RapidsPluginUtils.safeShutdown(
+      Seq(
+        () => GpuTimeZoneDB.shutdown(),
+        () => GpuSemaphore.shutdown(),
+        () => PythonWorkerSemaphore.shutdown(),
+        () => GpuDeviceManager.shutdown(),
+        () => ProfilerOnExecutor.shutdown(),
+        () => if (isAsyncProfilerEnabled) {
+          AsyncProfilerOnExecutor.shutdown()
+        },
+        () => Option(rapidsShuffleHeartbeatEndpoint).foreach(_.close()),
+        () => Option(shuffleCleanupEndpoint).foreach(_.close())) ++
+        extraExecutorPlugins.map(plugin => () => plugin.shutdown()) ++
+        Seq(
+          () => FileCache.shutdown(),
+          () => GpuCoreDumpHandler.shutdown(),
+          () => TrafficController.shutdown()))
   }
 
   override def onTaskFailed(failureReason: TaskFailedReason): Unit = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsExecutorPluginSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsExecutorPluginSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,5 +48,37 @@ class RapidsExecutorPluginSuite extends AnyFunSuite {
     assert(RapidsExecutorPlugin.cudfVersionSatisfied("7.0.2.2.2", "7.0.2.2.2"))
     assert(RapidsExecutorPlugin.cudfVersionSatisfied("7.0.1-20220101.001122-12", "7.0.1-SNAPSHOT"))
     assert(!RapidsExecutorPlugin.cudfVersionSatisfied("7.0.1-SNAPSHOT", "7.0.1-20220101.001122-12"))
+  }
+
+  test("safeShutdown runs all steps when none fail") {
+    var count = 0
+    RapidsPluginUtils.safeShutdown(Seq(
+      () => count += 1,
+      () => count += 1))
+    assert(count === 2)
+  }
+
+  test("safeShutdown runs remaining steps after a failure") {
+    var count = 0
+    val ex = intercept[RuntimeException] {
+      RapidsPluginUtils.safeShutdown(Seq(
+        () => count += 1,
+        () => throw new RuntimeException("first"),
+        () => count += 1,
+        () => throw new IllegalStateException("second")))
+    }
+    assert(count === 2)
+    assert(ex.getMessage === "first")
+    assert(ex.getSuppressed.length === 1)
+    assert(ex.getSuppressed()(0).isInstanceOf[IllegalStateException])
+    assert(ex.getSuppressed()(0).getMessage === "second")
+  }
+
+  test("safeShutdown rethrows the only failure") {
+    val ex = intercept[RuntimeException] {
+      RapidsPluginUtils.safeShutdown(Seq(() => throw new RuntimeException("only")))
+    }
+    assert(ex.getMessage === "only")
+    assert(ex.getSuppressed.isEmpty)
   }
 }


### PR DESCRIPTION
Fixes #10350.

### Description

`RapidsDriverPlugin` and `RapidsExecutorPlugin` call multiple subcomponent
`shutdown()` methods sequentially without error handling. If an early step
throws (for example `GpuDeviceManager.shutdown()`), later cleanup steps are
skipped and resources may not be torn down.

This change adds `RapidsPluginUtils.safeShutdown`, which runs every shutdown
step in the existing order even when prior steps fail. The semantics mirror
`RapidsPluginImplicits.safeClose`: the first exception is primary, subsequent
exceptions are added as suppressed, and the primary exception is rethrown at
the end if any step failed.

Both driver and executor plugin `shutdown()` methods now delegate to
`safeShutdown`. Each entry in `extraDriverPlugins` / `extraExecutorPlugins`
is registered as its own step so one failing plugin does not prevent other
plugins from shutting down. Shutdown order is unchanged, including the
conditional `AsyncProfilerOnExecutor.shutdown()` guard and `Option` endpoint
`close()` calls.

Unit tests in `RapidsExecutorPluginSuite` cover the success path, continued
execution after a failure, and suppressed-exception aggregation.

### Validation

- `mvn package -pl tests -am -DwildcardSuites="com.nvidia.spark.rapids.RapidsExecutorPluginSuite"` - BUILD SUCCESS
- `mvn verify -DskipTests -Dbuildver=330` - BUILD SUCCESS

GPU integration tests were not run locally (no NVIDIA GPU on dev machine).
Requesting a committer to comment `build` to trigger Blossom-CI.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required