### PR TITLE
Fix structs_to_json fallback tests for Spark 4.x[databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -34,10 +34,13 @@ non_utc_file_source_scan_allow = ['FileSourceScanExec'] if is_not_utc() else []
 non_utc_project_allow = ['StructsToJson', 'JsonToStructs'] if is_not_utc() else []
 
 # Spark 4.0+ lowers some to_json fallbacks through ProjectExec + evaluator invocation
-# instead of exposing StructsToJson directly as the non-GPU plan node.
+# instead of exposing StructsToJson directly as the non-GPU plan node. Databricks
+# keeps the Project on GPU and bridges only the StructsToJson expression to CPU.
+structs_to_json_uses_project_fallback = is_spark_400_or_later() and not is_databricks_runtime()
 structs_to_json_fallback_allow = ['StructsToJson'] + \
-    (['ProjectExec'] if is_spark_400_or_later() else [])
-structs_to_json_fallback_class = 'ProjectExec' if is_spark_400_or_later() else 'StructsToJson'
+    (['ProjectExec'] if structs_to_json_uses_project_fallback else [])
+structs_to_json_fallback_class = \
+    'ProjectExec' if structs_to_json_uses_project_fallback else 'StructsToJson'
 
 
 json_supported_gens = [

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -33,6 +33,12 @@ non_utc_file_source_scan_allow = ['FileSourceScanExec'] if is_not_utc() else []
 
 non_utc_project_allow = ['StructsToJson', 'JsonToStructs'] if is_not_utc() else []
 
+# Spark 4.0+ lowers some to_json fallbacks through ProjectExec + evaluator invocation
+# instead of exposing StructsToJson directly as the non-GPU plan node.
+structs_to_json_fallback_allow = ['StructsToJson'] + \
+    (['ProjectExec'] if is_spark_400_or_later() else [])
+structs_to_json_fallback_class = 'ProjectExec' if is_spark_400_or_later() else 'StructsToJson'
+
 
 json_supported_gens = [
     # Spark does not escape '\r' or '\n' even though it uses it to mark end of record
@@ -1275,7 +1281,7 @@ def test_structs_to_json_timestamp(data_gen, timestamp_format, timezone):
         lambda spark : struct_to_json(spark),
         conf=conf)
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
 @pytest.mark.parametrize('timezone', ['UTC+07:00'])
 def test_structs_to_json_fallback_timezone(data_gen, timezone):
@@ -1300,10 +1306,10 @@ def test_structs_to_json_fallback_timezone(data_gen, timezone):
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
 @pytest.mark.parametrize('timezone', ['UTC+07:00'])
 def test_structs_to_json_fallback_explicit_timezone(data_gen, timezone):
@@ -1326,10 +1332,10 @@ def test_structs_to_json_fallback_explicit_timezone(data_gen, timezone):
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
 def test_structs_to_json_fallback_analyzed_non_utc_timezone(data_gen):
     struct_gen = StructGen([
@@ -1352,10 +1358,10 @@ def test_structs_to_json_fallback_analyzed_non_utc_timezone(data_gen):
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 @pytest.mark.parametrize('data_gen', [date_gen, timestamp_gen], ids=idfn)
 def test_structs_to_json_fallback_legacy(data_gen):
     struct_gen = StructGen([
@@ -1373,10 +1379,10 @@ def test_structs_to_json_fallback_legacy(data_gen):
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 @pytest.mark.parametrize('data_gen', [date_gen], ids=idfn)
 @pytest.mark.parametrize('timezone', ['UTC'])
 @pytest.mark.parametrize('date_format', [
@@ -1402,10 +1408,10 @@ def test_structs_to_json_fallback_date_formats(data_gen, timezone, date_format):
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
 @pytest.mark.parametrize('timezone', ['UTC'])
 @pytest.mark.parametrize('timestamp_format', [
@@ -1431,11 +1437,11 @@ def test_structs_to_json_fallback_timestamp_formats(data_gen, timezone, timestam
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
 
-@allow_non_gpu('StructsToJson')
+@allow_non_gpu(*structs_to_json_fallback_allow)
 def test_structs_to_json_fallback_pretty():
     struct_gen = StructGen([
         ('a', long_gen),
@@ -1455,7 +1461,7 @@ def test_structs_to_json_fallback_pretty():
 
     assert_gpu_fallback_collect(
         lambda spark : struct_to_json(spark),
-        'StructsToJson',
+        structs_to_json_fallback_class,
         conf=conf)
 
 #####################################################

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,10 @@ case class GpuJsonToStructs(
   override protected def doColumnar(input: GpuColumnVector): cudf.ColumnVector = {
     NvtxRegistry.JSON_TO_STRUCTS {
       schema match {
-        case _: MapType => JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions)
+        case _: MapType =>
+          (JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions):
+            @scala.annotation.nowarn(
+              "cat=deprecation&msg=method extractRawMapFromJsonString in class JSONUtils is deprecated"))
         case struct: StructType =>
           val parsedStructs = JSONUtils.fromJSONToStructs(input.getBase, makeSchema(struct),
             cudfOptions, parsedOptions.locale == Locale.US)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -52,7 +52,8 @@ case class GpuJsonToStructs(
         case _: MapType =>
           (JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions):
             @scala.annotation.nowarn(
-              "cat=deprecation&msg=method extractRawMapFromJsonString in class JSONUtils is deprecated"))
+              "cat=deprecation&msg=method extractRawMapFromJsonString in class " +
+                "JSONUtils is deprecated"))
         case struct: StructType =>
           val parsedStructs = JSONUtils.fromJSONToStructs(input.getBase, makeSchema(struct),
             cudfOptions, parsedOptions.locale == Locale.US)


### PR DESCRIPTION

### Description

- Update `structs_to_json` fallback expectations for Spark 4.0+ because Spark now lowers affected `to_json` fallbacks through `ProjectExec` and a `StructsToJsonEvaluator` invocation instead of exposing `StructsToJson` directly in the executed plan.
- Keep the existing `StructsToJson` fallback expectation for Spark 3.x so the JSON integration tests continue to validate the correct non-GPU plan node on older Spark versions.
- Validated the change with a Spark 4.0.3 / CUDA 13 build and JSON integration tests, including the `structs_to_json_fallback` cases and the full `json_test` selection.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required