### PR TITLE
[BUG] Preserve regex extract capture-group indexing

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -530,7 +530,11 @@ def test_regexp_replace_character_set_negated():
         conf=_regexp_conf)
 
 def test_regexp_extract():
-    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}/?[abcd]{1,3}')
+    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}/?[abcd]{1,3}') \
+        .with_special_case('a') \
+        .with_special_case('b') \
+        .with_special_case('ab') \
+        .with_special_case('cd')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'regexp_extract(a, "([0-9]+)", 1)',
@@ -542,7 +546,11 @@ def test_regexp_extract():
                 'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)", 3)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)$", 3)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)", 3)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)$", 3)'),
+                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)$", 3)',
+                'regexp_extract(a, "(a)|(b)", 2)',
+                'regexp_extract(a, "(?:(a)(b))", 2)',
+                'regexp_extract(a, "((a)|(b))", 3)',
+                'regexp_extract(a, "(a)(b)|(c)(d)", 4)'),
         conf=_regexp_conf)
 
 def test_regexp_extract_no_match():
@@ -580,6 +588,14 @@ def test_regexp_extract_idx_out_of_bounds():
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)$", 4)').collect(),
             error_message = message,
+            conf=_regexp_conf)
+
+    non_capturing_message = "Regex group count is 1, but the specified group index is 2" if is_before_spark_350() and not (is_databricks_runtime() and spark_version() == "3.4.1") else \
+        "[INVALID_PARAMETER_VALUE.REGEX_GROUP_INDEX] The value of parameter(s) `idx` in `regexp_extract` is invalid: Expects group index between 0 and 1, but got 2."
+    assert_gpu_and_cpu_error(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'regexp_extract(a, "(?:(a))", 2)').collect(),
+            error_message = non_capturing_message,
             conf=_regexp_conf)
 
 def test_regexp_extract_multiline():
@@ -898,13 +914,21 @@ def test_regexp_extract_all_idx_zero():
 
 @pytest.mark.parametrize('slices', [4, 40, 400], ids=idfn)
 def test_regexp_extract_all_idx_positive(slices):
-    gen = mk_str_gen('[abcd]{0,3}[0-9]{0,3}-[0-9]{0,3}[abcd]{1,3}')
+    gen = mk_str_gen('[abcd]{0,3}[0-9]{0,3}-[0-9]{0,3}[abcd]{1,3}') \
+        .with_special_case('a') \
+        .with_special_case('b') \
+        .with_special_case('abab') \
+        .with_special_case('cdcd')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen, num_slices=slices).selectExpr(
                 'regexp_extract_all(a, "([a-d]+).*([0-9])", 1)',
                 'regexp_extract_all(a, "(a)(b)", 2)',
                 'regexp_extract_all(a, "([a-z0-9]((([abcd](\\\\d?)))))", 3)',
                 'regexp_extract_all(a, "(\\\\d+)-(\\\\d+)", 2)',
+                'regexp_extract_all(a, "(a)|(b)", 2)',
+                'regexp_extract_all(a, "(?:(a)(b))", 2)',
+                'regexp_extract_all(a, "((a)|(b))", 3)',
+                'regexp_extract_all(a, "(a)(b)|(c)(d)", 4)',
             ),
         conf=_regexp_conf)
 
@@ -931,6 +955,15 @@ def test_regexp_extract_all_idx_out_of_bounds():
                 'regexp_extract_all(a, "([a-d]+).*([0-9])", 3)'
             ).collect(),
         error_message=message,
+        conf=_regexp_conf)
+
+    non_capturing_message = "Regex group count is 1, but the specified group index is 2" if is_before_spark_350() and not (is_databricks_runtime() and spark_version() == "3.4.1") else \
+        "[INVALID_PARAMETER_VALUE.REGEX_GROUP_INDEX] The value of parameter(s) `idx` in `regexp_extract_all` is invalid: Expects group index between 0 and 1, but got 2."
+    assert_gpu_and_cpu_error(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'regexp_extract_all(a, "(?:(a))", 2)'
+            ).collect(),
+        error_message=non_capturing_message,
         conf=_regexp_conf)
 
 def test_rlike_unicode_support():

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -530,11 +530,7 @@ def test_regexp_replace_character_set_negated():
         conf=_regexp_conf)
 
 def test_regexp_extract():
-    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}/?[abcd]{1,3}') \
-        .with_special_case('a') \
-        .with_special_case('b') \
-        .with_special_case('ab') \
-        .with_special_case('cd')
+    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}/?[abcd]{1,3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'regexp_extract(a, "([0-9]+)", 1)',
@@ -546,7 +542,12 @@ def test_regexp_extract():
                 'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)", 3)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)$", 3)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)", 3)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)$", 3)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)$", 3)'),
