### PR TITLE
[BUG] Validate repeated regex choices

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -879,11 +879,12 @@ def test_rlike_missing_escape():
 @allow_non_gpu('ProjectExec', 'RLike')
 def test_rlike_fallback_possessive_quantifier():
     gen = mk_str_gen('(\u20ac|\\w){0,3}a[|b*.$\r\n]{0,2}c\\w{0,3}')
-    assert_gpu_fallback_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr(
-                'a rlike "a*+"'),
-                'RLike',
-        conf=_regexp_conf)
+    for pattern in ['a*+', '(3?|a)+', '(a|3?)+']:
+        assert_gpu_fallback_collect(
+            lambda spark, pattern=pattern: unary_op_df(spark, gen).selectExpr(
+                f'a rlike "{pattern}"'),
+            'RLike',
+            conf=_regexp_conf)
 
 def test_regexp_extract_all_idx_zero():
     gen = mk_str_gen('[abcd]{0,3}[0-9]{0,3}-[0-9]{0,3}[abcd]{1,3}')
@@ -998,6 +999,8 @@ def test_unsupported_fallback_regexp_extract():
     assert_gpu_did_fallback('REGEXP_EXTRACT("PROD", "[a-z]+", num)')
     assert_gpu_did_fallback('REGEXP_EXTRACT("PROD", reg_ex, 0)')
     assert_gpu_did_fallback('REGEXP_EXTRACT("PROD", reg_ex, num)')
+    assert_gpu_did_fallback('REGEXP_EXTRACT(a, "(3?|a)+", 0)')
+    assert_gpu_did_fallback('REGEXP_EXTRACT(a, "(a|3?)+", 0)')
 
 
 @allow_non_gpu('RegExpExtractAll')

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -830,6 +830,10 @@ class CudfRegexTranspiler(mode: RegexMode) {
         }
         None
 
+      case RegexChoice(a, b) =>
+        getUnsupportedRepetitionBaseOption(a)
+          .orElse(getUnsupportedRepetitionBaseOption(b))
+
       case RegexGroup(_, term, _) =>
         getUnsupportedRepetitionBaseOption(term)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -204,6 +204,18 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
         "cuDF does not support repetition of group containing: 3*"))
   }
 
+  test("repetition base validation recurses into choices") {
+    Seq("(3?|a)+", "(a|3?)+").foreach { pattern =>
+      assertUnsupported(pattern, RegexFindMode,
+        "cuDF does not support repetition of group containing: 3?")
+    }
+    Seq(
+      "(3|a)+" -> "(3|a)+",
+      raw"(a|\d)+" -> "(a|[0-9])+").foreach { case (pattern, expected) =>
+      assert(transpile(pattern, RegexFindMode) === expected)
+    }
+  }
+
   test("cuDF does not support OR at BOL / EOL") {
     val patterns = Seq("$|a", "^|a")
     patterns.foreach(pattern => {


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +3 lines** (RegexParser.scala; all executable added lines covered, shim 330)

Closes #14736

## Summary

- Recurse through both branches of `RegexChoice` when validating a repeated regex base.
- Reject unsupported nested repetitions such as `(3?|a)+` before they reach the cuDF regex compiler.
- Extend the existing Scala and Python fallback coverage for both choice orderings, with supported-choice controls.

## Current-main reproduction

At base `796ef8b3`, `(3?|a)+` and `(a|3?)+` were accepted for GPU `RLike` and `RegExpExtract`, then failed in cuDF with `regcomp.cpp:1199: Unsupported regex pattern`. The original anchor examples in #14736 are already rejected on current main, but the missing `RegexChoice` traversal remained observable through these unsupported repeated terms.

## Validation

- `RegularExpressionTranspilerSuite`: `Tests: succeeded 95, failed 0, canceled 6, ignored 0, pending 0`; `BUILD SUCCESS`.
- Spark 330 `dist` and `integration_tests` package build: `BUILD SUCCESS`.
- Focused Python ITs `test_rlike_fallback_possessive_quantifier` and `test_unsupported_fallback_regexp_extract`: `2 passed, 3 warnings in 9.17s`.
- Fix-line coverage: `RegexParser.scala: added=4 covered_by_test=3`; the fourth raw diff line is blank, so all three added executable lines are covered.

## Performance impact

The change is limited to query planning/transpilation. It adds recursive traversal of previously skipped choice branches, remains O(regex AST size), and adds no per-row or GPU-kernel work.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
