### PR TITLE
Use configured copy buffer for Hadoop vectored reads

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/hadoop/HadoopInputFile.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/hadoop/HadoopInputFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 package com.nvidia.spark.rapids.fileio.hadoop;
 
+import ai.rapids.cudf.HostMemoryBuffer;
 import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.jni.fileio.SeekableInputStream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 import java.util.OptionalLong;
 
@@ -34,21 +35,30 @@ import java.util.OptionalLong;
  * for reading the file.
  */
 public class HadoopInputFile implements RapidsInputFile {
+    private static final String PARQUET_READ_ALLOCATION_SIZE = "parquet.read.allocation.size";
+
     private final Path filePath;
     private final FileSystem fs;
+    private final int copyBufferSize;
 
     public static HadoopInputFile create(Path filePath, Configuration conf) throws IOException {
         Objects.requireNonNull(filePath, "filePath can't be null!");
         Objects.requireNonNull(conf, "Hadoop conf can't be null");
         FileSystem fs = filePath.getFileSystem(conf);
-        return new HadoopInputFile(filePath, fs);
+        int copyBufferSize = conf.getInt(PARQUET_READ_ALLOCATION_SIZE,
+                RapidsInputFile.DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE);
+        return new HadoopInputFile(filePath, fs, copyBufferSize);
     }
 
-    private HadoopInputFile(Path filePath, FileSystem fs) {
+    private HadoopInputFile(Path filePath, FileSystem fs, int copyBufferSize) {
         Objects.requireNonNull(filePath, "filePath can't be null!");
         Objects.requireNonNull(fs, "FileSystem can't be null");
+        if (copyBufferSize <= 0) {
+            throw new IllegalArgumentException(PARQUET_READ_ALLOCATION_SIZE + " must be positive");
+        }
         this.filePath = filePath;
         this.fs = fs;
+        this.copyBufferSize = copyBufferSize;
     }
 
     @Override
@@ -69,5 +79,15 @@ public class HadoopInputFile implements RapidsInputFile {
     @Override
     public SeekableInputStream open() throws IOException {
         return new HadoopInputStream(fs.open(filePath));
+    }
+
+    @Override
+    public void readVectored(HostMemoryBuffer output, List<RapidsInputFile.CopyRange> copyRanges)
+            throws IOException {
+        if (copyRanges.isEmpty()) {
+            return;
+        }
+        byte[] copyBuffer = new byte[copyBufferSize];
+        RapidsInputFile.readVectoredUsingCopyBuffer(this, output, copyRanges, copyBuffer);
     }
 }


### PR DESCRIPTION
Fixes #15163.

### Description

When an optimized input-file implementation is not selected, remote Parquet reads use `HadoopInputFile` and the generic `RapidsInputFile.readVectored` fallback. Before NVIDIA/cudf-spark-jni#4765, that fallback used `HostMemoryBuffer.copyFromStream` with a 128 KiB internal copy chunk, while the pre-NVIDIA/cudf-spark#14674 Hadoop copy loop used `parquet.read.allocation.size` with an 8 MiB default.

This PR overrides `HadoopInputFile.readVectored` to use the caller-supplied-buffer helper from NVIDIA/cudf-spark-jni#4765:

- read the copy size from `parquet.read.allocation.size`
- default to the JNI fallback size of 8 MiB
- allocate a temporary buffer for each `readVectored` call
- avoid a retained shared buffer or `ThreadLocal` state
- leave `GpuParquetScan` on the `inputFile.readVectored` abstraction introduced by #14674

The measured regression was on the S3A fallback with PerfIO disabled. The same `HadoopInputFile` fallback is also used by GCS and other Hadoop-backed filesystems that do not provide their own optimized `readVectored` implementation. When S3 PerfIO is enabled, `S3InputFile.readVectored` continues to use the optimized PerfIO path and bypasses this fallback.

Requires the JNI change from NVIDIA/cudf-spark-jni#4765, merged as `f5c95d88e16846a66a61870441e73c84863e706c`. The `release/26.06` base branch selects JNI `26.06.1-SNAPSHOT` through #15228.

### Testing

The JNI change (`901ca4f570cb843c814121a7698ba8b3d5896fbf`) passed all eight `RapidsInputFileTest` tests. After installing that JNI artifact locally, the cudf-spark change commit (`ba4487c750ba73cf2f2281288ca319ad7f3752be`) was packaged on an x86 host with:

```text
mvn -B -pl sql-plugin -am -DskipTests \
  -Dspark-rapids-jni.version=26.06.1-SNAPSHOT package
```

Result: `BUILD SUCCESS`.

### Performance Validation

Five interleaved full-NDS runs per configuration did not reproduce a stable performance regression after the fix, with either PerfIO disabled or enabled. See #15163 for the complete environment, per-run results, and analysis.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
