### PR TITLE
[BUG] Treat anchors in regex character classes as literals

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -374,7 +374,14 @@ def test_re_replace_anchors():
         .with_special_case("TEST") \
         .with_special_case("TEST\n") \
         .with_special_case("TEST\r\n") \
-        .with_special_case("TEST\r")
+        .with_special_case("TEST\r") \
+        .with_special_case("$") \
+        .with_special_case("^") \
+        .with_special_case("$\n") \
+        .with_special_case("\n$") \
+        .with_special_case("a^") \
+        .with_special_case("a^\n") \
+        .with_special_case("a\nb")
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, gen).selectExpr(
             'REGEXP_REPLACE(a, "TEST$", "")',
@@ -388,6 +395,13 @@ def test_re_replace_anchors():
             'REGEXP_REPLACE(a, "^TEST\\\\Z", "PROD")',
             'REGEXP_REPLACE(a, "TEST\\\\Z", "PROD")',
             'REGEXP_REPLACE(a, "^TEST$", "PROD")',
+            # Issue #14746: $ and ^ inside character classes are literals, not anchors.
+            'REGEXP_REPLACE(a, "[$\\\\n]", "X")',
+            'REGEXP_REPLACE(a, "[$]\\\\n", "X")',
+            'REGEXP_REPLACE(a, "\\\\n[$]", "X")',
+            'REGEXP_REPLACE(a, "(?:[$])\\\\n", "X")',
+            'REGEXP_REPLACE(a, "[a^]$", "X")',
+            'REGEXP_REPLACE(a, "(?:[a^])$", "X")',
         ),
         conf=_regexp_conf)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -909,14 +909,14 @@ class CudfRegexTranspiler(mode: RegexMode) {
       contains(regex, {
         case RegexChar('^') | RegexEscaped('A') => true
         case _ => false
-      })
+      }, recurseIntoCharacterClasses = false)
     }
 
     def containsEndAnchor(regex: RegexAST): Boolean = {
       contains(regex, {
         case RegexChar('$') | RegexEscaped('z') | RegexEscaped('Z') => true
         case _ => false
-      })
+      }, recurseIntoCharacterClasses = false)
     }
 
     def containsNewline(regex: RegexAST): Boolean = {
@@ -961,7 +961,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
       }
     }
 
