### PR TITLE
[AutoSparkUT]Add RAPIDS SQL core migrated suites

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsBroadcastJoinSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsBroadcastJoinSuite.scala
@@ -20,6 +20,8 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
 import com.nvidia.spark.rapids.{GpuBuildLeft, GpuBuildRight, GpuBuildSide}
+import org.scalactic.source.Position
+import org.scalatest.Tag
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.Tests.IS_TESTING
@@ -30,9 +32,6 @@ import org.apache.spark.sql.functions.broadcast
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuInMemoryTableScanExec
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinExec, GpuBroadcastNestedLoopJoinExec}
-import org.scalactic.source.Position
-import org.scalatest.Tag
-
 import org.apache.spark.sql.rapids.utils.{RapidsSQLTestsBaseTrait, RapidsTestsBaseTrait}
 import org.apache.spark.sql.rapids.utils.RapidsTestConstants.RAPIDS_TEST
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsBroadcastJoinSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsBroadcastJoinSuite.scala
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import com.nvidia.spark.rapids.{GpuBuildLeft, GpuBuildRight, GpuBuildSide}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
+import org.apache.spark.sql.execution.joins.BroadcastJoinSuiteBase
+import org.apache.spark.sql.functions.broadcast
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.GpuInMemoryTableScanExec
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinExec, GpuBroadcastNestedLoopJoinExec}
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+import org.apache.spark.sql.rapids.utils.{RapidsSQLTestsBaseTrait, RapidsTestsBaseTrait}
+import org.apache.spark.sql.rapids.utils.RapidsTestConstants.RAPIDS_TEST
+
+trait RapidsBroadcastJoinSuiteBase extends BroadcastJoinSuiteBase with RapidsTestsBaseTrait {
+  import testImplicits._
+
+  protected def testRapids(testName: String, testTag: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    test(RAPIDS_TEST + testName, testTag: _*)(testFun)
+  }
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    if (shouldRun(testName)) {
+      super.test(testName, testTags: _*)(testFun)
+    } else {
+      super.ignore(testName, testTags: _*)(testFun)
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    val conf = RapidsSQLTestsBaseTrait.nativeSparkConf(new SparkConf(), warehouse)
+    spark = SparkSession.builder()
+      .master("local[2]")
+      .appName("testing")
+      .config(conf)
+      .getOrCreate()
+  }
+
+  testRapids("broadcast hint uses GpuBroadcastHashJoinExec") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+      val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
+      val joined = df1.join(broadcast(df2), Seq("key"), "inner")
+
+      checkAnswer(joined, Seq(Row(1, "4", "1"), Row(2, "2", "2")))
+
+      val joins = joined.queryExecution.executedPlan.collect {
+        case join: GpuBroadcastHashJoinExec => join
+      }
+      assert(joins.size === 1,
+        s"Expected one GpuBroadcastHashJoinExec in plan:\n${joined.queryExecution.executedPlan}")
+    }
+  }
+
+  testRapids("SPARK-23192: broadcast hint should be retained after using the cached data") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      try {
+        val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+        val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
+        df2.cache()
+        val joined = df1.join(broadcast(df2), Seq("key"), "inner")
+
+        checkAnswer(joined, Seq(Row(1, "4", "1"), Row(2, "2", "2")))
+
+        val joins = collect(joined.queryExecution.executedPlan) {
+          case join: GpuBroadcastHashJoinExec => join
+        }
+        assert(joins.size === 1,
+          s"Expected one GpuBroadcastHashJoinExec in plan:\n" +
+            joined.queryExecution.executedPlan)
+      } finally {
+        spark.catalog.clearCache()
+      }
+    }
+  }
+
+  testRapids("SPARK-23214: cached data should not carry extra hint info") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      try {
+        val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
+        val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
+        broadcast(df2).cache()
+
+        val joined = df1.join(df2, Seq("key"), "inner")
+
+        checkAnswer(joined, Seq(Row(1, "4", "1"), Row(2, "2", "2")))
+
+        val cachedScans = collect(joined.queryExecution.executedPlan) {
+          case scan: GpuInMemoryTableScanExec => scan
+        }
+        assert(cachedScans.size === 1,
+          s"Expected one GpuInMemoryTableScanExec in plan:\n" +
+            joined.queryExecution.executedPlan)
+
+        val broadcastJoins = collect(joined.queryExecution.executedPlan) {
+          case join: GpuBroadcastHashJoinExec => join
+        }
+        assert(broadcastJoins.isEmpty,
+          s"Did not expect GpuBroadcastHashJoinExec in plan:\n" +
+            joined.queryExecution.executedPlan)
+      } finally {
+        spark.catalog.clearCache()
+      }
+    }
+  }
+
+  testRapids("SPARK-37742: join planning shouldn't read invalid InMemoryRelation stats") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10") {
+      try {
+        val df1 = Seq(1).toDF("key")
+        val df2 = Seq((1, "1"), (2, "2")).toDF("key", "value")
+        df2.persist()
+        df2.queryExecution.toRdd
+
+        val joined = df1.join(df2, Seq("key"), "inner")
+
+        checkAnswer(joined, Seq(Row(1, "1")))
+
+        val cachedScans = collect(joined.queryExecution.executedPlan) {
+          case scan: GpuInMemoryTableScanExec => scan
+        }
+        assert(cachedScans.size === 1,
+          s"Expected one GpuInMemoryTableScanExec in plan:\n" +
+            joined.queryExecution.executedPlan)
+
+        val broadcastJoins = collect(joined.queryExecution.executedPlan) {
+          case join: GpuBroadcastHashJoinExec => join
+        }
+        assert(broadcastJoins.isEmpty,
+          s"Did not expect GpuBroadcastHashJoinExec in plan:\n" +
+            joined.queryExecution.executedPlan)
+      } finally {
+        spark.catalog.clearCache()
+      }
+    }
+  }
+
+
+  testRapids("Shouldn't change broadcast join buildSide if user clearly specified") {
+    def assertGpuBroadcastHashJoinBuildSide(
+        sqlText: String,
+        expectedBuildSide: GpuBuildSide,
+        expectedRows: Int): Unit = {
+      val df = sql(sqlText)
+      val rows = df.collect()
+      assert(rows.length === expectedRows)
+
+      val joins = collect(df.queryExecution.executedPlan) {
+        case join: GpuBroadcastHashJoinExec => join
+      }
+      assert(joins.size === 1,
+        s"Expected one GpuBroadcastHashJoinExec in plan:\n" +
+          df.queryExecution.executedPlan)
+      assert(joins.head.buildSide === expectedBuildSide,
+        s"Unexpected build side in plan:\n" + df.queryExecution.executedPlan)
+    }
+
+    def assertGpuBroadcastNestedLoopJoinBuildSide(
+        sqlText: String,
+        expectedBuildSide: GpuBuildSide,
+        expectedRows: Int): Unit = {
+      val df = sql(sqlText)
+      val rows = df.collect()
+      assert(rows.length === expectedRows)
+
+      val joins = collect(df.queryExecution.executedPlan) {
+        case join: GpuBroadcastNestedLoopJoinExec => join
+      }
+      assert(joins.size === 1,
+        s"Expected one GpuBroadcastNestedLoopJoinExec in plan:\n" +
+          df.queryExecution.executedPlan)
+      assert(joins.head.gpuBuildSide === expectedBuildSide,
+        s"Unexpected build side in plan:\n" + df.queryExecution.executedPlan)
+    }
+
+    withTempView("t1", "t2") {
+      Seq((1, "4"), (2, "2")).toDF("key", "value").createTempView("t1")
+      Seq((1, "1"), (2, "12.3"), (2, "123")).toDF("key", "value")
+        .createTempView("t2")
+
+      assertGpuBroadcastHashJoinBuildSide(
+        "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 JOIN t2 ON t1.key = t2.key",
+        GpuBuildLeft,
+        3)
+      assertGpuBroadcastHashJoinBuildSide(
+        "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 LEFT JOIN t2 ON t1.key = t2.key",
+        GpuBuildRight,
+        3)
+      assertGpuBroadcastHashJoinBuildSide(
+        "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key",
+        GpuBuildLeft,
+        3)
+      assertGpuBroadcastHashJoinBuildSide(
+        "SELECT /*+ MAPJOIN(t1) */ * FROM t1 JOIN t2 ON t1.key = t2.key",
+        GpuBuildLeft,
+        3)
+      assertGpuBroadcastHashJoinBuildSide(
+        "SELECT /*+ MAPJOIN(t2) */ * FROM t1 JOIN t2 ON t1.key = t2.key",
+        GpuBuildRight,
+        3)
+
+      withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "true") {
+        // Full outer BNLJ and preserved-side outer builds remain CPU-only in RAPIDS.
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 JOIN t2",
+          GpuBuildLeft,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 LEFT JOIN t2",
+          GpuBuildRight,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t1, t2) */ * FROM t1 RIGHT JOIN t2",
+          GpuBuildLeft,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t1) */ * FROM t1 JOIN t2",
+          GpuBuildLeft,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT /*+ MAPJOIN(t2) */ * FROM t1 JOIN t2",
+          GpuBuildRight,
+          6)
+      }
+    }
+  }
+
+  testRapids("Shouldn't bias towards build right if user didn't specify") {
+    def assertGpuBroadcastHashJoinBuildSide(
+        sqlText: String,
+        expectedBuildSide: GpuBuildSide,
+        expectedRows: Int): Unit = {
+      val df = sql(sqlText)
+      val rows = df.collect()
+      assert(rows.length === expectedRows)
+
+      val joins = collect(df.queryExecution.executedPlan) {
+        case join: GpuBroadcastHashJoinExec => join
+      }
+      assert(joins.size === 1,
+        s"Expected one GpuBroadcastHashJoinExec in plan:\n" +
+          df.queryExecution.executedPlan)
+      assert(joins.head.buildSide === expectedBuildSide,
+        s"Unexpected build side in plan:\n" + df.queryExecution.executedPlan)
+    }
+
+    def assertGpuBroadcastNestedLoopJoinBuildSide(
+        sqlText: String,
+        expectedBuildSide: GpuBuildSide,
+        expectedRows: Int): Unit = {
+      val df = sql(sqlText)
+      val rows = df.collect()
+      assert(rows.length === expectedRows)
+
+      val joins = collect(df.queryExecution.executedPlan) {
+        case join: GpuBroadcastNestedLoopJoinExec => join
+      }
+      assert(joins.size === 1,
+        s"Expected one GpuBroadcastNestedLoopJoinExec in plan:\n" +
+          df.queryExecution.executedPlan)
+      assert(joins.head.gpuBuildSide === expectedBuildSide,
+        s"Unexpected build side in plan:\n" + df.queryExecution.executedPlan)
+    }
+
+    withTempView("t1", "t2") {
+      Seq((1, "4"), (2, "2")).toDF("key", "value").createTempView("t1")
+      Seq((1, "1"), (2, "12.3"), (2, "123")).toDF("key", "value")
+        .createTempView("t2")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10485760") {
+        assertGpuBroadcastHashJoinBuildSide(
+          "SELECT * FROM t1 JOIN t2 ON t1.key = t2.key",
+          GpuBuildLeft,
+          3)
+        assertGpuBroadcastHashJoinBuildSide(
+          "SELECT * FROM t2 JOIN t1 ON t1.key = t2.key",
+          GpuBuildRight,
+          3)
+        assertGpuBroadcastHashJoinBuildSide(
+          "SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key",
+          GpuBuildRight,
+          3)
+        assertGpuBroadcastHashJoinBuildSide(
+          "SELECT * FROM t2 LEFT JOIN t1 ON t1.key = t2.key",
+          GpuBuildRight,
+          3)
+        assertGpuBroadcastHashJoinBuildSide(
+          "SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key",
+          GpuBuildLeft,
+          3)
+        assertGpuBroadcastHashJoinBuildSide(
+          "SELECT * FROM t2 RIGHT JOIN t1 ON t1.key = t2.key",
+          GpuBuildLeft,
+          3)
+      }
+
+      withSQLConf(
+          SQLConf.CROSS_JOINS_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10485760") {
+        // Full outer BNLJ remains CPU-only in RAPIDS.
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT * FROM t1 JOIN t2",
+          GpuBuildLeft,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT * FROM t2 JOIN t1",
+          GpuBuildRight,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT * FROM t1 LEFT JOIN t2",
+          GpuBuildRight,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT * FROM t2 LEFT JOIN t1",
+          GpuBuildRight,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT * FROM t1 RIGHT JOIN t2",
+          GpuBuildLeft,
+          6)
+        assertGpuBroadcastNestedLoopJoinBuildSide(
+          "SELECT * FROM t2 RIGHT JOIN t1",
+          GpuBuildLeft,
+          6)
+      }
+    }
+  }
+
+  testRapids("broadcast non-equi join uses GpuBroadcastNestedLoopJoinExec") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.CROSS_JOINS_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val df1 = Seq(1, 2).toDF("left")
+      val df2 = Seq(1, 3).toDF("right")
+      val joined = df1.join(broadcast(df2), $"left" < $"right")
+
+      checkAnswer(joined, Seq(Row(1, 3), Row(2, 3)))
+
+      val joins = joined.queryExecution.executedPlan.collect {
+        case join: GpuBroadcastNestedLoopJoinExec => join
+      }
+      assert(joins.size === 1,
+        s"Expected one GpuBroadcastNestedLoopJoinExec in plan:\n" +
+          joined.queryExecution.executedPlan)
+    }
+  }
+
+}
+
+class RapidsBroadcastJoinSuite
+  extends RapidsBroadcastJoinSuiteBase
+  with DisableAdaptiveExecutionSuite
+
+class RapidsBroadcastJoinSuiteAE
+  extends RapidsBroadcastJoinSuiteBase
+  with EnableAdaptiveExecutionSuite

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsBroadcastJoinSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsBroadcastJoinSuite.scala
@@ -22,6 +22,7 @@ package org.apache.spark.sql.rapids.suites
 import com.nvidia.spark.rapids.{GpuBuildLeft, GpuBuildRight, GpuBuildSide}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.joins.BroadcastJoinSuiteBase
