### PR TITLE
Support Iceberg 1.11 on Spark 4.0.2 and 4.0.3 [databricks]

### DIFF
--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -31,6 +31,7 @@ com/nvidia/spark/rapids/iceberg/spark/RapidsSparkCatalog.class
 com/nvidia/spark/rapids/iceberg/spark/RapidsSparkSessionCatalog.class
 com/nvidia/spark/rapids/iceberg/spark/source/RapidsSparkTable.class
 org/apache/iceberg/aws/s3/IcebergS3InputFileAccess.class
+org/apache/iceberg/data/GpuFileHelpers.class
 org/apache/iceberg/io/GpuClusteredWriterBridge.class
 org/apache/iceberg/io/GpuFanoutWriterBridge.class
 org/apache/iceberg/io/GpuPositionDeleteFileWriter$.class

--- a/iceberg/README.md
+++ b/iceberg/README.md
@@ -14,7 +14,7 @@ and the directory that contains the corresponding support code.
 | 1.6.x           | Spark 3.5.0-3.5.3          | `iceberg-1-6-x`  |
 | 1.9.x           | Spark 3.5.4-3.5.8          | `iceberg-1-9-x`  |
 | 1.10.x          | Spark 3.5.4-3.5.8, 4.0.x  | `iceberg-1-10-x` |
-| 1.11.x          | Spark 4.1.x                | `iceberg-1-11-x` |
+| 1.11.x          | Spark 4.0.2-4.0.3, 4.1.x  | `iceberg-1-11-x` |
 
 Iceberg GPU acceleration is currently supported on Spark 3.5.x, 4.0.x, and 4.1.x.
 
@@ -24,7 +24,9 @@ build. The correct version-specific implementation is selected at runtime by pro
 sub-packages (`iceberg19x`, `iceberg110x`, `iceberg111x`) to avoid class conflicts, and the
 common `ShimUtils` dispatcher delegates to the appropriate implementation.
 
-For Spark 4.0.x, only `iceberg-1-10-x` is compiled during the build.
+For Spark 4.0.0-4.0.1, only `iceberg-1-10-x` is compiled during the build. For Spark
+4.0.2-4.0.3, both `iceberg-1-10-x` and `iceberg-1-11-x` are compiled, and the correct
+implementation is selected at runtime.
 
 For Spark 4.1.x, only `iceberg-1-11-x` is compiled during the build. Apache Iceberg
 publishes the `iceberg-spark-runtime-4.1` artifact starting at version 1.11.0, so earlier

--- a/iceberg/README.md
+++ b/iceberg/README.md
@@ -14,7 +14,7 @@ and the directory that contains the corresponding support code.
 | 1.6.x           | Spark 3.5.0-3.5.3          | `iceberg-1-6-x`  |
 | 1.9.x           | Spark 3.5.4-3.5.8          | `iceberg-1-9-x`  |
 | 1.10.x          | Spark 3.5.4-3.5.8, 4.0.x  | `iceberg-1-10-x` |
-| 1.11.x          | Spark 4.0.2-4.0.3, 4.1.x  | `iceberg-1-11-x` |
+| 1.11.x          | Spark 4.0.2+, 4.1.x        | `iceberg-1-11-x` |
 
 Iceberg GPU acceleration is currently supported on Spark 3.5.x, 4.0.x, and 4.1.x.
 
@@ -25,7 +25,7 @@ sub-packages (`iceberg19x`, `iceberg110x`, `iceberg111x`) to avoid class conflic
 common `ShimUtils` dispatcher delegates to the appropriate implementation.
 
 For Spark 4.0.0-4.0.1, only `iceberg-1-10-x` is compiled during the build. For Spark
-4.0.2-4.0.3, both `iceberg-1-10-x` and `iceberg-1-11-x` are compiled, and the correct
+4.0.2+, both `iceberg-1-10-x` and `iceberg-1-11-x` are compiled, and the correct
 implementation is selected at runtime.
 
 For Spark 4.1.x, only `iceberg-1-11-x` is compiled during the build. Apache Iceberg