-    def checkEndAnchorContextSplit(r1: RegexAST, r2: RegexAST): Unit = {
+    def checkAdjacentEndAnchorContextSplit(r1: RegexAST, r2: RegexAST): Unit = {
       if ((containsEndAnchor(r1) &&
           (containsNewline(r2) || containsEmpty(r2) || containsBeginAnchor(r2))) ||
         (containsEndAnchor(r2) &&
@@ -973,29 +973,43 @@ class CudfRegexTranspiler(mode: RegexMode) {
       }
     }
 
+    def checkEndAnchorContextSplit(parts: Seq[RegexAST]): Unit = {
+      var prefixContainsEmpty = false
+      var previousPart: Option[RegexAST] = None
+
+      parts.zipWithIndex.foreach { case (part, index) =>
+        previousPart.foreach(previous => checkAdjacentEndAnchorContextSplit(previous, part))
+
+        // Split also rejects an optional term anywhere before a real end anchor. Keep this
+        // prefix-wide check limited to optional terms: newline and begin-anchor context is
+        // intentionally adjacent-only, so supported expressions such as ^a$ and \na$ remain
+        // on the GPU.
+        if (prefixContainsEmpty && containsEndAnchor(part)) {
+          val prefix = parts.take(index).map(_.toRegexString).mkString
+          throw new RegexUnsupportedException(
+            s"End of line/string anchor is not supported in this context: " +
+              s"${toReadableString(prefix)}${toReadableString(part.toRegexString)}",
+            parts.headOption.flatMap(_.position))
+        }
+
+        prefixContainsEmpty = prefixContainsEmpty || containsEmpty(part)
+        previousPart = Some(part)
+      }
+    }
+
     def checkUnsupported(regex: RegexAST): Unit = {
       regex match {
+        case RegexSequence(parts) if mode == RegexSplitMode =>
+          checkEndAnchorContextSplit(parts)
         case RegexSequence(parts) =>
           for (i <- 1 until parts.length) {
-            if (mode == RegexSplitMode) {
-              checkEndAnchorContextSplit(parts(i - 1), parts(i))
-            } else {
-              checkEndAnchorContext(parts(i - 1), parts(i))
-            }
+            checkEndAnchorContext(parts(i - 1), parts(i))
           }
         case RegexChoice(l, r) =>
           checkUnsupported(l)
           checkUnsupported(r)
         case RegexGroup(_, term, _) => checkUnsupported(term)
         case RegexRepetition(ast, _) => checkUnsupported(ast)
-        case RegexCharacterClass(_, components) =>
-          for (i <- 1 until components.length) {
-            if (mode == RegexSplitMode) {
-              checkEndAnchorContextSplit(components(i - 1), components(i))
-            } else {
-              checkEndAnchorContext(components(i - 1), components(i))
-            }
-          }
         case _ =>
           // ignore
       }
@@ -1579,16 +1593,22 @@ class CudfRegexTranspiler(mode: RegexMode) {
     }
   }
 
-  private def contains(regex: RegexAST, f: RegexAST => Boolean): Boolean = {
+  private def contains(regex: RegexAST, f: RegexAST => Boolean,
+      recurseIntoCharacterClasses: Boolean = true): Boolean = {
     if (f(regex)) {
       true
     } else {
       regex match {
-        case RegexSequence(parts) => parts.exists(x => contains(x, f))
-        case RegexGroup(_, term, _) => contains(term, f)
-        case RegexChoice(l, r) => contains(l, f) || contains(r, f)
-        case RegexRepetition(term, _) => contains(term, f)
-        case RegexCharacterClass(_, chars) => chars.exists(ch => contains(ch, f))
+        case RegexSequence(parts) =>
+          parts.exists(x => contains(x, f, recurseIntoCharacterClasses))
+        case RegexGroup(_, term, _) => contains(term, f, recurseIntoCharacterClasses)
+        case RegexChoice(l, r) =>
+          contains(l, f, recurseIntoCharacterClasses) ||
+            contains(r, f, recurseIntoCharacterClasses)
+        case RegexRepetition(term, _) => contains(term, f, recurseIntoCharacterClasses)
+        case RegexCharacterClass(_, chars) if recurseIntoCharacterClasses =>
+          chars.exists(ch => contains(ch, f, recurseIntoCharacterClasses))
+        case RegexCharacterClass(_, _) => false
         case leaf => f(leaf)
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -989,7 +989,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
           throw new RegexUnsupportedException(
             s"End of line/string anchor is not supported in this context: " +
               s"${toReadableString(prefix)}${toReadableString(part.toRegexString)}",
-            parts.headOption.flatMap(_.position))
+            part.position)
         }
 
         prefixContainsEmpty = prefixContainsEmpty || containsEmpty(part)
@@ -1000,7 +1000,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
     def checkUnsupported(regex: RegexAST): Unit = {
       regex match {
         case RegexSequence(parts) if mode == RegexSplitMode =>
-          checkEndAnchorContextSplit(parts)
+          checkEndAnchorContextSplit(parts.toSeq)
         case RegexSequence(parts) =>
           for (i <- 1 until parts.length) {
             checkEndAnchorContext(parts(i - 1), parts(i))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -339,6 +339,34 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
       "End of line/string anchor is not supported in this context")
   }
 
+  test("issue-14746: anchors inside character classes are literals") {
+    val patterns = Seq(
+      """[$\n]""",
+      """[$^]""",
+      """[$]\n""",
+      """\n[$]""",
+      """(?:[$])\n""",
+      """[a^]$""",
+      """(?:[a^])$""")
+    val inputs = Seq("", "$", "^", "\n", "$\n", "\n$", "a^", "a^\n", "a\nb")
+
+    assertCpuGpuMatchesRegexpFind(patterns, inputs)
+    assertCpuGpuMatchesRegexpReplace(patterns, inputs)
+
+    // Character-class components are alternatives, not a sequence with anchor context.
+    val characterClass = RegexCharacterClass(
+      negated = false, ListBuffer(RegexChar('$'), RegexChar('\n')))
+    val (transpiledClass, _) = new CudfRegexTranspiler(RegexReplaceMode)
+      .getTranspiledAST(characterClass, None, None)
+    assert(transpiledClass === characterClass)
+
+    // Real anchors outside a class must still detect newlines inside the adjacent class.
+    Seq("""[\r\n]$""", """$[\r\n]""").foreach { pattern =>
+      assertUnsupported(pattern, RegexReplaceMode,
+        "End of line/string anchor is not supported in this context")
+    }
+  }
+
   test("line anchor $ - find") {
     val patterns = Seq("a$", "a$b", "\f$", "$\f","TEST$")
     val inputs = Seq("a", "a\n", "a\r", "a\r\n", "a\f", "\f", "\r", "\u0085", "\u2028",
@@ -763,6 +791,23 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     for (limit <- Seq(Integer.MIN_VALUE, -2, -1)) {
       assertNoTranspileToSplittableString(patterns)
       doStringSplitTest(patterns, data, limit)
+    }
+  }
+
+  test("issue-14746: string split treats anchors in character classes as literals") {
+    val patterns = Set(
+      """[$\n]""",
+      """[$^]""",
+      """[$]\n""",
+      "^a$",
+      """\na$""",
+      """[\r\n]a$""")
+    val data = Seq("", "$", "^", "a", "\na", "\r\na", "$\n", "\n$", "a\nb")
+    doStringSplitTest(patterns, data, -1)
+
+    Seq("""[\r\n]$""", """$[\r\n]""").foreach { pattern =>
+      assertUnsupported(pattern, RegexSplitMode,
+        "End of line/string anchor is not supported in this context")
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -809,6 +809,12 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
       assertUnsupported(pattern, RegexSplitMode,
         "End of line/string anchor is not supported in this context")
     }
+
+    val optionalPrefixError = intercept[RegexUnsupportedException] {
+      transpile("a?bc$", RegexSplitMode)
+    }
+    assert(optionalPrefixError.getMessage.endsWith("near index 4"),
+      s"Unexpected split anchor position: ${optionalPrefixError.getMessage}")
   }
 
   test("issue-14748: word boundaries are not literal split delimiters") {


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +28 lines** (`RegexParser.scala`; fix-line intersection, Spark 3.3.0)

Closes #14746

## What changed

- Stop begin/end-anchor scans from descending into character classes, where `$` and `^` are literals rather than anchors.
- Stop applying sequence-adjacency checks directly to character-class components. Newline and empty-match scans still recurse into character classes.
- Preserve the split-mode guard for an optional term before a later real end anchor while keeping newline and begin-anchor checks adjacent-only. This retains the existing `\00*[D$3]$` fallback without regressing supported patterns such as `^a$`, `\na$`, and `[\r\n]a$`.
- Extend the existing regex replacement Python integration test and add focused Scala find, replace, split, direct-AST, and negative controls.

## Reproduction

Against `origin/main` at `796ef8b3c`, the full 32-config Spark 3.3.0 reproduction planned `[$]\n`, `\n[$]`, `[a^]$`, and `(?:[a^])$` through `GpuCpuBridge` with `End of line/string anchor is not supported in this context`, even though GPU and CPU results matched. After this change these patterns remain on GPU.

`[$\n]` already remained on GPU through the normal parser path because it is represented as one character-class AST node. The direct-AST regression test covers the separate invalid character-class component walk described in the issue.

Real unsupported anchor/newline contexts such as `[\r\n]$` and `$[\r\n]`, along with the existing zero-length repetition split cases, continue to fall back.

## Validation

- `RegularExpressionTranspilerSuite` (Spark 3.3.0): `Tests: succeeded 96, failed 0, canceled 6, ignored 0, pending 0`; Maven reactor `BUILD SUCCESS`.
- `mvn package -DskipTests -pl dist,integration_tests -am -Dbuildver=330 ...`: `BUILD SUCCESS`.
- `regexp_test.py::test_re_replace_anchors` with Spark 3.3.0 and Python 3.10.18: `1 passed`.
- Clean JaCoCo rerun: `FIXLINE_COVERED=28 (of 42 added prod lines)` in `RegexParser.scala`.
- `git diff --check` and Python bytecode compilation passed.

## Performance impact

This is a cold, plan-time AST validation path. The normal split traversal remains O(total AST nodes): it retains one previous-node reference and one cumulative optional-term flag, with no indexed access into `ListBuffer`. Anchor scans now skip character-class children, reducing work for those subtrees. There is no change to GPU kernels, data-path execution, or per-row runtime. The Python coverage extends one existing 2,048-row query from 11 to 17 regex projections without multiplying its parameter matrix.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