@@ -53,6 +54,14 @@ trait RapidsBroadcastJoinSuiteBase extends BroadcastJoinSuiteBase with RapidsTes
   }
 
   override def beforeAll(): Unit = {
+    // Do the SparkFunSuite setup that BroadcastJoinSuiteBase.beforeAll() would normally do.
+    // Calling super.beforeAll() here would create Spark's local-cluster session before RAPIDS
+    // configs are applied.
+    System.setProperty(IS_TESTING.key, "true")
+    if (enableAutoThreadAudit) {
+      doThreadPreAudit()
+    }
+
     val conf = RapidsSQLTestsBaseTrait.nativeSparkConf(new SparkConf(), warehouse)
     spark = SparkSession.builder()
       .master("local[2]")

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileScanSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.FileScanSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsFileScanSuite extends FileScanSuite with RapidsSQLTestsBaseTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceAggregatePushDownSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceAggregatePushDownSuite.scala
@@ -19,7 +19,12 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
-import org.apache.spark.sql.execution.datasources.{OrcV1AggregatePushDownSuite, OrcV2AggregatePushDownSuite, ParquetV1AggregatePushDownSuite, ParquetV2AggregatePushDownSuite}
+import org.apache.spark.sql.execution.datasources.{
+  OrcV1AggregatePushDownSuite,
+  OrcV2AggregatePushDownSuite,
+  ParquetV1AggregatePushDownSuite,
+  ParquetV2AggregatePushDownSuite
+}
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
 
 class RapidsParquetV1AggregatePushDownSuite

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceAggregatePushDownSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceAggregatePushDownSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.execution.datasources.{OrcV1AggregatePushDownSuite, OrcV2AggregatePushDownSuite, ParquetV1AggregatePushDownSuite, ParquetV2AggregatePushDownSuite}
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsParquetV1AggregatePushDownSuite
+  extends ParquetV1AggregatePushDownSuite
+  with RapidsSQLTestsBaseTrait
+
+class RapidsParquetV2AggregatePushDownSuite
+  extends ParquetV2AggregatePushDownSuite
+  with RapidsSQLTestsBaseTrait
+
+class RapidsOrcV1AggregatePushDownSuite
+  extends OrcV1AggregatePushDownSuite
+  with RapidsSQLTestsBaseTrait
+
+class RapidsOrcV2AggregatePushDownSuite
+  extends OrcV2AggregatePushDownSuite
+  with RapidsSQLTestsBaseTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceStrategySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceStrategySuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import com.nvidia.spark.rapids.GpuFilterExec
+import com.nvidia.spark.rapids.shims.ShimPredicateHelper
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.expressions.ExpressionSet
+import org.apache.spark.sql.execution.FilterExec
+import org.apache.spark.sql.execution.datasources.FileSourceStrategySuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsFileSourceStrategySuite
+  extends FileSourceStrategySuite
+  with RapidsSQLTestsTrait
+  with ShimPredicateHelper {
+  override def getPhysicalFilters(df: DataFrame): ExpressionSet = {
+    ExpressionSet(
+      df.queryExecution.executedPlan.collect {
+        case FilterExec(f, _) => splitConjunctivePredicates(f)
+        case GpuFilterExec(f, _) => splitConjunctivePredicates(f)
+      }.flatten)
+  }
+
+  testRapids("partitioned table - after scan filters") {
+    val table =
+      createTable(
+        files = Seq(
+          "p1=1/file1" -> 10,
+          "p1=2/file2" -> 10))
+
+    val df1 = table.where("p1 = 1 AND (p1 + c1) = 2 AND c1 = 1")
+    val filters1 = gpuPhysicalFilterStrings(df1)
+    assert(filters1.exists(f => f.contains("c1") && f.contains("= 1")))
+    assert(!filters1.exists(f => f.contains("p1") && f.contains("= 1")))
+
+    val df2 = table.where("(p1 + c2) = 2 AND c1 = 1")
+    val filters2 = gpuPhysicalFilterStrings(df2)
+    assert(filters2.exists(f => f.contains("c1") && f.contains("= 1")))
+    assert(filters2.exists(f =>
+      f.contains("p1") && f.contains("c2") && f.contains("+") && f.contains("= 2")))
+  }
+
+  private def gpuPhysicalFilterStrings(df: DataFrame): Seq[String] = {
+    df.queryExecution.executedPlan.collect {
+      case GpuFilterExec(f, _) => splitConjunctivePredicates(f).map(_.toString)
+    }.flatten
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcFilterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcFilterSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.execution.datasources.orc.OrcFilterSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsOrcFilterSuite extends OrcFilterSuite with RapidsSQLTestsBaseTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcQuerySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcQuerySuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.execution.datasources.orc.{OrcV1QuerySuite, OrcV2QuerySuite}
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsOrcV1QuerySuite extends OrcV1QuerySuite with RapidsSQLTestsBaseTrait
+
+class RapidsOrcV2QuerySuite extends OrcV2QuerySuite with RapidsSQLTestsBaseTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
@@ -67,10 +67,8 @@ class RapidsOrcV2SchemaPruningSuite
       expectedSchemaCatalogStrings: String*): Unit = {
     val fileSourceScanSchemata =
       getExecutedPlan(df).collect {
-        case scan: GpuBatchScanExec =>
-          scan.scan match {
-            case orcScan: GpuOrcScan => orcScan.readDataSchema
-          }
+        case scan: GpuBatchScanExec if scan.scan.isInstanceOf[GpuOrcScan] =>
+          scan.scan.asInstanceOf[GpuOrcScan].readDataSchema
       }
     assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
       s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import com.nvidia.spark.rapids.GpuOrcScan
+import com.nvidia.spark.rapids.shims.GpuBatchScanExec
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.orc.{OrcV1SchemaPruningSuite, OrcV2SchemaPruningSuite}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsOrcV1SchemaPruningSuite
+  extends OrcV1SchemaPruningSuite
+  with RapidsSQLTestsBaseTrait {
+
+  override protected def checkScanSchemata(
+      df: DataFrame,
+      expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      getExecutedPlan(df).collect {
+        case scan: FileSourceScanExec => scan.requiredSchema
+        case scan: GpuFileSourceScanExec => scan.requiredSchema
+      }
+    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings")
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
+}
+
+class RapidsOrcV2SchemaPruningSuite
+  extends OrcV2SchemaPruningSuite
+  with RapidsSQLTestsBaseTrait {
+
+  override def sparkConf: SparkConf =
+    super.sparkConf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+
+  override def checkScanSchemata(
+      df: DataFrame,
+      expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      getExecutedPlan(df).collect {
+        case scan: GpuBatchScanExec =>
+          scan.scan match {
+            case orcScan: GpuOrcScan => orcScan.readDataSchema
+          }
+      }
+    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings")
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
@@ -24,60 +24,43 @@ import com.nvidia.spark.rapids.shims.GpuBatchScanExec
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.orc.{OrcV1SchemaPruningSuite, OrcV2SchemaPruningSuite}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
-import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+import org.apache.spark.sql.rapids.utils.{RapidsSchemaPruningTestUtils, RapidsSQLTestsBaseTrait}
 
 class RapidsOrcV1SchemaPruningSuite
   extends OrcV1SchemaPruningSuite
-  with RapidsSQLTestsBaseTrait {
+  with RapidsSQLTestsBaseTrait
+  with RapidsSchemaPruningTestUtils {
 
-  override protected def checkScanSchemata(
+  override protected def checkScan(
       df: DataFrame,
       expectedSchemaCatalogStrings: String*): Unit = {
-    val fileSourceScanSchemata =
-      getExecutedPlan(df).collect {
-        case scan: FileSourceScanExec => scan.requiredSchema
-        case scan: GpuFileSourceScanExec => scan.requiredSchema
-      }
-    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
-      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
-        s"but expected $expectedSchemaCatalogStrings")
-    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
-      case (scanSchema, expectedScanSchemaCatalogString) =>
-        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
-        implicit val equality = schemaEquality
-        assert(scanSchema === expectedScanSchema)
+    checkScanSchema(df, expectedSchemaCatalogStrings: _*) {
+      case scan: FileSourceScanExec => scan.requiredSchema
+      case scan: GpuFileSourceScanExec => scan.requiredSchema
     }
+    df.collect()
   }
 }
 
 class RapidsOrcV2SchemaPruningSuite
   extends OrcV2SchemaPruningSuite
-  with RapidsSQLTestsBaseTrait {
+  with RapidsSQLTestsBaseTrait
+  with RapidsSchemaPruningTestUtils {
 
   override def sparkConf: SparkConf =
     super.sparkConf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
 
-  override def checkScanSchemata(
+  override protected def checkScan(
       df: DataFrame,
       expectedSchemaCatalogStrings: String*): Unit = {
-    val fileSourceScanSchemata =
-      getExecutedPlan(df).collect {
-        case scan: GpuBatchScanExec if scan.scan.isInstanceOf[GpuOrcScan] =>
-          scan.scan.asInstanceOf[GpuOrcScan].readDataSchema
-      }
-    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
-      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
-        s"but expected $expectedSchemaCatalogStrings")
-    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
-      case (scanSchema, expectedScanSchemaCatalogString) =>
-        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
-        implicit val equality = schemaEquality
-        assert(scanSchema === expectedScanSchema)
+    checkScanSchema(df, expectedSchemaCatalogStrings: _*) {
+      case scan: GpuBatchScanExec if scan.scan.isInstanceOf[GpuOrcScan] =>
+        scan.scan.asInstanceOf[GpuOrcScan].readDataSchema
     }
+    df.collect()
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetFilterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetFilterSuite.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import java.nio.charset.StandardCharsets
+import java.sql.{Date, Timestamp}
+
+import com.nvidia.spark.rapids.parquet.GpuParquetScan
+import com.nvidia.spark.rapids.shims.GpuBatchScanExec
+
+import org.apache.spark.sql.{Column, DataFrame, Row}
+import org.apache.spark.sql.execution.datasources.parquet.{
+  ParquetFilterSuite, ParquetV1FilterSuite, ParquetV2FilterSuite}
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.{
+  TIMESTAMP_MICROS, TIMESTAMP_MILLIS}
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+trait RapidsParquetFilterCorrectnessTests extends RapidsSQLTestsBaseTrait {
+  this: ParquetFilterSuite =>
+
+  protected def assertGpuParquetScan(df: DataFrame): Unit = {
+    val executed = getExecutedPlan(df)
+    assert(executed.exists {
+      case _: GpuFileSourceScanExec => true
+      case scan: GpuBatchScanExec => scan.scan.isInstanceOf[GpuParquetScan]
+      case _ => false
+    }, s"Expected a GPU Parquet scan in plan:\n${df.queryExecution.executedPlan}")
+  }
+
+  protected def checkGpuParquetAnswer(df: DataFrame, expected: Seq[Row]): Unit = {
+    assertGpuParquetScan(df)
+    checkAnswer(df, expected)
+  }
+
+  private def withWrittenParquet(df: DataFrame)(f: DataFrame => Unit): Unit = {
+    withTempPath { path =>
+      df.write.parquet(path.getAbsolutePath)
+      f(spark.read.parquet(path.getAbsolutePath))
+    }
+  }
+
+  private def withParquetFilterPushdown(f: => Unit): Unit = {
+    withSQLConf(
+      SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
+      SQLConf.PARQUET_FILTER_PUSHDOWN_DATE_ENABLED.key -> "true",
+      SQLConf.PARQUET_FILTER_PUSHDOWN_TIMESTAMP_ENABLED.key -> "true") {
+      f
+    }
+  }
+
+  testRapids("filter pushdown - binary final output correctness") {
+    import testImplicits._
+
+    implicit class IntToBinary(int: Int) {
+      def b: Array[Byte] = int.toString.getBytes(StandardCharsets.UTF_8)
+    }
+
+    withParquetFilterPushdown {
+      withWrittenParquet((1 to 4).map(i => (i, Option(i.b))).toDF("id", "b")) { df =>
+        def idsFor(predicate: Column): DataFrame = df.where(predicate).select("id")
+
+        checkGpuParquetAnswer(idsFor(col("b") === lit(1.b)), Seq(Row(1)))
+        checkGpuParquetAnswer(idsFor(col("b") <=> lit(1.b)), Seq(Row(1)))
+        checkGpuParquetAnswer(idsFor(col("b").isNull), Seq.empty)
+        checkGpuParquetAnswer(idsFor(col("b").isNotNull), (1 to 4).map(Row(_)))
+        checkGpuParquetAnswer(idsFor(col("b") =!= lit(1.b)), (2 to 4).map(Row(_)))
+        checkGpuParquetAnswer(idsFor(col("b") < lit(2.b)), Seq(Row(1)))
+        checkGpuParquetAnswer(idsFor(col("b") > lit(3.b)), Seq(Row(4)))
+        checkGpuParquetAnswer(idsFor(col("b") <= lit(1.b)), Seq(Row(1)))
+        checkGpuParquetAnswer(idsFor(col("b") >= lit(4.b)), Seq(Row(4)))
+        checkGpuParquetAnswer(idsFor(!(col("b") < lit(4.b))), Seq(Row(4)))
+        checkGpuParquetAnswer(
+          idsFor(col("b") < lit(2.b) || col("b") > lit(3.b)),
+          Seq(Row(1), Row(4)))
+      }
+    }
+  }
+
+  testRapids("filter pushdown - date final output correctness") {
+    import testImplicits._
+
+    withParquetFilterPushdown {
+      Seq(false, true).foreach { java8Api =>
+        withSQLConf(
+          SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
+          SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key -> "CORRECTED") {
+          val data = Seq(
+            (1, Option(Date.valueOf("1000-01-01"))),
+            (2, Option(Date.valueOf("2018-03-19"))),
+            (3, Option(Date.valueOf("2018-03-20"))),
+            (4, Option(Date.valueOf("2018-03-21"))))
+          withWrittenParquet(data.toDF("id", "d")) { df =>
+            def idsWhere(predicate: String): DataFrame = df.where(predicate).select("id")
+
+            checkGpuParquetAnswer(idsWhere("d is null"), Seq.empty)
+            checkGpuParquetAnswer(idsWhere("d is not null"), (1 to 4).map(Row(_)))
+            checkGpuParquetAnswer(idsWhere("d = date '1000-01-01'"), Seq(Row(1)))
+            checkGpuParquetAnswer(idsWhere("d <=> date '1000-01-01'"), Seq(Row(1)))
+            checkGpuParquetAnswer(
+              idsWhere("d != date '1000-01-01'"),
+              Seq(Row(2), Row(3), Row(4)))
+            checkGpuParquetAnswer(idsWhere("d < date '2018-03-19'"), Seq(Row(1)))
+            checkGpuParquetAnswer(idsWhere("d > date '2018-03-20'"), Seq(Row(4)))
+            checkGpuParquetAnswer(idsWhere("d <= date '1000-01-01'"), Seq(Row(1)))
+            checkGpuParquetAnswer(idsWhere("d >= date '2018-03-21'"), Seq(Row(4)))
+            checkGpuParquetAnswer(idsWhere("not (d < date '2018-03-21')"), Seq(Row(4)))
+            checkGpuParquetAnswer(
+              idsWhere("d < date '2018-03-19' or d > date '2018-03-20'"),
+              Seq(Row(1), Row(4)))
+            checkGpuParquetAnswer(
+              idsWhere("d in (date '2018-03-19', date '2018-03-20', " +
+                "date '2018-03-21', date '2018-03-22')"),
+              Seq(Row(2), Row(3), Row(4)))
+          }
+        }
+      }
+    }
+  }
+
+  testRapids("filter pushdown - timestamp final output correctness") {
+    import testImplicits._
+
+    withParquetFilterPushdown {
+      Seq(false, true).foreach { java8Api =>
+        Seq(TIMESTAMP_MILLIS, TIMESTAMP_MICROS).foreach { timestampType =>
+          withSQLConf(
+            SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
+            SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key -> "CORRECTED",
+            SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> timestampType.toString) {
+            val timestamps = if (timestampType == TIMESTAMP_MILLIS) {
+              Seq(
+                "1000-06-14 08:28:53.123",
+                "1582-06-15 08:28:53.001",
+                "1900-06-16 08:28:53.0",
+                "2018-06-17 08:28:53.999")
+            } else {
+              Seq(
+                "1000-06-14 08:28:53.123456",
+                "1582-06-15 08:28:53.123456",
+                "1900-06-16 08:28:53.123456",
+                "2018-06-17 08:28:53.123456")
+            }
+            val data = timestamps.zipWithIndex.map { case (ts, idx) =>
+              (idx + 1, Option(Timestamp.valueOf(ts)))
+            }
+            withWrittenParquet(data.toDF("id", "ts")) { df =>
+              def idsWhere(predicate: String): DataFrame = df.where(predicate).select("id")
+              def tsLiteral(index: Int): String = s"timestamp '${timestamps(index)}'"
+
+              checkGpuParquetAnswer(idsWhere("ts is null"), Seq.empty)
+              checkGpuParquetAnswer(idsWhere("ts is not null"), (1 to 4).map(Row(_)))
+              checkGpuParquetAnswer(idsWhere(s"ts = ${tsLiteral(0)}"), Seq(Row(1)))
+              checkGpuParquetAnswer(idsWhere(s"ts <=> ${tsLiteral(0)}"), Seq(Row(1)))
+              checkGpuParquetAnswer(
+                idsWhere(s"ts != ${tsLiteral(0)}"),
+                Seq(Row(2), Row(3), Row(4)))
+              checkGpuParquetAnswer(idsWhere(s"ts < ${tsLiteral(1)}"), Seq(Row(1)))
+              checkGpuParquetAnswer(idsWhere(s"ts > ${tsLiteral(2)}"), Seq(Row(4)))
+              checkGpuParquetAnswer(idsWhere(s"ts <= ${tsLiteral(0)}"), Seq(Row(1)))
+              checkGpuParquetAnswer(idsWhere(s"ts >= ${tsLiteral(3)}"), Seq(Row(4)))
+              checkGpuParquetAnswer(idsWhere(s"not (ts < ${tsLiteral(3)})"), Seq(Row(4)))
+              checkGpuParquetAnswer(
+                idsWhere(s"ts < ${tsLiteral(1)} or ts > ${tsLiteral(2)}"),
+                Seq(Row(1), Row(4)))
+              checkGpuParquetAnswer(
+                idsWhere(s"ts in (${tsLiteral(1)}, ${tsLiteral(2)}, ${tsLiteral(3)})"),
+                Seq(Row(2), Row(3), Row(4)))
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+class RapidsParquetV1FilterSuite
+  extends ParquetV1FilterSuite
+  with RapidsSQLTestsBaseTrait
+  with RapidsParquetFilterCorrectnessTests {
+  override protected def readResourceParquetFile(name: String): DataFrame = {
+    spark.read.parquet(testFile(name))
+  }
+}
+
+class RapidsParquetV2FilterSuite
+  extends ParquetV2FilterSuite
+  with RapidsSQLTestsBaseTrait
+  with RapidsParquetFilterCorrectnessTests {
+  override protected def readResourceParquetFile(name: String): DataFrame = {
+    spark.read.parquet(testFile(name))
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetFilterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetFilterSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.{
   TIMESTAMP_MICROS, TIMESTAMP_MILLIS}
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
-import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+import org.apache.spark.sql.rapids.utils.{RapidsParquetResourceTest, RapidsSQLTestsBaseTrait}
 
 trait RapidsParquetFilterCorrectnessTests extends RapidsSQLTestsBaseTrait {
   this: ParquetFilterSuite =>
@@ -196,17 +196,11 @@ trait RapidsParquetFilterCorrectnessTests extends RapidsSQLTestsBaseTrait {
 class RapidsParquetV1FilterSuite
   extends ParquetV1FilterSuite
   with RapidsSQLTestsBaseTrait
-  with RapidsParquetFilterCorrectnessTests {
-  override protected def readResourceParquetFile(name: String): DataFrame = {
-    spark.read.parquet(testFile(name))
-  }
-}
+  with RapidsParquetResourceTest
+  with RapidsParquetFilterCorrectnessTests
 
 class RapidsParquetV2FilterSuite
   extends ParquetV2FilterSuite
   with RapidsSQLTestsBaseTrait
-  with RapidsParquetFilterCorrectnessTests {
-  override protected def readResourceParquetFile(name: String): DataFrame = {
-    spark.read.parquet(testFile(name))
-  }
-}
+  with RapidsParquetResourceTest
+  with RapidsParquetFilterCorrectnessTests

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetIOSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetIOSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.parquet.ParquetIOSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsParquetIOSuite extends ParquetIOSuite with RapidsSQLTestsBaseTrait {
+  override protected def readResourceParquetFile(name: String): DataFrame = {
+    spark.read.parquet(testFile(name))
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetProtobufCompatibilitySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetProtobufCompatibilitySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetProtobufCompatibilitySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetProtobufCompatibilitySuite.scala
@@ -19,14 +19,10 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.parquet.ParquetProtobufCompatibilitySuite
-import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+import org.apache.spark.sql.rapids.utils.{RapidsParquetResourceTest, RapidsSQLTestsBaseTrait}
 
 class RapidsParquetProtobufCompatibilitySuite
   extends ParquetProtobufCompatibilitySuite
-  with RapidsSQLTestsBaseTrait {
-    override protected def readResourceParquetFile(name: String): DataFrame = {
-      spark.read.parquet(testFile(name))
-    }
-}
+  with RapidsSQLTestsBaseTrait
+  with RapidsParquetResourceTest

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetSchemaPruningSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetSchemaPruningSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetSchemaPruningSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetSchemaPruningSuite.scala
@@ -20,32 +20,23 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaPruningSuite
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
-import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+import org.apache.spark.sql.rapids.utils.{RapidsSchemaPruningTestUtils, RapidsSQLTestsBaseTrait}
 
 class RapidsParquetSchemaPruningSuite
   extends ParquetSchemaPruningSuite
-  with RapidsSQLTestsBaseTrait {
+  with RapidsSQLTestsBaseTrait
+  with RapidsSchemaPruningTestUtils {
 
-  override protected def checkScanSchemata(df: DataFrame,
-                                           expectedSchemaCatalogStrings: String*): Unit = {
-    val fileSourceScanSchemata =
-      collect(df.queryExecution.executedPlan) {
-        case scan: FileSourceScanExec => scan.requiredSchema
-        case gpuScan: GpuFileSourceScanExec => gpuScan.requiredSchema
-      }
-    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
-      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
-        s"but expected $expectedSchemaCatalogStrings")
-    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
-      case (scanSchema, expectedScanSchemaCatalogString) =>
-        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
-        implicit val equality = schemaEquality
-        assert(scanSchema === expectedScanSchema)
+  override protected def checkScan(
+      df: DataFrame,
+      expectedSchemaCatalogStrings: String*): Unit = {
+    checkScanSchema(df, expectedSchemaCatalogStrings: _*) {
+      case scan: FileSourceScanExec => scan.requiredSchema
+      case gpuScan: GpuFileSourceScanExec => gpuScan.requiredSchema
     }
-
+    df.collect()
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPruneFileSourcePartitionsSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPruneFileSourcePartitionsSuite.scala
@@ -34,7 +34,8 @@ class RapidsPruneFileSourcePartitionsSuite
   extends PruneFileSourcePartitionsSuite
   with RapidsSQLTestsTrait {
 
-  override protected def collectPartitionFiltersFn(): PartialFunction[SparkPlan, Seq[Expression]] = {
+  override protected def collectPartitionFiltersFn()
+      : PartialFunction[SparkPlan, Seq[Expression]] = {
     case scan: FileSourceScanExec => scan.partitionFilters
     case scan: GpuFileSourceScanExec => scan.partitionFilters
     case scan: GpuBatchScanExec if gpuPartitionFilters(scan.scan).isDefined =>

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPruneFileSourcePartitionsSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPruneFileSourcePartitionsSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import com.nvidia.spark.rapids.{GpuCSVScan, GpuOrcScan}
+import com.nvidia.spark.rapids.parquet.GpuParquetScan
+import com.nvidia.spark.rapids.shims.GpuBatchScanExec
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.json.rapids.GpuJsonScan
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.PruneFileSourcePartitionsSuite
+import org.apache.spark.sql.rapids.{GpuAvroScan, GpuFileSourceScanExec}
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsPruneFileSourcePartitionsSuite
+  extends PruneFileSourcePartitionsSuite
+  with RapidsSQLTestsTrait {
+
+  override protected def collectPartitionFiltersFn(): PartialFunction[SparkPlan, Seq[Expression]] = {
+    case scan: FileSourceScanExec => scan.partitionFilters
+    case scan: GpuFileSourceScanExec => scan.partitionFilters
+    case scan: GpuBatchScanExec if gpuPartitionFilters(scan.scan).isDefined =>
+      gpuPartitionFilters(scan.scan).get
+  }
+
+  override def getScanExecPartitionSize(plan: SparkPlan): Long = {
+    plan.collectFirst {
+      case scan: GpuFileSourceScanExec => scan.selectedPartitions.length.toLong
+      case scan: GpuBatchScanExec => scan.inputPartitions.size.toLong
+    }.getOrElse(super.getScanExecPartitionSize(plan))
+  }
+
+  private def gpuPartitionFilters(scan: Any): Option[Seq[Expression]] = scan match {
+    case parquetScan: GpuParquetScan => Some(parquetScan.partitionFilters)
+    case orcScan: GpuOrcScan => Some(orcScan.partitionFilters)
+    case csvScan: GpuCSVScan => Some(csvScan.partitionFilters)
+    case jsonScan: GpuJsonScan => Some(jsonScan.partitionFilters)
+    case avroScan: GpuAvroScan => Some(avroScan.partitionFilters)
+    case _ => None
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPruneFileSourcePartitionsSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPruneFileSourcePartitionsSuite.scala
@@ -19,15 +19,13 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
-import com.nvidia.spark.rapids.{GpuCSVScan, GpuOrcScan}
-import com.nvidia.spark.rapids.parquet.GpuParquetScan
 import com.nvidia.spark.rapids.shims.GpuBatchScanExec
 
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.json.rapids.GpuJsonScan
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.PruneFileSourcePartitionsSuite
-import org.apache.spark.sql.rapids.{GpuAvroScan, GpuFileSourceScanExec}
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
 
 class RapidsPruneFileSourcePartitionsSuite
@@ -36,25 +34,19 @@ class RapidsPruneFileSourcePartitionsSuite
 
   override protected def collectPartitionFiltersFn()
       : PartialFunction[SparkPlan, Seq[Expression]] = {
-    case scan: FileSourceScanExec => scan.partitionFilters
-    case scan: GpuFileSourceScanExec => scan.partitionFilters
-    case scan: GpuBatchScanExec if gpuPartitionFilters(scan.scan).isDefined =>
-      gpuPartitionFilters(scan.scan).get
+    super.collectPartitionFiltersFn().orElse {
+      case scan: GpuFileSourceScanExec =>
+        scan.partitionFilters
+      case scan: GpuBatchScanExec if scan.scan.isInstanceOf[FileScan] =>
+        scan.scan.asInstanceOf[FileScan].partitionFilters
+    }
   }
 
   override def getScanExecPartitionSize(plan: SparkPlan): Long = {
     plan.collectFirst {
       case scan: GpuFileSourceScanExec => scan.selectedPartitions.length.toLong
-      case scan: GpuBatchScanExec => scan.inputPartitions.size.toLong
+      case scan: GpuBatchScanExec if scan.scan.isInstanceOf[FileScan] =>
+        scan.partitions.size.toLong
     }.getOrElse(super.getScanExecPartitionSize(plan))
-  }
-
-  private def gpuPartitionFilters(scan: Any): Option[Seq[Expression]] = scan match {
-    case parquetScan: GpuParquetScan => Some(parquetScan.partitionFilters)
-    case orcScan: GpuOrcScan => Some(orcScan.partitionFilters)
-    case csvScan: GpuCSVScan => Some(csvScan.partitionFilters)
-    case jsonScan: GpuJsonScan => Some(jsonScan.partitionFilters)
-    case avroScan: GpuAvroScan => Some(avroScan.partitionFilters)
-    case _ => None
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSortSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSortSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import com.nvidia.spark.rapids.{GpuSortExec, GpuTopN}
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.SortSuite
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsSortSuite extends SortSuite with RapidsSQLTestsBaseTrait {
+  import testImplicits._
+
+  testRapids("basic sorting query uses GpuSortExec") {
+    val df = Seq(("Hello", 4, 2.0), ("Hello", 1, 1.0), ("World", 8, 3.0))
+      .toDF("a", "b", "c")
+      .sort($"a".asc, $"b".asc)
+
+    assert(df.collect().toSeq === Seq(
+      Row("Hello", 1, 1.0),
+      Row("Hello", 4, 2.0),
+      Row("World", 8, 3.0)))
+
+    val gpuSorts = getExecutedPlan(df).collect {
+      case sort: GpuSortExec => sort
+    }
+    assert(gpuSorts.nonEmpty, s"Expected GpuSortExec in plan:\n${df.queryExecution.executedPlan}")
+  }
+
+  testRapids("sort followed by limit query uses GpuTopN") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      val df = (1 to 100).map(Tuple1(_)).toDF("a").sort($"a".desc).limit(10)
+      assert(df.collect().toSeq === (100 to 91 by -1).map(v => Row(v)))
+
+      val gpuTopNs = getExecutedPlan(df).collect {
+        case topN: GpuTopN => topN
+      }
+      assert(gpuTopNs.nonEmpty, s"Expected GpuTopN in plan:\n${df.queryExecution.executedPlan}")
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSortSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSortSuite.scala
@@ -19,7 +19,7 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
-import com.nvidia.spark.rapids.{GpuSortExec, GpuTopN}
+import com.nvidia.spark.rapids.GpuSortExec
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.SortSuite
@@ -50,10 +50,7 @@ class RapidsSortSuite extends SortSuite with RapidsSQLTestsBaseTrait {
       val df = (1 to 100).map(Tuple1(_)).toDF("a").sort($"a".desc).limit(10)
       assert(df.collect().toSeq === (100 to 91 by -1).map(v => Row(v)))
 
-      val gpuTopNs = getExecutedPlan(df).collect {
-        case topN: GpuTopN => topN
-      }
-      assert(gpuTopNs.nonEmpty, s"Expected GpuTopN in plan:\n${df.queryExecution.executedPlan}")
+      RapidsTakeOrderedAndProjectSuite.assertTopN(df, getExecutedPlan(df))
     }
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTakeOrderedAndProjectSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTakeOrderedAndProjectSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import com.nvidia.spark.rapids.GpuTopN
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.TakeOrderedAndProjectSuite
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+class RapidsTakeOrderedAndProjectSuite
+  extends TakeOrderedAndProjectSuite
+  with RapidsSQLTestsBaseTrait {
+  import testImplicits._
+
+  testRapids("TakeOrderedAndProject query without project uses GpuTopN") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      val df = Seq((3, 10), (1, 30), (2, 20), (4, 40)).toDF("a", "b")
+        .orderBy($"a".desc, $"b".desc)
+        .limit(2)
+
+      assert(df.collect().toSeq === Seq(Row(4, 40), Row(3, 10)))
+      assertGpuTopN(df)
+    }
+  }
+
+  testRapids("TakeOrderedAndProject query with project uses GpuTopN") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      val df = Seq((3, 10), (1, 30), (2, 20), (4, 40)).toDF("a", "b")
+        .orderBy($"a".desc, $"b".desc)
+        .limit(2)
+        .select($"b")
+
+      assert(df.collect().toSeq === Seq(Row(40), Row(10)))
+      assertGpuTopN(df)
+    }
+  }
+
+  private def assertGpuTopN(df: org.apache.spark.sql.DataFrame): Unit = {
+    val gpuTopNs = getExecutedPlan(df).collect {
+      case topN: GpuTopN => topN
+    }
+    assert(gpuTopNs.nonEmpty, s"Expected GpuTopN in plan:\n${df.queryExecution.executedPlan}")
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTakeOrderedAndProjectSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTakeOrderedAndProjectSuite.scala
@@ -20,11 +20,22 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
 import com.nvidia.spark.rapids.GpuTopN
+import org.scalatest.Assertions
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.TakeOrderedAndProjectSuite
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
+
+object RapidsTakeOrderedAndProjectSuite extends Assertions {
+  def assertTopN(df: DataFrame, executedPlan: Seq[SparkPlan]): Unit = {
+    val gpuTopNs = executedPlan.collect {
+      case topN: GpuTopN => topN
+    }
+    assert(gpuTopNs.nonEmpty, s"Expected GpuTopN in plan:\n${df.queryExecution.executedPlan}")
+  }
+}
 
 class RapidsTakeOrderedAndProjectSuite
   extends TakeOrderedAndProjectSuite
@@ -38,7 +49,7 @@ class RapidsTakeOrderedAndProjectSuite
         .limit(2)
 
       assert(df.collect().toSeq === Seq(Row(4, 40), Row(3, 10)))
-      assertGpuTopN(df)
+      RapidsTakeOrderedAndProjectSuite.assertTopN(df, getExecutedPlan(df))
     }
   }
 
@@ -50,14 +61,7 @@ class RapidsTakeOrderedAndProjectSuite
         .select($"b")
 
       assert(df.collect().toSeq === Seq(Row(40), Row(10)))
-      assertGpuTopN(df)
+      RapidsTakeOrderedAndProjectSuite.assertTopN(df, getExecutedPlan(df))
     }
-  }
-
-  private def assertGpuTopN(df: org.apache.spark.sql.DataFrame): Unit = {
-    val gpuTopNs = getExecutedPlan(df).collect {
-      case topN: GpuTopN => topN
-    }
-    assert(gpuTopNs.nonEmpty, s"Expected GpuTopN in plan:\n${df.queryExecution.executedPlan}")
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsParquetResourceTest.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsParquetResourceTest.scala
@@ -17,12 +17,15 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "330"}
 spark-rapids-shim-json-lines ***/
-package org.apache.spark.sql.rapids.suites
+package org.apache.spark.sql.rapids.utils
 
-import org.apache.spark.sql.execution.datasources.parquet.ParquetIOSuite
-import org.apache.spark.sql.rapids.utils.{RapidsParquetResourceTest, RapidsSQLTestsBaseTrait}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 
-class RapidsParquetIOSuite
-  extends ParquetIOSuite
-  with RapidsSQLTestsBaseTrait
-  with RapidsParquetResourceTest
+trait RapidsParquetResourceTest extends ParquetTest {
+  this: RapidsSQLTestsBaseTrait =>
+
+  override protected def readResourceParquetFile(name: String): DataFrame = {
+    spark.read.parquet(testFile(name))
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsSchemaPruningTestUtils.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsSchemaPruningTestUtils.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.utils
+
+import org.scalactic.Equality
+import org.scalatest.Assertions
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.types.StructType
+
+trait RapidsSchemaPruningTestUtils extends Assertions with AdaptiveSparkPlanHelper {
+  protected def schemaEquality: Equality[StructType]
+
+  protected def checkScanSchema(
+      df: DataFrame,
+      expectedSchemaCatalogStrings: String*)
+      (scanSchema: PartialFunction[SparkPlan, StructType]): Unit = {
+    val fileSourceScanSchemas =
+      collect(df.queryExecution.executedPlan)(scanSchema)
+    assert(fileSourceScanSchemas.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemas.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings")
+    fileSourceScanSchemas.zip(expectedSchemaCatalogStrings).foreach {
+      case (actualScanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality: Equality[StructType] = schemaEquality
+        assert(actualScanSchema === expectedScanSchema)
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -32,6 +32,32 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
   enableSuite[RapidsDataFrameJoinSuite]
     .exclude("SPARK-24690 enables star schema detection even if CBO disabled", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14653"))
+  enableSuite[RapidsBroadcastJoinSuite]
+    .exclude("unsafe broadcast hash join updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU broadcast hash join execution."))
+    .exclude("unsafe broadcast hash outer join updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU broadcast hash join execution."))
+    .exclude("unsafe broadcast left semi join updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU broadcast hash join execution."))
+    .exclude("SPARK-23192: broadcast hint should be retained after using the cached data", ADJUST_UT("Replaced by testRapids version that checks GpuBroadcastHashJoinExec."))
+    .exclude("SPARK-23214: cached data should not carry extra hint info", ADJUST_UT("Replaced by testRapids version that checks GpuInMemoryTableScanExec and no GpuBroadcastHashJoinExec."))
+    .exclude("Shouldn't change broadcast join buildSide if user clearly specified", ADJUST_UT("Replaced by testRapids version that checks GpuBroadcastHashJoinExec and supported GpuBroadcastNestedLoopJoinExec build-side choices."))
+    .exclude("Shouldn't bias towards build right if user didn't specify", ADJUST_UT("Replaced by testRapids version that checks no-hint GpuBroadcastHashJoinExec and supported GpuBroadcastNestedLoopJoinExec build-side choices."))
+    .exclude("broadcast join where streamed side's output partitioning is HashPartitioning", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("broadcast join where streamed side's output partitioning is PartitioningCollection", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("BroadcastHashJoinExec output partitioning scenarios for inner join", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("BroadcastHashJoinExec output partitioning size should be limited with a config", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("SPARK-37742: join planning shouldn't read invalid InMemoryRelation stats", ADJUST_UT("Replaced by testRapids version that checks GpuInMemoryTableScanExec and no GpuBroadcastHashJoinExec."))
+  enableSuite[RapidsBroadcastJoinSuiteAE]
+    .exclude("unsafe broadcast hash join updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU broadcast hash join execution."))
+    .exclude("unsafe broadcast hash outer join updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU broadcast hash join execution."))
+    .exclude("unsafe broadcast left semi join updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU broadcast hash join execution."))
+    .exclude("SPARK-23192: broadcast hint should be retained after using the cached data", ADJUST_UT("Replaced by testRapids version that checks GpuBroadcastHashJoinExec."))
+    .exclude("SPARK-23214: cached data should not carry extra hint info", ADJUST_UT("Replaced by testRapids version that checks GpuInMemoryTableScanExec and no GpuBroadcastHashJoinExec."))
+    .exclude("Shouldn't change broadcast join buildSide if user clearly specified", ADJUST_UT("Replaced by testRapids version that checks GpuBroadcastHashJoinExec and supported GpuBroadcastNestedLoopJoinExec build-side choices."))
+    .exclude("Shouldn't bias towards build right if user didn't specify", ADJUST_UT("Replaced by testRapids version that checks no-hint GpuBroadcastHashJoinExec and supported GpuBroadcastNestedLoopJoinExec build-side choices."))
+    .exclude("broadcast join where streamed side's output partitioning is HashPartitioning", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("broadcast join where streamed side's output partitioning is PartitioningCollection", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("BroadcastHashJoinExec output partitioning scenarios for inner join", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("BroadcastHashJoinExec output partitioning size should be limited with a config", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15141"))
+    .exclude("SPARK-37742: join planning shouldn't read invalid InMemoryRelation stats", ADJUST_UT("Replaced by testRapids version that checks GpuInMemoryTableScanExec and no GpuBroadcastHashJoinExec."))
   enableSuite[RapidsDynamicPartitionPruningV1SuiteAEOff]
     .exclude("Make sure dynamic pruning works on uncorrelated queries", ADJUST_UT("Replaced by testRapids version that checks GpuSubqueryBroadcastExec"))
     .exclude("static scan metrics", ADJUST_UT("Replaced by testRapids version that checks GpuFileSourceScanExec metrics"))
@@ -142,6 +168,11 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-24596 Non-cascading Cache Invalidation - verify cached data reuse", ADJUST_UT("Replaced by testRapids version that checks non-cascading cache invalidation reuses loaded cached data without re-evaluating the UDF."))
     .exclude("SPARK-26708 Cache data and cached plan should stay consistent", ADJUST_UT("Replaced by testRapids version that checks loaded and unloaded dependent caches keep consistent cached plans under RAPIDS."))
   enableSuite[RapidsDatasetPrimitiveSuite]
+  enableSuite[RapidsFileSourceStrategySuite]
+    .exclude("partitioned table - after scan filters", ADJUST_UT("Replaced by testRapids version that checks GpuFilterExec residual filters."))
+    .exclude("[SPARK-16818] partition pruned file scans implement sameResult correctly", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15161"))
+  enableSuite[RapidsFileScanSuite]
+  enableSuite[RapidsPruneFileSourcePartitionsSuite]
   enableSuite[RapidsDataFrameWindowFunctionsSuite]
     .exclude("Window spill with more than the inMemoryThreshold and spillThreshold", WONT_FIX_ISSUE("GPU implementation doesn't respect the inMemoryThreshold and spillThreshold"))
     .exclude("SPARK-21258: complex object in combination with spilling", WONT_FIX_ISSUE("GPU implementation doesn't respect the inMemoryThreshold and spillThreshold"))
@@ -165,6 +196,39 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsMathFunctionsSuite]
   enableSuite[RapidsMiscFunctionsSuite]
   enableSuite[RapidsParquetAvroCompatibilitySuite]
+  enableSuite[RapidsParquetV1FilterSuite]
+    .exclude("filter pushdown - binary", ADJUST_UT("Original Spark test verifies parquet-mr FilterPredicate construction and record-level filtering for BinaryType; GPU Parquet scan does not use parquet-mr record filters, so the replacement checks final output correctness with a GPU scan."))
+    .exclude("filter pushdown - date", ADJUST_UT("Original Spark test verifies parquet-mr FilterPredicate construction and record-level filtering for DateType across CORRECTED/LEGACY rebase modes; GPU Parquet scan does not use parquet-mr predicates, so the replacement checks final output correctness for the supported GPU scan path."))
+    .exclude("filter pushdown - timestamp", ADJUST_UT("Original Spark test verifies parquet-mr FilterPredicate construction and record-level filtering for TIMESTAMP_MILLIS/TIMESTAMP_MICROS, plus no INT96 pushdown, across CORRECTED/LEGACY rebase modes; GPU Parquet scan does not use parquet-mr predicates, so the replacement checks final output correctness for the supported GPU scan path."))
+    .exclude("Filters should be pushed down for vectorized Parquet reader at row group level", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("SPARK-31026: Parquet predicate pushdown for fields having dots in the names", WONT_FIX_ISSUE("CPU Parquet-mr reader counter assertion; GPU scan metrics do not expose the same reader counter."))
+    .exclude("Filters should be pushed down for Parquet readers at row group level", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("filter pushdown - StringStartsWith", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("SPARK-17091: Convert IN predicate to Parquet filter push-down", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("Support Parquet column index", WONT_FIX_ISSUE("CPU Parquet column-index pruning accumulator test; GPU scan metrics do not expose the same reader counter."))
+    .exclude("SPARK-34562: Bloom filter push down", WONT_FIX_ISSUE("CPU Parquet bloom-filter pruning accumulator test; GPU scan metrics do not expose the same reader counter."))
+    .exclude("SPARK-36866: filter pushdown - year-month interval", WONT_FIX_ISSUE("Original Spark test verifies parquet-mr FilterPredicate construction and exact record-level filtering for YearMonthIntervalType after stripping Spark filters; RAPIDS uses GPU Parquet scan, and this shim does not support year-month interval comparison predicates as GPU residual filters, so the inherited check can observe extra row-group rows."))
+    .exclude("SPARK-36866: filter pushdown - day-time interval", WONT_FIX_ISSUE("Original Spark test verifies parquet-mr FilterPredicate construction and exact record-level filtering for DayTimeIntervalType after stripping Spark filters; RAPIDS uses GPU Parquet scan rather than parquet-mr record filtering, so the inherited check can observe extra row-group rows."))
+  enableSuite[RapidsParquetV2FilterSuite]
+    .exclude("filter pushdown - binary", ADJUST_UT("Original Spark test verifies parquet-mr FilterPredicate construction and record-level filtering for BinaryType; GPU Parquet scan does not use parquet-mr record filters, so the replacement checks final output correctness with a GPU scan."))
+    .exclude("filter pushdown - date", ADJUST_UT("Original Spark test verifies parquet-mr FilterPredicate construction and record-level filtering for DateType across CORRECTED/LEGACY rebase modes; GPU Parquet scan does not use parquet-mr predicates, so the replacement checks final output correctness for the supported GPU scan path."))
+    .exclude("filter pushdown - timestamp", ADJUST_UT("Original Spark test verifies parquet-mr FilterPredicate construction and record-level filtering for TIMESTAMP_MILLIS/TIMESTAMP_MICROS, plus no INT96 pushdown, across CORRECTED/LEGACY rebase modes; GPU Parquet scan does not use parquet-mr predicates, so the replacement checks final output correctness for the supported GPU scan path."))
+    .exclude("Filters should be pushed down for vectorized Parquet reader at row group level", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("SPARK-31026: Parquet predicate pushdown for fields having dots in the names", WONT_FIX_ISSUE("CPU Parquet-mr reader counter assertion; GPU scan metrics do not expose the same reader counter."))
+    .exclude("Filters should be pushed down for Parquet readers at row group level", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("filter pushdown - StringStartsWith", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("SPARK-17091: Convert IN predicate to Parquet filter push-down", WONT_FIX_ISSUE("CPU Parquet row-group pruning accumulator test; it asserts Spark parquet-mr reader counters instead of GPU scan behavior."))
+    .exclude("Support Parquet column index", WONT_FIX_ISSUE("CPU Parquet column-index pruning accumulator test; GPU scan metrics do not expose the same reader counter."))
+    .exclude("SPARK-34562: Bloom filter push down", WONT_FIX_ISSUE("CPU Parquet bloom-filter pruning accumulator test; GPU scan metrics do not expose the same reader counter."))
+    .exclude("SPARK-36866: filter pushdown - year-month interval", WONT_FIX_ISSUE("Original Spark test verifies parquet-mr FilterPredicate construction and exact record-level filtering for YearMonthIntervalType after stripping Spark filters; RAPIDS uses GPU Parquet scan, and this shim does not support year-month interval comparison predicates as GPU residual filters, so the inherited check can observe extra row-group rows."))
+    .exclude("SPARK-36866: filter pushdown - day-time interval", WONT_FIX_ISSUE("Original Spark test verifies parquet-mr FilterPredicate construction and exact record-level filtering for DayTimeIntervalType after stripping Spark filters; RAPIDS uses GPU Parquet scan rather than parquet-mr record filtering, so the inherited check can observe extra row-group rows."))
+  enableSuite[RapidsParquetIOSuite]
+    .exclude("vectorized reader: missing all struct fields", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15178"))
+    .exclude("compression codec", WONT_FIX_ISSUE("Inherited test asserts CPU Parquet writer codec metadata; GPU writer can emit a different valid set of codecs."))
+    .exclude("SPARK-35640: int as long should throw schema incompatible error", WONT_FIX_ISSUE("GPU Parquet reader accepts the widening read where the CPU vectorized reader throws this schema mismatch exception."))
+    .exclude("SPARK-11044 Parquet writer version fixed as version1 ", WONT_FIX_ISSUE("Inherited test asserts CPU parquet-mr dictionary encoding names; GPU writer uses different valid encodings."))
+  enableSuite[RapidsParquetV1AggregatePushDownSuite]
+  enableSuite[RapidsParquetV2AggregatePushDownSuite]
   enableSuite[RapidsParquetColumnIndexSuite]
   enableSuite[RapidsParquetCompressionCodecPrecedenceSuite]
     .exclude("Create parquet table with compression", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11416"))
@@ -199,6 +263,59 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsParquetThriftCompatibilitySuite]
     .exclude("Read Parquet file generated by parquet-thrift", ADJUST_UT("https://github.com/NVIDIA/spark-rapids/pull/11591"))
   enableSuite[RapidsParquetVectorizedSuite]
+  enableSuite[RapidsOrcFilterSuite]
+  enableSuite[RapidsOrcV1QuerySuite]
+    .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core", WONT_FIX_ISSUE("Inherited Spark check toggles between CPU native/hive ORC implementations; RAPIDS uses the GPU ORC path instead."))
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column", WONT_FIX_ISSUE("CPU ORC vectorized-reader assertion; GPU uses GpuOrcScan rather than Spark CPU vectorized reader flag."))
+    .exclude("SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException", WONT_FIX_ISSUE("CPU ORC vectorized-reader assertion; GPU uses GpuOrcScan rather than Spark CPU vectorized reader flag."))
+    .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields", WONT_FIX_ISSUE("CPU ORC vectorized-reader limit assertion; GPU does not expose Spark CPU ORC vectorized-reader flag."))
+  enableSuite[RapidsOrcV2QuerySuite]
+    .exclude("SPARK-20728 Make ORCFileFormat configurable between sql/hive and sql/core", WONT_FIX_ISSUE("Inherited Spark check toggles between CPU native/hive ORC implementations; RAPIDS uses the GPU ORC path instead."))
+    .exclude("SPARK-34862: Support ORC vectorized reader for nested column", WONT_FIX_ISSUE("CPU ORC vectorized-reader assertion; GPU uses GpuOrcScan rather than Spark CPU vectorized reader flag."))
+    .exclude("SPARK-37728: Reading nested columns with ORC vectorized reader should not cause ArrayIndexOutOfBoundsException", WONT_FIX_ISSUE("CPU ORC vectorized-reader assertion; GPU uses GpuOrcScan rather than Spark CPU vectorized reader flag."))
+    .exclude("SPARK-36594: ORC vectorized reader should properly check maximal number of fields", WONT_FIX_ISSUE("CPU ORC vectorized-reader limit assertion; GPU does not expose Spark CPU ORC vectorized-reader flag."))
+  enableSuite[RapidsOrcV1AggregatePushDownSuite]
+  enableSuite[RapidsOrcV2AggregatePushDownSuite]
+    .exclude("nested column: Count(top level column) push down", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15186"))
+
+  private val orcSchemaPruningModes = Seq(
+    "Spark vectorized reader - without partition data column",
+    "Spark vectorized reader - with partition data column",
+    "Non-vectorized reader - without partition data column",
+    "Non-vectorized reader - with partition data column")
+
+  private val orcComplexReaderFailureReason =
+    KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15179")
+
+  private val orcV1ComplexReaderFailureCases = Seq(
+    "select a single complex field",
+    "select a single complex field and the partition column",
+    "partial schema intersection - select missing subfield",
+    "empty schema intersection",
+    "select one deep nested complex field after join",
+    "select one deep nested complex field after outer join")
+
+  private val orcV1SchemaPruning = enableSuite[RapidsOrcV1SchemaPruningSuite]
+  orcV1ComplexReaderFailureCases.foreach { testName =>
+    orcSchemaPruningModes.foreach { mode =>
+      orcV1SchemaPruning.exclude(s"$mode - $testName", orcComplexReaderFailureReason)
+    }
+  }
+
+  private val orcV2ComplexReaderFailureCases = Seq(
+    "select a single complex field",
+    "select a single complex field and the partition column",
+    "partial schema intersection - select missing subfield",
+    "empty schema intersection",
+    "select one deep nested complex field after join",
+    "select one deep nested complex field after outer join")
+
+  private val orcV2SchemaPruning = enableSuite[RapidsOrcV2SchemaPruningSuite]
+  orcV2ComplexReaderFailureCases.foreach { testName =>
+    orcSchemaPruningModes.foreach { mode =>
+      orcV2SchemaPruning.exclude(s"$mode - $testName", orcComplexReaderFailureReason)
+    }
+  }
   enableSuite[RapidsRandomSuite]
     .exclude("random", ADJUST_UT("Replaced by testRapids version that considers partitionIndex offset"))
     .exclude("SPARK-9127 codegen with long seed", ADJUST_UT("Replaced by testRapids version that considers partitionIndex offset"))
@@ -206,6 +323,17 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsRegexpExpressionsSuite]
   enableSuite[RapidsSQLWindowFunctionSuite]
     .exclude("test with low buffer spill threshold", WONT_FIX_ISSUE("GPU window implementation doesn't respect Spark WindowExec spill thresholds."))
+  enableSuite[RapidsSortSuite]
+    .exclude("basic sorting using ExternalSort", ADJUST_UT("Replaced by testRapids query-level version that checks GpuSortExec."))
+    .exclude("sorting all nulls", WONT_FIX_ISSUE("Direct CPU SortExec SparkPlanTest, not a GPU execution path."))
+    .exclude("sort followed by limit", ADJUST_UT("Replaced by testRapids query-level version that checks GpuTopN."))
+    .exclude("sorting does not crash for large inputs", WONT_FIX_ISSUE("Direct CPU SortExec spill-path SparkPlanTest, not a GPU execution path."))
+    .exclude("sorting updates peak execution memory", WONT_FIX_ISSUE("CPU memory metric test; not applicable to GPU sort execution."))
+    .exclude("SPARK-33260: sort order is a Stream", WONT_FIX_ISSUE("Direct CPU SortExec SparkPlanTest, not a GPU execution path."))
+    .excludeByPrefix("sorting on ", WONT_FIX_ISSUE("Direct CPU SortExec SparkPlanTest, not a GPU execution path."))
+  enableSuite[RapidsTakeOrderedAndProjectSuite]
+    .exclude("TakeOrderedAndProject.doExecute without project", ADJUST_UT("Replaced by testRapids query-level version that checks GpuTopN."))
+    .exclude("TakeOrderedAndProject.doExecute with project", ADJUST_UT("Replaced by testRapids query-level version that checks GpuTopN."))
   enableSuite[RapidsStringExpressionsSuite]
     .exclude("SPARK-22550: Elt should not generate codes beyond 64KB", WONT_FIX_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10775"))
     .exclude("SPARK-22603: FormatString should not generate codes beyond 64KB", WONT_FIX_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10775"))


### PR DESCRIPTION
Fixes #15187.

### Description
Added below Suites from Spark 330 UT.
  - `RapidsBroadcastJoinSuite`
  - `RapidsBroadcastJoinSuiteAE`
  - `RapidsFileScanSuite`
  - `RapidsFileSourceStrategySuite`
  - `RapidsPruneFileSourcePartitionsSuite`
  - `RapidsParquetIOSuite`
  - `RapidsParquetV1FilterSuite`
  - `RapidsParquetV2FilterSuite`
  - `RapidsOrcFilterSuite`
  - `RapidsOrcV1QuerySuite`
  - `RapidsOrcV2QuerySuite`
  - `RapidsParquetV1AggregatePushDownSuite`
  - `RapidsParquetV2AggregatePushDownSuite`
  - `RapidsOrcV1AggregatePushDownSuite`
  - `RapidsOrcV2AggregatePushDownSuite`
  - `RapidsOrcV1SchemaPruningSuite`
  - `RapidsOrcV2SchemaPruningSuite`
  - `RapidsSortSuite`
  - `RapidsTakeOrderedAndProjectSuite`

### Checklists
Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [X] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
