### PR TITLE
Fix legacy timestamp fallback test with CPU bridge

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -765,7 +765,8 @@ def test_formats_for_legacy_mode_other_formats_tz_rules():
 def test_to_timestamp_legacy_millisecond_format_fallback():
     conf = {
         'spark.sql.legacy.timeParserPolicy': 'LEGACY',
-        'spark.rapids.sql.incompatibleDateFormats.enabled': True
+        'spark.rapids.sql.incompatibleDateFormats.enabled': True,
+        'spark.rapids.sql.expression.cpuBridge.enabled': False
     }
     assert_gpu_fallback_collect(
         lambda spark: spark.createDataFrame(


### PR DESCRIPTION
A test only change that fixes a regression with the GPU/CPU bridge work that was just merged in

### Description

Disable the bridge for the failing test so it can run as is.

### Checklists

Documentation
- [X] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [X] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
