### PR TITLE
Suppress JSON map parsing deprecation warning [skip ci]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,11 @@ case class GpuJsonToStructs(
   override protected def doColumnar(input: GpuColumnVector): cudf.ColumnVector = {
     NvtxRegistry.JSON_TO_STRUCTS {
       schema match {
-        case _: MapType => JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions)
+        case _: MapType =>
+          (JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions):
+            @scala.annotation.nowarn(
+              "cat=deprecation&msg=method extractRawMapFromJsonString in class " +
+                "JSONUtils is deprecated"))
         case struct: StructType =>
           val parsedStructs = JSONUtils.fromJSONToStructs(input.getBase, makeSchema(struct),
             cudfOptions, parsedOptions.locale == Locale.US)


### PR DESCRIPTION
Caused by https://github.com/NVIDIA/cudf-spark-jni/pull/4741.

### Description

The JNI PR deprecated the two-argument `JSONUtils.extractRawMapFromJsonString` API, causing
cudf-spark CI compilation to fail because deprecation warnings are treated as errors. Suppress this
warning while retaining compatibility with older JNI artifacts that only provide this API.

Scala 2.13 / Spark 4.0.3 package and scalastyle passed.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
