### PR TITLE
[BUG] Preserve regex sequence semantics in multi-replace

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -449,14 +449,23 @@ def test_re_replace_null():
         conf=_regexp_conf)
 
 def test_regexp_replace():
-    gen = mk_str_gen('[abcd]{0,3}')
+    gen = mk_str_gen('[abcd]{0,3}') \
+        .with_special_case('xfoocat') \
+        .with_special_case('foofoocat') \
+        .with_special_case('foofish') \
+        .with_special_case('foodog') \
+        .with_special_case('catfoo') \
+        .with_special_case('dogfoo')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'regexp_replace(a, "a", "A")',
                 'regexp_replace(a, "[^xyz]", "A")',
                 'regexp_replace(a, "([^x])|([^y])", "A")',
                 'regexp_replace(a, "(?:aa)+", "A")',
-                'regexp_replace(a, "a|b|c", "A")'),
+                'regexp_replace(a, "a|b|c", "A")',
+                'regexp_replace(a, "foo(cat|dog)", "X")',
+                'regexp_replace(a, "(cat|dog)foo", "X")',
+                'regexp_replace(a, "(foo)(cat)", "X")'),
         conf=_regexp_conf)
 
 @pytest.mark.skipif(is_before_spark_320(), reason='regexp is synonym for RLike starting in Spark 3.2.0')

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -449,6 +449,17 @@ def test_re_replace_null():
         conf=_regexp_conf)
 
 def test_regexp_replace():
+    gen = mk_str_gen('[abcd]{0,3}')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'regexp_replace(a, "a", "A")',
+                'regexp_replace(a, "[^xyz]", "A")',
+                'regexp_replace(a, "([^x])|([^y])", "A")',
+                'regexp_replace(a, "(?:aa)+", "A")',
+                'regexp_replace(a, "a|b|c", "A")'),
+        conf=_regexp_conf)
+
+def test_regexp_replace_mixed_sequence():
     gen = mk_str_gen('[abcd]{0,3}') \
         .with_special_case('xfoocat') \
         .with_special_case('foofoocat') \
@@ -458,11 +469,6 @@ def test_regexp_replace():
         .with_special_case('dogfoo')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
-                'regexp_replace(a, "a", "A")',
-                'regexp_replace(a, "[^xyz]", "A")',
-                'regexp_replace(a, "([^x])|([^y])", "A")',
-                'regexp_replace(a, "(?:aa)+", "A")',
-                'regexp_replace(a, "a|b|c", "A")',
                 'regexp_replace(a, "foo(cat|dog)", "X")',
                 'regexp_replace(a, "(cat|dog)foo", "X")',
                 'regexp_replace(a, "(foo)(cat)", "X")'),

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -460,18 +460,23 @@ def test_regexp_replace():
         conf=_regexp_conf)
 
 def test_regexp_replace_mixed_sequence():
-    gen = mk_str_gen('[abcd]{0,3}') \
+    suffix_gen = mk_str_gen('[abcd]{0,3}') \
         .with_special_case('xfoocat') \
         .with_special_case('foofoocat') \
         .with_special_case('foofish') \
-        .with_special_case('foodog') \
+        .with_special_case('foodog')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, suffix_gen).selectExpr(
+                'regexp_replace(a, "foo(cat|dog)", "X")',
+                'regexp_replace(a, "(foo)(cat)", "X")'),
+        conf=_regexp_conf)
+
+    prefix_gen = mk_str_gen('[abcd]{0,3}') \
         .with_special_case('catfoo') \
         .with_special_case('dogfoo')
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr(
-                'regexp_replace(a, "foo(cat|dog)", "X")',
-                'regexp_replace(a, "(cat|dog)foo", "X")',
-                'regexp_replace(a, "(foo)(cat)", "X")'),
+            lambda spark: unary_op_df(spark, prefix_gen).selectExpr(
+                'regexp_replace(a, "(cat|dog)foo", "X")'),
         conf=_regexp_conf)
 
 @pytest.mark.skipif(is_before_spark_320(), reason='regexp is synonym for RLike starting in Spark 3.2.0')

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1257,15 +1257,23 @@ object GpuRegExpUtils {
           case _ => None
         }
       case RegexSequence(parts) =>
