### PR TITLE
[BUG] Fix regex transpiler corner case: split word boundaries (#14748)

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -197,7 +197,12 @@ def test_split_optimized_no_re_combined():
 @allow_non_gpu('ProjectExec', 'StringSplit')
 def test_split_unsupported_fallback():
     data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \
-        .with_special_case('boo:and:foo')
+        .with_special_case('boo:and:foo') \
+        .with_special_case('foo bar') \
+        .with_special_case('hello world') \
+        .with_special_case('a') \
+        .with_special_case(' leading') \
+        .with_special_case('trailing ')
     assert_gpu_sql_fallback_collect(
         lambda spark : unary_op_df(spark, data_gen),
         'StringSplit',
@@ -205,6 +210,11 @@ def test_split_unsupported_fallback():
         'select ' +
         'split(a, "o*"),' +
         'split(a, "o?") from string_split_table')
+    assert_gpu_sql_fallback_collect(
+        lambda spark : unary_op_df(spark, data_gen),
+        'StringSplit',
+        'string_split_table',
+        'select split(a, "\\\\b") from string_split_table')
 
 def test_split_regexp_disabled_no_fallback():
     conf = { 'spark.rapids.sql.regexp.enabled': 'false' }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -762,6 +762,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
 
   def transpileToSplittableString(e: RegexAST): Option[String] = {
     e match {
+      case RegexEscaped('b') | RegexEscaped('B') => None
       case RegexEscaped(ch) if escapeChars.contains(ch) => Some(escapeChars(ch).toString)
       case RegexEscaped(ch) if regexPunct.contains(ch) => Some(ch.toString)
       case RegexChar(ch) if !regexMetaChars.contains(ch) => Some(ch.toString)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -769,6 +769,10 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     }
   }
 
+  test("issue-14748: word boundaries are not literal split delimiters") {
+    assertNoTranspileToSplittableString(Set(raw"\b", raw"\B"))
+  }
+
   test("regexp_split - character class repetition - ? and *") {
     val patterns = Set(raw"[a-z][0-9]?", raw"[a-z][0-9]*")
     val data = Seq("a", "aa", "a1a1", "a1b2", "a1b")


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +1 line** (`RegexParser.scala` production fix line covered by `RegularExpressionTranspilerSuite`; shim 330)

Closes #14748
Contributes to #14733

## What this fixes

`transpileToSplittableString` no longer converts top-level `\b` and `\B` word-boundary tokens into literal delimiters. The existing split-mode regex validation now rejects those unsupported boundaries and falls back to the CPU `StringSplit` implementation, restoring CPU/GPU parity while preserving the literal fast path for other escapes.

## Approach

No semantic deviation from the issue's suggested fix. The live baseline reproduced the `split` mismatch while `regexp_replace` already matched CPU on current `main`, so the production change is limited to the split-only simplification helper.

## Tests added

- Scala unit: `com.nvidia.spark.rapids.RegularExpressionTranspilerSuite` -> `issue-14748: word boundaries are not literal split delimiters`
- Python IT: `test_split_unsupported_fallback`

## Local validation

Scala suite:

```text
Tests: succeeded 95, failed 0, canceled 6, ignored 0, pending 0
```

Python IT:

```text
1 passed, 74 deselected, 3 warnings in 6.72s
```

End-to-end reproduction on the patched dist JAR:

```text
RAPIDS Enabled: YES
Plugins Loaded: YES
REGEXP_REPLACE_MATCH=true
SPLIT_MATCH=true
ALL_MATCH=true
FIXED_REPRO_EXIT_CODE=0
```

## Performance impact

This adds one constant-time AST match during query planning, not per row, batch, or regex match. Only top-level `\b` and `\B` delimiters leave the incorrect literal fast path and fall back to CPU; all supported split patterns keep their existing path.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
