### PR TITLE
Fix Spark 4.x JSON ProjectExec test allowlist [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -31,16 +31,18 @@ TEXT_INPUT_EXEC='FileSourceScanExec'
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
 non_utc_file_source_scan_allow = ['FileSourceScanExec'] if is_not_utc() else []
 
-non_utc_project_allow = ['StructsToJson', 'JsonToStructs'] if is_not_utc() else []
-
 # Spark 4.0+ lowers some to_json fallbacks through ProjectExec + evaluator invocation
 # instead of exposing StructsToJson directly as the non-GPU plan node. Databricks
 # keeps the Project on GPU and bridges only the StructsToJson expression to CPU.
-structs_to_json_uses_project_fallback = is_spark_400_or_later() and not is_databricks_runtime()
+to_json_uses_project_fallback = is_spark_400_or_later() and not is_databricks_runtime()
+
+non_utc_project_allow = (['StructsToJson', 'JsonToStructs'] +
+                         (['ProjectExec'] if to_json_uses_project_fallback else [])) \
+    if is_not_utc() else []
 structs_to_json_fallback_allow = ['StructsToJson'] + \
-    (['ProjectExec'] if structs_to_json_uses_project_fallback else [])
+    (['ProjectExec'] if to_json_uses_project_fallback else [])
 structs_to_json_fallback_class = \
-    'ProjectExec' if structs_to_json_uses_project_fallback else 'StructsToJson'
+    'ProjectExec' if to_json_uses_project_fallback else 'StructsToJson'
 
 
 json_supported_gens = [


### PR DESCRIPTION
Fixes #15204.

### Description

- Fix Spark 4.x Scala 2.13 JSON integration tests by allowing `ProjectExec` when non-UTC `to_json` plans lower through `StructsToJsonEvaluator`, because Apache Spark 4.x leaves the containing project on CPU for these cases.
- Reuse the existing Databricks-aware `to_json` fallback condition so Databricks continues to validate `StructsToJson` CPU bridging, because DBR keeps the project on GPU and bridges only the expression.
- Validated with `mvn -s /home/liangcail/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=403 -DskipTests -DskipITs -Dcuda.version=cuda13 -pl dist,integration_tests -am package` and Spark 4.0.3 JSON integration tests for the issue cases: `38 passed`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required