### PR TITLE
[AutoSparkUT] Fix V2 GPU scan sameResult equality [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -117,6 +117,8 @@ case class GpuOrcScan(
     case o: GpuOrcScan =>
       super.equals(o) && dataSchema == o.dataSchema && options == o.options &&
           equivalentFilters(pushedFilters, o.pushedFilters) &&
+          rapidsConf.isOrcFloatTypesToStringEnable ==
+              o.rapidsConf.isOrcFloatTypesToStringEnable &&
           queryUsesInputFile == o.queryUsesInputFile
     case _ => false
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ case class GpuOrcScan(
   override def equals(obj: Any): Boolean = obj match {
     case o: GpuOrcScan =>
       super.equals(o) && dataSchema == o.dataSchema && options == o.options &&
-          equivalentFilters(pushedFilters, o.pushedFilters) && rapidsConf == o.rapidsConf &&
+          equivalentFilters(pushedFilters, o.pushedFilters) &&
           queryUsesInputFile == o.queryUsesInputFile
     case _ => false
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -142,7 +142,7 @@ case class GpuParquetScan(
   override def equals(obj: Any): Boolean = obj match {
     case p: GpuParquetScan =>
       super.equals(p) && dataSchema == p.dataSchema && options == p.options &&
-          equivalentFilters(pushedFilters, p.pushedFilters) && rapidsConf == p.rapidsConf &&
+          equivalentFilters(pushedFilters, p.pushedFilters) &&
           queryUsesInputFile == p.queryUsesInputFile
     case _ => false
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ case class GpuAvroScan(
   override def equals(obj: Any): Boolean = obj match {
     case a: GpuAvroScan =>
       super.equals(a) && dataSchema == a.dataSchema && options == a.options &&
-          equivalentFilters(pushedFilters, a.pushedFilters) && rapidsConf == a.rapidsConf &&
+          equivalentFilters(pushedFilters, a.pushedFilters) &&
           queryUsesInputFile == a.queryUsesInputFile
     case _ => false
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuReaderTypeSuites.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuReaderTypeSuites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import com.nvidia.spark.rapids.RapidsReaderType._
 import com.nvidia.spark.rapids.shims.GpuBatchScanExec
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.rapids.{ExternalSource, GpuFileSourceScanExec}
 
@@ -28,6 +30,7 @@ trait ReaderTypeSuite extends SparkQueryCompareTestSuite {
 
   /** File format */
   protected def format: String
+  protected def expectedV2ScanClassName: String
 
   protected def otherConfs: Iterable[(String, String)] = Seq.empty
   protected def testContextOk: Boolean = true
@@ -148,18 +151,73 @@ trait ReaderTypeSuite extends SparkQueryCompareTestSuite {
       testReaderType(conf, testFile, MULTITHREADED)
     })
   }
+
+  test("[SPARK-16818] V2 GPU partition-pruned scans implement sameResult correctly") {
+    assume(testContextOk)
+    withTempPath { file =>
+      withCpuSparkSession(spark => {
+        import spark.implicits._
+        Seq((1, 10), (2, 20), (3, 30))
+          .toDF("id", "b")
+          .write
+          .partitionBy("id")
+          .format(format)
+          .save(file.getCanonicalPath)
+      })
+
+      val conf = new SparkConf()
+        .set("spark.sql.sources.useV1SourceList", "")
+        .set("spark.sql.adaptive.enabled", "false")
+
+      withGpuSparkSession(spark => {
+        val df = spark.read.format(format).load(file.toString)
+
+        def getPlanAndScan(partition: Int): (DataFrame, SparkPlan, GpuBatchScanExec) = {
+          val filtered = df.where(s"id = $partition")
+          val plan = filtered.queryExecution.executedPlan
+          val scans = plan.collect { case scan: GpuBatchScanExec => scan }
+          assert(scans.length == 1, s"Expected one GPU V2 scan, found ${scans.length}")
+          assert(scans.head.scan.getClass.getName == expectedV2ScanClassName,
+            s"Expected $expectedV2ScanClassName, found ${scans.head.scan.getClass.getName}")
+          (filtered, plan, scans.head)
+        }
+
+        val (df2a, p2a, s2a) = getPlanAndScan(2)
+        val (_, p2b, s2b) = getPlanAndScan(2)
+        val (_, p3, s3) = getPlanAndScan(3)
+
+        val rows = df2a.collect()
+        assert(rows.length == 1)
+        assert(rows.head.getAs[Int]("b") == 20)
+
+        assert(p2a.sameResult(p2b), "Equivalent V2 scan plans should have the same result")
+        assert(s2a.sameResult(s2b), "Equivalent V2 batch scans should have the same result")
+        assert(s2a.scan == s2b.scan, "Equivalent V2 scans should be equal")
+        assert(!p2a.sameResult(p3), "Different partition filters should not have the same result")
+        assert(!s2a.sameResult(s3),
+          "V2 batch scans with different partition filters should not have the same result")
+        assert(s2a.scan != s3.scan, "V2 scans with different partition filters should not be equal")
+      }, conf.setAll(otherConfs))
+    }
+  }
 }
 
 class GpuParquetReaderTypeSuites extends ReaderTypeSuite {
   override protected def format: String = "parquet"
+  override protected def expectedV2ScanClassName: String =
+    "com.nvidia.spark.rapids.parquet.GpuParquetScan"
 }
 
 class GpuOrcReaderTypeSuites extends ReaderTypeSuite {
   override protected def format: String = "orc"
+  override protected def expectedV2ScanClassName: String =
+    "com.nvidia.spark.rapids.GpuOrcScan"
 }
 
 class GpuAvroReaderTypeSuites extends ReaderTypeSuite {
   override lazy val format: String = "avro"
+  override protected def expectedV2ScanClassName: String =
+    "org.apache.spark.sql.rapids.GpuAvroScan"
   override lazy val otherConfs: Iterable[(String, String)] = Seq(
     ("spark.rapids.sql.format.avro.read.enabled", "true"),
     ("spark.rapids.sql.format.avro.enabled", "true"))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuReaderTypeSuites.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuReaderTypeSuites.scala
@@ -193,6 +193,20 @@ trait ReaderTypeSuite extends SparkQueryCompareTestSuite {
         assert(p2a.sameResult(p2b), "Equivalent V2 scan plans should have the same result")
         assert(s2a.sameResult(s2b), "Equivalent V2 batch scans should have the same result")
         assert(s2a.scan == s2b.scan, "Equivalent V2 scans should be equal")
+        s2a.scan match {
+          case scan: GpuOrcScan =>
+            def withFloatToString(enabled: Boolean): GpuOrcScan =
+              scan.copy(rapidsConf = new RapidsConf(Map(
+                RapidsConf.ENABLE_ORC_FLOAT_TYPES_TO_STRING.key -> enabled.toString)))
+            val enabled1 = withFloatToString(enabled = true)
+            val enabled2 = withFloatToString(enabled = true)
+            val disabled = withFloatToString(enabled = false)
+            assert(enabled1 == enabled2,
+              "ORC V2 scans with equal float-to-string settings should be equal")
+            assert(enabled1 != disabled,
+              "ORC V2 scans with different float-to-string settings should not be equal")
+          case _ =>
+        }
         assert(!p2a.sameResult(p3), "Different partition filters should not have the same result")
         assert(!s2a.sameResult(s3),
           "V2 batch scans with different partition filters should not have the same result")


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +3 lines** (`GpuOrcScan` +1, `GpuParquetScan` +1, `GpuAvroScan` +1; fix-line measurement, shim 330).

Closes #15161.

## What changed

`GpuOrcScan`, `GpuParquetScan`, and `GpuAvroScan` compared `RapidsConf` instances in their `equals` implementations. `RapidsConf` uses object identity equality, so separately planned but semantically equivalent V2 scans failed canonical plan equality and `sameResult`.

This change removes the reader-configuration object from scan equality, matching Spark's V2 `FileScan` semantics and the existing V1 GPU scan policy. Result-defining scan fields and normalized partition/data filters remain part of equality, so scans with different partition filters still compare unequal.

### Why `RapidsConf` is intentionally excluded

`sameResult` compares result semantics, not every execution setting. Comparing the entire `RapidsConf` by value would incorrectly make operational options such as reader strategy, batching, threading, memory, and debug settings part of scan identity, so equivalent scans could remain unequal when only non-semantic settings differ. Spark CPU [`FileScan.equals`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala#L92-L113) excludes the session configuration, and the GPU V1 fix in [PR #1310](https://github.com/NVIDIA/cudf-spark/pull/1310) established the same policy.

The V2 scans still compare their result-defining file, schema, option, and filter state. If a specific RAPIDS setting ever changes returned rows, values, or schema, that effective value should be compared explicitly rather than comparing the whole `RapidsConf` container.

The regression test forces V2 GPU scans and covers Parquet, ORC, and Avro. It verifies positive and negative equality at the full plan, `GpuBatchScanExec`, and underlying scan levels, then executes the selected GPU scan and checks its result.

## Test traceability

- RAPIDS test: `[SPARK-16818] V2 GPU partition-pruned scans implement sameResult correctly`
- Original Spark test: `[SPARK-16818] partition pruned file scans implement sameResult correctly`
- Spark source: `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala`, lines 420-437
- Adaptation: force DataSource V2 and exercise GPU Parquet, ORC, and Avro scans

## Validation

Spark 3.3 GPU suites:

```text
GpuParquetReaderTypeSuites
GpuOrcReaderTypeSuites
GpuAvroReaderTypeSuites

Tests: succeeded 21, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

Root-project RAT and scalastyle verification:

```text
Processed 1652 file(s)
Found 0 errors
Found 0 warnings
BUILD SUCCESS
```

JaCoCo fix-line intersection covered all three executable production changes: 3 of 5 added production lines; the two uncovered additions are copyright-year updates.

## Performance impact

This only changes equality used during plan canonicalization/reuse, a cold planning path. It does not change GPU kernels, scan I/O, execution loops, or memory behavior. Equivalent V2 scans can now participate in canonicalization and reuse as intended.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