-        if (GpuOverrides.isSupportedStringReplacePattern(regex.toRegexString)) {
+        if (parts.isEmpty) {
+          None
+        } else if (GpuOverrides.isSupportedStringReplacePattern(regex.toRegexString)) {
           Some(Seq(regex.toRegexString))
+        } else if (parts.size == 1) {
+          getChoicesFromRegex(parts.head)
         } else {
-          parts.foldLeft(Some(Seq[String]()): Option[Seq[String]]) { (m: Option[Seq[String]], r) =>
-            getChoicesFromRegex(r) match {
-              case Some(l) => m.map(_ ++ l)
-              case _ => None
-            }
-          }
+          // A sequence represents concatenation, not a union. Fixed single-literal
+          // children can be joined; alternatives require the regex engine.
+          parts.foldLeft(Option("")) {
+            case (Some(prefix), part) =>
+              getChoicesFromRegex(part) match {
+                case Some(literals) if literals.size == 1 => Some(prefix + literals.head)
+                case _ => None
+              }
+            case (None, _) => None
+          }.map(Seq(_))
         }
       case _ =>
         if (GpuOverrides.isSupportedStringReplacePattern(regex.toRegexString)) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1266,14 +1266,15 @@ object GpuRegExpUtils {
         } else {
           // A sequence represents concatenation, not a union. Fixed single-literal
           // children can be joined; alternatives require the regex engine.
-          parts.foldLeft(Option("")) {
-            case (Some(prefix), part) =>
+          parts.foldLeft(Option(new StringBuilder)) {
+            case (Some(builder), part) =>
               getChoicesFromRegex(part) match {
-                case Some(literals) if literals.size == 1 => Some(prefix + literals.head)
+                case Some(literals) if literals.size == 1 =>
+                  Some(builder.append(literals.head))
                 case _ => None
               }
             case (None, _) => None
-          }.map(Seq(_))
+          }.map(builder => Seq(builder.result()))
         }
       case _ =>
         if (GpuOverrides.isSupportedStringReplacePattern(regex.toRegexString)) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -209,6 +209,9 @@ class RegExpUtilsSuite extends AnyFunSuite {
       "(aa|bb)|(cc|dd)" -> Seq("aa", "bb", "cc", "dd"),
       "aa|bb|cc|dd|ee" -> Seq("aa", "bb", "cc", "dd", "ee"),
       "aa|bb|cc|dd|ee|ff" -> Seq("aa", "bb", "cc", "dd", "ee", "ff"),
+      "foo(cat)" -> Seq("foocat"),
+      "(foo)(cat)" -> Seq("foocat"),
+      "(foo)(cat)|(bar)(dog)" -> Seq("foocat", "bardog"),
       "a\n|b\t|c\r" -> Seq("a\n", "b\t", "c\r")
     )
 
@@ -218,6 +221,17 @@ class RegExpUtilsSuite extends AnyFunSuite {
       val result = GpuRegExpUtils.getChoicesFromRegex(ast)
       assert(result.isDefined && result.forall(_ == choices))
     }
+
+    Seq("foo(cat|dog)", "(cat|dog)foo").foreach { pattern =>
+      val (ast, _) = (new CudfRegexTranspiler(RegexReplaceMode)).getTranspiledAST(pattern,
+        None, Some(""))
+      assert(GpuRegExpUtils.getChoicesFromRegex(ast).isEmpty,
+        s"mixed sequence must not use stringReplaceMulti: $pattern")
+    }
+
+    val emptySequence = RegexSequence(
+      scala.collection.mutable.ListBuffer.empty[RegexAST])
+    assert(GpuRegExpUtils.getChoicesFromRegex(emptySequence).isEmpty)
 
   }
 


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +12 lines** (`stringFunctions.scala`; fix-line coverage, shim 330)

Closes #14747

## Summary

- stop treating concatenated regex components as independent multi-replace choices
- keep the existing fast path for plain literals, flat alternations, and concatenations whose children are all fixed literals
- route mixed sequences containing alternatives through the existing GPU regex kernel

## Validation

- `com.nvidia.spark.rapids.RegExpUtilsSuite`: Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
- Spark 3.3 distribution build: BUILD SUCCESS
- Spark 3.3 integration-tests build: BUILD SUCCESS
- `regexp_test.py::test_regexp_replace`: 1 passed, 39545 deselected
- JaCoCo fix-line intersection: 12 of 15 added production lines covered by the focused Scala suite

## Performance impact

This changes only literal-regex analysis during query planning. Fixed-literal concatenations remain on `stringReplaceMulti`; only sequences that require alternative/cartesian semantics move to the existing GPU regex kernel. There is no new per-row logic or GPU kernel work.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