--- a/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
@@ -42,6 +42,29 @@ import java.util.List;
  * dependency, we will need to introduce all other dependencies like `iceberg-parquet`.
  */
 public class GpuFileHelpers {
+  private static final Method BUILDER_FOR;
+  private static final Method EQUALITY_DELETE_ROW_SCHEMA;
+  private static final Method EQUALITY_FIELD_IDS;
+  private static final Method BUILD;
+
+  static {
+    try {
+      BUILDER_FOR = findMethod(GenericFileWriterFactory.class, "builderFor", Table.class);
+      Class<?> builderClass = BUILDER_FOR.getReturnType();
+      EQUALITY_DELETE_ROW_SCHEMA =
+          findMethod(builderClass, "equalityDeleteRowSchema", Schema.class);
+      EQUALITY_FIELD_IDS = findMethod(builderClass, "equalityFieldIds", int[].class);
+      BUILD = findMethod(builderClass, "build");
+
+      BUILDER_FOR.setAccessible(true);
+      EQUALITY_DELETE_ROW_SCHEMA.setAccessible(true);
+      EQUALITY_FIELD_IDS.setAccessible(true);
+      BUILD.setAccessible(true);
+    } catch (NoSuchMethodException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
   public static DeleteFile writeDeleteFile(
       Table table,
       OutputFile out,
@@ -73,24 +96,10 @@ public class GpuFileHelpers {
     try {
       // Iceberg 1.10 declares Builder package-private while 1.11 makes it public. Avoid static
       // linkage so this common class has identical bytecode in both version-specific modules.
-      Method builderFor = GenericFileWriterFactory.class
-          .getDeclaredMethod("builderFor", Table.class);
-      builderFor.setAccessible(true);
-      Object builder = builderFor.invoke(null, table);
-
-      Method equalityDeleteRowSchema =
-          findMethod(builder.getClass(), "equalityDeleteRowSchema", Schema.class);
-      equalityDeleteRowSchema.setAccessible(true);
-      builder = equalityDeleteRowSchema.invoke(builder, deleteRowSchema);
-
-      Method equalityFieldIdsMethod =
-          findMethod(builder.getClass(), "equalityFieldIds", int[].class);
-      equalityFieldIdsMethod.setAccessible(true);
-      builder = equalityFieldIdsMethod.invoke(builder, (Object) equalityFieldIds);
-
-      Method build = findMethod(builder.getClass(), "build");
-      build.setAccessible(true);
-      return (FileWriterFactory<Record>) build.invoke(builder);
+      Object builder = BUILDER_FOR.invoke(null, table);
+      builder = EQUALITY_DELETE_ROW_SCHEMA.invoke(builder, deleteRowSchema);
+      builder = EQUALITY_FIELD_IDS.invoke(builder, (Object) equalityFieldIds);
+      return (FileWriterFactory<Record>) BUILD.invoke(builder);
     } catch (ReflectiveOperationException e) {
       throw new IOException("Failed to create Iceberg file writer factory", e);
     }

--- a/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
@@ -42,6 +42,8 @@ import java.util.List;
  * dependency, we will need to introduce all other dependencies like `iceberg-parquet`.
  */
 public class GpuFileHelpers {
+  private static final String GENERIC_FILE_WRITER_FACTORY_CLASS =
+      "org.apache.iceberg.data.GenericFileWriterFactory";
   private static final Method BUILDER_FOR;
   private static final Method EQUALITY_DELETE_ROW_SCHEMA;
   private static final Method EQUALITY_FIELD_IDS;
@@ -49,7 +51,9 @@ public class GpuFileHelpers {
 
   static {
     try {
-      BUILDER_FOR = findMethod(GenericFileWriterFactory.class, "builderFor", Table.class);
+      Class<?> factoryClass = Class.forName(
+          GENERIC_FILE_WRITER_FACTORY_CLASS, true, Table.class.getClassLoader());
+      BUILDER_FOR = findMethod(factoryClass, "builderFor", Table.class);
       Class<?> builderClass = BUILDER_FOR.getReturnType();
       EQUALITY_DELETE_ROW_SCHEMA =
           findMethod(builderClass, "equalityDeleteRowSchema", Schema.class);
@@ -60,7 +64,7 @@ public class GpuFileHelpers {
       EQUALITY_DELETE_ROW_SCHEMA.setAccessible(true);
       EQUALITY_FIELD_IDS.setAccessible(true);
       BUILD.setAccessible(true);
-    } catch (NoSuchMethodException e) {
+    } catch (ReflectiveOperationException e) {
       throw new ExceptionInInitializerError(e);
     }
   }

--- a/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.apache.iceberg.types.Types;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.List;
 
 /**
@@ -51,10 +52,7 @@ public class GpuFileHelpers {
     int[] equalityFieldIds =
         deleteRowSchema.columns().stream().mapToInt(Types.NestedField::fieldId).toArray();
     FileWriterFactory<Record> factory =
-        GenericFileWriterFactory.builderFor(table)
-            .equalityDeleteRowSchema(deleteRowSchema)
-            .equalityFieldIds(equalityFieldIds)
-            .build();
+        newWriterFactory(table, deleteRowSchema, equalityFieldIds);
 
     EqualityDeleteWriter<Record> writer =
         factory.newEqualityDeleteWriter(encrypt(out), table.spec(), partition);
@@ -67,5 +65,34 @@ public class GpuFileHelpers {
 
   private static EncryptedOutputFile encrypt(OutputFile out) {
     return EncryptedFiles.encryptedOutput(out, EncryptionKeyMetadata.EMPTY);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static FileWriterFactory<Record> newWriterFactory(
+      Table table, Schema deleteRowSchema, int[] equalityFieldIds) throws IOException {
+    try {
+      // Iceberg 1.10 declares Builder package-private while 1.11 makes it public. Avoid static
+      // linkage so this common class has identical bytecode in both version-specific modules.
+      Method builderFor = GenericFileWriterFactory.class
+          .getDeclaredMethod("builderFor", Table.class);
+      builderFor.setAccessible(true);
+      Object builder = builderFor.invoke(null, table);
+
+      Method equalityDeleteRowSchema = builder.getClass()
+          .getDeclaredMethod("equalityDeleteRowSchema", Schema.class);
+      equalityDeleteRowSchema.setAccessible(true);
+      builder = equalityDeleteRowSchema.invoke(builder, deleteRowSchema);
+
+      Method equalityFieldIdsMethod = builder.getClass()
+          .getDeclaredMethod("equalityFieldIds", int[].class);
+      equalityFieldIdsMethod.setAccessible(true);
+      builder = equalityFieldIdsMethod.invoke(builder, (Object) equalityFieldIds);
+
+      Method build = builder.getClass().getDeclaredMethod("build");
+      build.setAccessible(true);
+      return (FileWriterFactory<Record>) build.invoke(builder);
+    } catch (ReflectiveOperationException e) {
+      throw new IOException("Failed to create Iceberg file writer factory", e);
+    }
   }
 }

--- a/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/data/GpuFileHelpers.java
@@ -78,21 +78,34 @@ public class GpuFileHelpers {
       builderFor.setAccessible(true);
       Object builder = builderFor.invoke(null, table);
 
-      Method equalityDeleteRowSchema = builder.getClass()
-          .getDeclaredMethod("equalityDeleteRowSchema", Schema.class);
+      Method equalityDeleteRowSchema =
+          findMethod(builder.getClass(), "equalityDeleteRowSchema", Schema.class);
       equalityDeleteRowSchema.setAccessible(true);
       builder = equalityDeleteRowSchema.invoke(builder, deleteRowSchema);
 
-      Method equalityFieldIdsMethod = builder.getClass()
-          .getDeclaredMethod("equalityFieldIds", int[].class);
+      Method equalityFieldIdsMethod =
+          findMethod(builder.getClass(), "equalityFieldIds", int[].class);
       equalityFieldIdsMethod.setAccessible(true);
       builder = equalityFieldIdsMethod.invoke(builder, (Object) equalityFieldIds);
 
-      Method build = builder.getClass().getDeclaredMethod("build");
+      Method build = findMethod(builder.getClass(), "build");
       build.setAccessible(true);
       return (FileWriterFactory<Record>) build.invoke(builder);
     } catch (ReflectiveOperationException e) {
       throw new IOException("Failed to create Iceberg file writer factory", e);
     }
+  }
+
+  private static Method findMethod(Class<?> type, String name, Class<?>... parameterTypes)
+      throws NoSuchMethodException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredMethod(name, parameterTypes);
+      } catch (NoSuchMethodException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchMethodException(type.getName() + "." + name);
   }
 }

--- a/iceberg/iceberg-1-11-x/src/main/spark400/java/com/nvidia/spark/rapids/iceberg/GpuInternalRow.java
+++ b/iceberg/iceberg-1-11-x/src/main/spark400/java/com/nvidia/spark/rapids/iceberg/GpuInternalRow.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+spark-rapids-shim-json-lines ***/
+
+package com.nvidia.spark.rapids.iceberg;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.unsafe.types.VariantVal;
+
+public class GpuInternalRow extends GpuInternalRowBase {
+  public GpuInternalRow(InternalRow row) {
+    super(row);
+  }
+
+  @Override
+  public VariantVal getVariant(int ordinal) {
+    return getWrapped().getVariant(ordinal);
+  }
+}

--- a/iceberg/iceberg-1-11-x/src/main/spark402/scala/com/nvidia/spark/rapids/iceberg/iceberg111x/IcebergProviderImpl.scala
+++ b/iceberg/iceberg-1-11-x/src/main/spark402/scala/com/nvidia/spark/rapids/iceberg/iceberg111x/IcebergProviderImpl.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "402"}
+{"spark": "403"}
+spark-rapids-shim-json-lines ***/
+
+package com.nvidia.spark.rapids.iceberg.iceberg111x
+
+import com.nvidia.spark.rapids.iceberg.IcebergProviderBase
+
+class IcebergProviderImpl extends IcebergProviderBase

--- a/iceberg/iceberg-1-11-x/src/main/spark411/scala/com/nvidia/spark/rapids/iceberg/iceberg111x/IcebergProviderImpl.scala
+++ b/iceberg/iceberg-1-11-x/src/main/spark411/scala/com/nvidia/spark/rapids/iceberg/iceberg111x/IcebergProviderImpl.scala
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+spark-rapids-shim-json-lines ***/
 
 package com.nvidia.spark.rapids.iceberg.iceberg111x
 

--- a/iceberg/iceberg-1-11-x/src/main/spark411/scala/org/apache/iceberg/spark/source/GpuSparkIncrementalAppendScan.scala
+++ b/iceberg/iceberg-1-11-x/src/main/spark411/scala/org/apache/iceberg/spark/source/GpuSparkIncrementalAppendScan.scala
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+spark-rapids-shim-json-lines ***/
 
 package org.apache.iceberg.spark.source
 

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -175,7 +175,7 @@ run_iceberg_version_detect_tests() {
     if [[ "$iceberg_spark_ver" == "4.1" ]]; then
         iceberg_versions="1.11.0"
     elif [[ "$iceberg_spark_ver" == "4.0" ]]; then
-        if [[ "$spark_patch_ver" -ge 2 && "$spark_patch_ver" -le 3 ]]; then
+        if [[ "$spark_patch_ver" -ge 2 ]]; then
             iceberg_versions="1.10.1 1.11.0"
         else
             iceberg_versions="1.10.1"

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -175,7 +175,11 @@ run_iceberg_version_detect_tests() {
     if [[ "$iceberg_spark_ver" == "4.1" ]]; then
         iceberg_versions="1.11.0"
     elif [[ "$iceberg_spark_ver" == "4.0" ]]; then
-        iceberg_versions="1.10.1"
+        if [[ "$spark_patch_ver" -ge 2 && "$spark_patch_ver" -le 3 ]]; then
+            iceberg_versions="1.10.1 1.11.0"
+        else
+            iceberg_versions="1.10.1"
+        fi
     elif [[ "$spark_patch_ver" -le 3 ]]; then
         iceberg_versions="1.6.1"
     else

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -277,7 +277,8 @@ run_iceberg_tests() {
   # Supported Iceberg versions per Spark patch version:
   # Spark 3.5.0-3.5.3 -> Iceberg 1.6.1
   # Spark 3.5.4+       -> Iceberg 1.9.2, 1.10.1
-  # Spark 4.0.x        -> Iceberg 1.10.1
+  # Spark 4.0.0-4.0.1 -> Iceberg 1.10.1
+  # Spark 4.0.2-4.0.3 -> Iceberg 1.10.1, 1.11.0
   # Spark 4.1.x        -> Iceberg 1.11.0
   local supported_versions
   if [[ "$ICEBERG_SPARK_VER" == "4.1" ]]; then
@@ -291,7 +292,11 @@ run_iceberg_tests() {
       echo "!!!! Skipping Iceberg tests. Spark 4.0 Iceberg tests require Scala 2.13"
       return 0
     fi
-    supported_versions="1.10.1"
+    if [[ "$SPARK_PATCH_VER" -ge 2 && "$SPARK_PATCH_VER" -le 3 ]]; then
+      supported_versions="1.10.1 1.11.0"
+    else
+      supported_versions="1.10.1"
+    fi
   elif [[ "$SPARK_PATCH_VER" -le 3 ]]; then
     supported_versions="1.6.1"
   else

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -278,7 +278,7 @@ run_iceberg_tests() {
   # Spark 3.5.0-3.5.3 -> Iceberg 1.6.1
   # Spark 3.5.4+       -> Iceberg 1.9.2, 1.10.1
   # Spark 4.0.0-4.0.1 -> Iceberg 1.10.1
-  # Spark 4.0.2-4.0.3 -> Iceberg 1.10.1, 1.11.0
+  # Spark 4.0.2+       -> Iceberg 1.10.1, 1.11.0
   # Spark 4.1.x        -> Iceberg 1.11.0
   local supported_versions
   if [[ "$ICEBERG_SPARK_VER" == "4.1" ]]; then
@@ -292,7 +292,7 @@ run_iceberg_tests() {
       echo "!!!! Skipping Iceberg tests. Spark 4.0 Iceberg tests require Scala 2.13"
       return 0
     fi
-    if [[ "$SPARK_PATCH_VER" -ge 2 && "$SPARK_PATCH_VER" -le 3 ]]; then
+    if [[ "$SPARK_PATCH_VER" -ge 2 ]]; then
       supported_versions="1.10.1 1.11.0"
     else
       supported_versions="1.10.1"

--- a/pom.xml
+++ b/pom.xml
@@ -669,11 +669,13 @@
                 <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
                 <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
                 <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-10-x</rapids.iceberg.artifactId>
+                <rapids.iceberg.artifactId2>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId2>
                 <slf4j.version>2.0.7</slf4j.version>
             </properties>
             <modules>
                 <module>delta-lake/delta-40x</module>
                 <module>iceberg/iceberg-1-10-x</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
         </profile>
         <profile>
@@ -693,11 +695,13 @@
                 <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
                 <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
                 <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-10-x</rapids.iceberg.artifactId>
+                <rapids.iceberg.artifactId2>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId2>
                 <slf4j.version>2.0.7</slf4j.version>
             </properties>
             <modules>
                 <module>delta-lake/delta-40x</module>
                 <module>iceberg/iceberg-1-10-x</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
         </profile>
         <profile>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -669,11 +669,13 @@
                 <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
                 <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
                 <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-10-x</rapids.iceberg.artifactId>
+                <rapids.iceberg.artifactId2>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId2>
                 <slf4j.version>2.0.7</slf4j.version>
             </properties>
             <modules>
                 <module>delta-lake/delta-40x</module>
                 <module>iceberg/iceberg-1-10-x</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
         </profile>
         <profile>
@@ -693,11 +695,13 @@
                 <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
                 <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
                 <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-10-x</rapids.iceberg.artifactId>
+                <rapids.iceberg.artifactId2>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId2>
                 <slf4j.version>2.0.7</slf4j.version>
             </properties>
             <modules>
                 <module>delta-lake/delta-40x</module>
                 <module>iceberg/iceberg-1-10-x</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
         </profile>
         <profile>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -50,8 +50,8 @@ case class GpuJsonToStructs(
     NvtxRegistry.JSON_TO_STRUCTS {
       schema match {
         case _: MapType =>
-          JSONUtils.extractRawMapFromJsonString(
-            input.getBase, cudfOptions, JSONUtils.MapValueType.STRING)
+          JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions):
+            @scala.annotation.nowarn("cat=deprecation")
         case struct: StructType =>
           val parsedStructs = JSONUtils.fromJSONToStructs(input.getBase, makeSchema(struct),
             cudfOptions, parsedOptions.locale == Locale.US)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,9 @@ case class GpuJsonToStructs(
   override protected def doColumnar(input: GpuColumnVector): cudf.ColumnVector = {
     NvtxRegistry.JSON_TO_STRUCTS {
       schema match {
-        case _: MapType => JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions)
+        case _: MapType =>
+          JSONUtils.extractRawMapFromJsonString(
+            input.getBase, cudfOptions, JSONUtils.MapValueType.STRING)
         case struct: StructType =>
           val parsedStructs = JSONUtils.fromJSONToStructs(input.getBase, makeSchema(struct),
             cudfOptions, parsedOptions.locale == Locale.US)


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA/cudf-spark/pull/14883.

### Description

Add Iceberg 1.11 support for Spark 4.0.2 and 4.0.3 while retaining Iceberg 1.10.1 as
the default runtime version. The Spark 4.0.2 and 4.0.3 build profiles now package both
Iceberg modules. Nightly coverage for Spark 4.0.2 + Iceberg 1.11 will be configured
separately.

Split the Iceberg 1.11 sources by Spark shim compatibility. Spark 4.0.2 and 4.0.3 use
the Spark 4.0 `GpuInternalRow` implementation and the base Iceberg scan rules, while
the Spark 4.1-only provider and incremental append scan remain in the Spark 4.1 shim.
Use reflection that walks the builder class hierarchy for the Iceberg writer API difference
so `GpuFileHelpers` has identical bytecode across the supported Iceberg modules and can
remain unshimmed.

Validation:

- Built the Scala 2.13 distribution with `-Dbuildver=402`, `403`, and `411`.
- Ran `test_iceberg_version_detection`, `test_iceberg_incremental_read`, and the byte
  and decimal128 variants of `test_iceberg_v2_eq_deletes` on Spark 4.0.2 and 4.0.3 with
  Iceberg 1.10.1 and 1.11.0, and on Spark 4.1.1 with Iceberg 1.11.0.
- Repeated the same integration scenarios with `ICEBERG_EXTRA_CLASSPATH` using the
  flattened RAPIDS aggregator and matching Iceberg runtime jars.
- Compared overlapping Iceberg 1.10/1.11 class bytecode for Spark 4.0.2 and 4.0.3 and
  checked the shaded package for duplicate class entries.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
