### PR TITLE
Fix Iceberg class packaging across shims [databricks]

### DIFF
--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -12,7 +12,6 @@ com/nvidia/spark/rapids/fileio/iceberg/IcebergInputFile.class
 com/nvidia/spark/rapids/fileio/iceberg/IcebergInputStream.class
 com/nvidia/spark/rapids/fileio/iceberg/IcebergOutputFile.class
 com/nvidia/spark/rapids/fileio/iceberg/IcebergOutputStream.class
-com/nvidia/spark/rapids/iceberg/GpuInternalRow.class
 com/nvidia/spark/rapids/iceberg/GpuInternalRowBase.class
 com/nvidia/spark/rapids/iceberg/data/GpuDeleteFilter2.class
 com/nvidia/spark/rapids/iceberg/package.class
@@ -32,7 +31,6 @@ com/nvidia/spark/rapids/iceberg/spark/RapidsSparkCatalog.class
 com/nvidia/spark/rapids/iceberg/spark/RapidsSparkSessionCatalog.class
 com/nvidia/spark/rapids/iceberg/spark/source/RapidsSparkTable.class
 org/apache/iceberg/aws/s3/IcebergS3InputFileAccess.class
-org/apache/iceberg/data/GpuFileHelpers.class
 org/apache/iceberg/io/GpuClusteredWriterBridge.class
 org/apache/iceberg/io/GpuFanoutWriterBridge.class
 org/apache/iceberg/io/GpuPositionDeleteFileWriter$.class
@@ -47,7 +45,6 @@ org/apache/iceberg/spark/source/GpuBaseReader.class
 org/apache/iceberg/spark/source/GpuSparkPlanningUtil.class
 org/apache/iceberg/spark/source/GpuSparkScanAccess.class
 org/apache/iceberg/spark/source/GpuSparkWriteAccess.class
-org/apache/iceberg/spark/source/GpuStructInternalRow.class
 org/apache/spark/sql/rapids/AdaptiveSparkPlanHelperShim*
 org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback*
 rapids/*.py


### PR DESCRIPTION
Fixes NVIDIA/cudf-spark#15152.

### Description

Spark 4.1.1 adds `getGeometry` and `getGeography` to the `InternalRow` contract. Because `GpuInternalRowBase` extends `InternalRow` and `GpuInternalRow` extends `GpuInternalRowBase`, the Spark 4.1.1 implementation of `GpuInternalRow` must implement and delegate these new methods. Its bytecode therefore differs from earlier Spark shims and must not be included in the unshim list.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