+        conf=_regexp_conf)
+
+    capture_group_gen = mk_str_gen('[abcd]{1,2}')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, capture_group_gen).selectExpr(
                 'regexp_extract(a, "(a)|(b)", 2)',
                 'regexp_extract(a, "(?:(a)(b))", 2)',
                 'regexp_extract(a, "((a)|(b))", 3)',
@@ -914,17 +915,20 @@ def test_regexp_extract_all_idx_zero():
 
 @pytest.mark.parametrize('slices', [4, 40, 400], ids=idfn)
 def test_regexp_extract_all_idx_positive(slices):
-    gen = mk_str_gen('[abcd]{0,3}[0-9]{0,3}-[0-9]{0,3}[abcd]{1,3}') \
-        .with_special_case('a') \
-        .with_special_case('b') \
-        .with_special_case('abab') \
-        .with_special_case('cdcd')
+    gen = mk_str_gen('[abcd]{0,3}[0-9]{0,3}-[0-9]{0,3}[abcd]{1,3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen, num_slices=slices).selectExpr(
                 'regexp_extract_all(a, "([a-d]+).*([0-9])", 1)',
                 'regexp_extract_all(a, "(a)(b)", 2)',
                 'regexp_extract_all(a, "([a-z0-9]((([abcd](\\\\d?)))))", 3)',
                 'regexp_extract_all(a, "(\\\\d+)-(\\\\d+)", 2)',
+            ),
+        conf=_regexp_conf)
+
+    capture_group_gen = mk_str_gen('[abcd]{1,2}')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(
+                spark, capture_group_gen, num_slices=slices).selectExpr(
                 'regexp_extract_all(a, "(a)|(b)", 2)',
                 'regexp_extract_all(a, "(?:(a)(b))", 2)',
                 'regexp_extract_all(a, "((a)|(b))", 3)',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1029,8 +1029,12 @@ class CudfRegexTranspiler(mode: RegexMode) {
           current += 1
           RegexGroup(n == current, updateGroupsForExtract(term, n), lookahead)
         }
+        case RegexGroup(false, term, lookahead) =>
+          RegexGroup(capture = false, updateGroupsForExtract(term, n), lookahead)
         case RegexSequence(parts) =>
           RegexSequence(parts.map(updateGroupsForExtract(_, n)))
+        case RegexChoice(left, right) =>
+          RegexChoice(updateGroupsForExtract(left, n), updateGroupsForExtract(right, n))
         case RegexRepetition(term, quantifier) =>
           RegexRepetition(updateGroupsForExtract(term, n), quantifier)
         case _ => regex

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1230,13 +1230,13 @@ object GpuRegExpUtils {
   }
 
   /**
-   * Returns the number of groups in regexp
-   * (includes both capturing and non-capturing groups)
+   * Returns the number of capturing groups in regexp.
    */
   def countGroups(pattern: String): Int = {
     def countGroups(regexp: RegexAST): Int = {
       regexp match {
-        case RegexGroup(_, term, _) => 1 + countGroups(term)
+        case RegexGroup(capture, term, _) =>
+          (if (capture) 1 else 0) + countGroups(term)
         case other => other.children().map(countGroups).sum
       }
    }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -519,6 +519,10 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     doTranspileTest("(ab)+(c)(d)", "(ab)+(?:c)(?:d)", 1)
     doTranspileTest("(ab)+(c)(d)", "(?:ab)+(c)(?:d)", 2)
     doTranspileTest("([a-z0-9]((([abcd](\\d?)))))", "(?:[a-z0-9](?:((?:[abcd](?:[0-9]?)))))", 3)
+    doTranspileTest("(a)|(b)", "(?:a)|(b)", 2)
+    doTranspileTest("(?:(a)(b))", "(?:(?:a)(b))", 2)
+    doTranspileTest("((a)|(b))", "(?:(?:a)|(b))", 3)
+    doTranspileTest("(a)(b)|(c)(d)", "(?:a)(?:b)|(c)(?:d)", 3)
     doTranspileTest("ab", "ab", 1)
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -199,6 +199,18 @@ class StringOperatorsSuite extends SparkQueryCompareTestSuite {
 }
 
 class RegExpUtilsSuite extends AnyFunSuite {
+  test("countGroups ignores non-capturing groups") {
+    val cases = Seq(
+      "(?:(a))" -> 1,
+      "(?:(a)(b))" -> 2,
+      "(?:(a)|(b))" -> 2,
+      "(x)(?:(a)|(b))(y)" -> 4)
+
+    cases.foreach { case (pattern, expected) =>
+      assert(GpuRegExpUtils.countGroups(pattern) == expected)
+    }
+  }
+
   test("get list of choices from regexp for multi-replace") {
     val regexChoices = Map(
       "aa|bb" -> Seq("aa", "bb"),


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +6 lines** (RegexParser.scala +4; stringFunctions.scala +2; all added executable lines covered, shim 330)

Closes #14737

## Summary

- Preserve Java capture-group numbering while selecting the requested group through non-capturing groups and alternation branches.
- Count only capturing groups when validating `regexp_extract` and `regexp_extract_all` group indices.
- Extend the existing Scala and Python coverage for alternation, nested non-capturing groups, and out-of-bounds indices.

Before this change, the GPU path returned different values from CPU for patterns such as `(a)|(b)` with index 2 and `(?:(a)(b))` with index 2. It also accepted an invalid index for `(?:(a))` that CPU rejected.

## Validation

- Scala: `Tests: succeeded 98, failed 0, canceled 6, ignored 0, pending 0`
- Maven: `BUILD SUCCESS` for the focused Scala suites and for the dist/integration-test build
- Python: `6 passed, 3 warnings in 31.80s` for focused `regexp_extract` and `regexp_extract_all` tests
- JaCoCo fix-line intersection: `FIXLINE_COVERED=6 (of 7 added prod lines)`; the seventh raw line is Scaladoc, so all six executable additions are covered

The `regexp_extract_all` test grows from four to eight expressions for each of three slice values, approximately doubling that test function's expression matrix.

## Performance impact

This changes only query-planning regex AST traversal. The added traversal visits alternation arms and non-capturing groups that were previously skipped, preserving O(AST size) planning work. It does not add per-row work or change the GPU execution kernel.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required