### PR TITLE
Prevent multithreaded shuffle merger deadlock

### DIFF
--- a/docs/design/rapids_shuffle_manager_v2_phase1_design.md
+++ b/docs/design/rapids_shuffle_manager_v2_phase1_design.md
@@ -55,8 +55,8 @@ IDs are not monotonically increasing.
 Phase 1 handles this by:
 1. **Detecting batch boundaries**: When partition ID decreases (e.g., from N-1 back to 0), 
    we know a new batch has started
-2. **Independent processing per batch**: Each batch gets its own merger thread and 
-   partial file
+2. **Independent processing per batch**: Each batch gets its own `BatchMerger` state and
+   partial file. Short merger steps run on a shared, bounded executor.
 3. **Final merge**: After all batches complete, merge their partial files into one output
 
 This multi-batch mechanism is essential - without it, the pipeline would break when 
@@ -160,7 +160,7 @@ partition ID. This allows us to:
 | Problem | Solution |
 |---------|----------|
 | Write amplification | Write to single output file per batch (no temp files per partition) - possible because data arrives in partition order |
-| No pipeline | 3-stage pipeline: Main Thread -> Writer Threads -> Merger Thread - Merger can write partitions sequentially because they arrive in order |
+| No pipeline | 3-stage pipeline: Main Thread -> Writer Pool -> Merger Pool - Each merger can write partitions sequentially because they arrive in order |
 | 200 partition limit | New architecture works with any number of partitions - no need to open N file handles since we write sequentially |
 | Uncontrolled page cache reliance | Application-controlled memory management with explicit spill decisions |
 
@@ -170,8 +170,8 @@ partition ID. This allows us to:
 
 Phase 1 introduces two major changes:
 
-**1. Three-Stage Pipeline**: Decouple record processing, serialization/compression, and 
-disk I/O into separate threads that run in parallel.
+**1. Three-Stage Pipeline**: Decouple record processing, serialization/compression, and
+disk I/O across the main thread and two bounded executors.
 
 **2. Memory-First Partial Files**: Replace per-partition temp files with a single 
 `SpillablePartialFileHandle` per batch that can reside in memory or on disk.
@@ -197,9 +197,9 @@ Together, these changes address all four problems:
 │                AFTER (Phase 1 Implementation)                               │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
-│  Main Thread          Writer Threads         Merger Thread                  │
-│  (queue tasks)   ──►  (serialize+compress)  ──►  (write to single output)   │
-│  [non-blocking]       [parallel]                 [sequential, pipelined]    │
+│  Main Thread          Writer Pool            Merger Pool                    │
+│  (queue tasks)   ──►  (serialize+compress)  ──►  (cooperative steps)        │
+│  [non-blocking]       [bounded parallelism]      [bounded, non-blocking]    │
 │                                                         │                   │
 │                                                         ▼                   │
 │                                          SpillablePartialFileHandle         │
@@ -265,13 +265,13 @@ based on current memory pressure:
 │  │               RapidsShuffleThreadedWriter (3-stage pipeline)          │  │
 │  │                                                                       │  │
 │  │  ┌─────────────┐    ┌─────────────────┐    ┌───────────────────────┐  │  │
-│  │  │ Main Thread │ ─► │ Writer Threads  │ ─► │    Merger Thread      │  │  │
-│  │  │             │    │     (Pool)      │    │    (per batch)        │  │  │
+│  │  │ Main Thread │ ─► │   Writer Pool   │ ─► │     Merger Pool       │  │  │
+│  │  │             │    │    (bounded)    │    │      (bounded)        │  │  │
 │  │  │ • Process   │    │                 │    │                       │  │  │
-│  │  │   records   │    │ • Serialize     │    │ • Wait for partition  │  │  │
-│  │  │ • Inc ref   │    │ • Compress      │    │   completion          │  │  │
-│  │  │ • Queue     │    │ • Write to      │    │ • Write to output     │  │  │
-│  │  │   tasks     │    │   buffer        │    │   in order            │  │  │
+│  │  │   records   │    │ • Serialize     │    │ • Drain ready records  │  │  │
+│  │  │ • Inc ref   │    │ • Compress      │    │ • Write in partition   │  │  │
+│  │  │ • Queue     │    │ • Write to      │    │   order                │  │  │
+│  │  │   tasks     │    │   buffer        │    │ • Yield if not ready   │  │  │
 │  │  └─────────────┘    └─────────────────┘    └───────────┬───────────┘  │  │
 │  │                                                        │              │  │
 │  └────────────────────────────────────────────────────────┼──────────────┘  │
@@ -390,7 +390,7 @@ The pipeline depends on cudf's partition output being **ordered by partition ID*
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-This ordering enables the Merger Thread to:
+This ordering enables each `BatchMerger` to:
 1. Know that when it sees partition 1 data, ALL of partition 0 data has already arrived
 2. Write partitions sequentially to a single output stream (0, then 1, then 2, ...)
 3. Never need to "go back" and write more data for an earlier partition
@@ -407,15 +407,15 @@ partition is "complete" and ready to write.
 │                                                                             │
 │  Stage 1              Stage 2                    Stage 3                    │
 │  ┌─────────────┐      ┌───────────────────┐      ┌─────────────────────┐    │
-│  │ Main Thread │      │  Writer Threads   │      │   Merger Thread     │    │
-│  │             │      │     (Pool)        │      │   (Per Batch)       │    │
+│  │ Main Thread │      │    Writer Pool    │      │    Merger Pool      │    │
+│  │             │      │     (bounded)     │      │     (bounded)       │    │
 │  │ 1. Process  │      │                   │      │                     │    │
-│  │    records  │ ───► │ 4. Execute        │ ───► │ 6. Wait for         │    │
-│  │ 2. Inc ref  │      │    compression    │      │    completions      │    │
+│  │    records  │ ───► │ 4. Execute        │ ───► │ 6. Drain ready      │    │
+│  │ 2. Inc ref  │      │    compression    │      │    records          │    │
 │  │    count    │      │    (serialize +   │      │ 7. Write to         │    │
 │  │ 3. Queue    │      │     compress)     │      │    OutputStream     │    │
 │  │    task     │      │ 5. Write to       │      │    in partition     │    │
-│  │             │      │    buffer         │      │    order            │    │
+│  │             │      │    buffer         │      │    order, then yield│    │
 │  └─────────────┘      └───────────────────┘      └──────────┬──────────┘    │
 │                                                             │               │
 │                                                             ▼               │
@@ -423,6 +423,12 @@ partition is "complete" and ready to write.
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
+
+Each batch owns its `BatchMerger` state, but not a dedicated thread. A merger step drains
+all currently ready records and returns when it reaches an unfinished compression future or an
+empty queue whose producer is not finished. Record enqueue, compression completion, and batch
+finalization reschedule the merger. The merger pool has the same size as the configured writer
+pool, so waiting batches do not occupy executor threads and merger concurrency remains bounded.
 
 **Multi-Batch Detection and Handling**:
 
@@ -449,11 +455,11 @@ The writer detects batch boundaries by observing partition ID decrease:
 When multi-batch is detected:
 1. Mark current batch as complete (set `maxPartitionIdQueued = numPartitions`)
 2. Add current batch state to pending list
-3. Create new batch state (new writer, new merger thread) - **no blocking!**
+3. Create a new batch state and writer; its merger steps use the shared pool - **no blocking!**
 4. Continue processing the new batch immediately
 
 After all records processed:
-1. Wait for all batch merger threads to complete (they run in **parallel**!)
+1. Wait for all batch merger futures to complete (bounded merger steps may complete out of order)
 2. Extract partial file handles from each batch
 3. Merge all partial files into final output
 
@@ -473,7 +479,7 @@ After all records processed:
 │  │   2. Inc ref count on ColumnarBatch                                 │    │
 │  │   3. Acquire limiter (may block if too much in-flight)              │    │
 │  │   4. Queue compression task to writer thread pool                   │    │
-│  │   5. Notify merger thread (non-blocking)                            │    │
+│  │   5. Schedule a cooperative merger step (non-blocking)             │    │
 │  └─────────────────────────────────────────────────────────────────────┘    │
 │                              │                                              │
 │                              ▼                                              │
@@ -488,12 +494,13 @@ After all records processed:
 │                              │                                              │
 │                              ▼                                              │
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
-│  │ Step 3: Merger Thread (for partitionId from 0 to N)                 │    │
+│  │ Step 3: Shared Merger Pool (for partitionId from 0 to N)            │    │
 │  │                                                                     │    │
-│  │   1. Wait for all futures for this partition to complete            │    │
+│  │   1. Drain ready futures from the head of the partition queue       │    │
 │  │   2. Incrementally write buffer content to OutputStream             │    │
 │  │   3. Release limiter for each completed future                      │    │
-│  │   4. Clean up buffer when partition is fully written                │    │
+│  │   4. Yield when the next future or producer work is not ready       │    │
+│  │   5. Reschedule on enqueue, future completion, or finalization      │    │
 │  └─────────────────────────────────────────────────────────────────────┘    │
 │                              │                                              │
 │                              ▼                                              │
@@ -527,17 +534,17 @@ After all records processed:
 │            │ batch state       │ batch state       │                        │
 │            ▼                   ▼                   ▼                        │
 │                                                                             │
-│  Merger Threads (all run in PARALLEL):                                      │
+│  Shared Merger Pool (bounded by configured writer thread count):            │
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
-│  │ Merger Thread 1: ══════════════════════► Write to PartialFile 1       │  │
-│  │ Merger Thread 2:        ═══════════════════════► Write to PartialFile2│  │
-│  │ Merger Thread 3:               ════════════════════► Write to Partial3│  │
+│  │ Batch 1 steps: ═══► yield ─────────► ═══► Write to PartialFile 1     │  │
+│  │ Batch 2 steps:      ═════► yield ─────────► Write to PartialFile 2   │  │
+│  │ Batch 3 steps:             ═══════► Write to PartialFile 3           │  │
 │  └───────────────────────────────────────────────────────────────────────┘  │
 │                                                    │                        │
 │                                                    ▼                        │
 │  After all batches complete:                                                │
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
-│  │ 1. Wait for all merger threads (parallel completion)                  │  │
+│  │ 1. Wait for all merger futures (completion order may differ)          │  │
 │  │ 2. Extract partial file handles                                       │  │
 │  │ 3. Final Merge (into new output file with FILE_ONLY mode):            │  │
 │  │    For each partition 0 to N:                                         │  │
@@ -626,7 +633,7 @@ All configs are `.startupOnly()` and `.internal()`.
 | `RapidsLocalDiskShuffleDataIO.scala` | New | RAPIDS ShuffleDataIO implementation |
 | `RapidsLocalDiskShuffleExecutorComponents.scala` | New | RAPIDS ShuffleExecutorComponents |
 | `RapidsLocalDiskShuffleMapOutputWriter.scala` | New | RAPIDS ShuffleMapOutputWriter |
-| `RapidsShuffleInternalManagerBase.scala` | Modified | Complete rewrite of threaded writer, added merger thread pool |
+| `RapidsShuffleInternalManagerBase.scala` | Modified | Complete rewrite of threaded writer, added bounded writer, reader, and merger pools |
 | `RapidsShuffleWriter.scala` | Modified | Changed from DiskBlockObjectWriter to ShuffleMapOutputWriter tracking |
 | `SpillableHostBuffer.scala` | Modified | Removed mandatory priority parameter |
 | `HostAlloc.scala` | Modified | Added `getUsageRatio()` and `isUsageBelowThreshold()` |
@@ -641,14 +648,14 @@ output in ascending partition order. Without this property, none of these would 
 | Original Problem | Phase 1 Solution | Why cudf Ordering Enables This |
 |------------------|------------------|--------------------------------|
 | **Write Amplification** | Single output file per batch instead of N temp files. Data written once, not twice. | Can write partition 0, then 1, then 2 sequentially to one file |
-| **No Pipeline** | Three-stage pipeline: Main Thread -> Writer Threads -> Merger Thread. All stages run in parallel. | Merger knows partition N is complete when it sees partition N+1 data |
+| **No Pipeline** | Three-stage pipeline: Main Thread -> Writer Pool -> Merger Pool. Ready work runs in parallel without blocking merger workers. | A merger knows partition N is complete when it sees partition N+1 data |
 | **200 Partition Limit** | New architecture works with any number of partitions. | No need to open N file handles; write sequentially to single output |
 | **Uncontrolled Page Cache** | SpillablePartialFileHandle gives application control over memory/disk decisions. | Sequential writes enable single buffer instead of N buffers |
 
 ### Additional Benefits
 
-1. **Multi-Batch Efficiency**: Multiple GPU batches can be processed in pipeline 
-   fashion, with parallel merger threads for each batch.
+1. **Multi-Batch Efficiency**: Multiple GPU batches can be processed in pipeline
+   fashion, with cooperative merger steps sharing a bounded pool.
 
 2. **Foundation for Phase 2**: The `SpillablePartialFileHandle` infrastructure 
    enables the skip-merge optimization in Phase 2, where data can stay in memory 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -16,10 +16,10 @@
 
 package org.apache.spark.sql.rapids
 
-import java.io.IOException
-import java.util.concurrent.{Callable, ConcurrentHashMap, ConcurrentLinkedQueue, ExecutionException,
-  Executors, ExecutorService, Future, LinkedBlockingQueue, TimeUnit}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import java.io.{IOException, OutputStream}
+import java.util.concurrent.{Callable, CompletableFuture, ConcurrentHashMap, ConcurrentLinkedQueue,
+  ExecutionException, Executors, ExecutorService, Future, FutureTask, LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -174,6 +174,8 @@ object RapidsShuffleInternalManagerBase extends Logging {
       p.submit(task)
     }
 
+    def execute(task: Runnable): Unit = p.execute(task)
+
     def shutdownNow(): Unit = p.shutdownNow()
   }
 
@@ -204,6 +206,11 @@ object RapidsShuffleInternalManagerBase extends Logging {
     writerSlots(slotNum % numWriterSlots).offer(task)
   }
 
+  def queueWriteTask[T](slotNum: Int, task: FutureTask[T]): Future[T] = {
+    writerSlots(slotNum % numWriterSlots).execute(task)
+    task
+  }
+
   /**
    * Send a task to a specific read slot.
    * @param slotNum the slot to submit to
@@ -215,19 +222,18 @@ object RapidsShuffleInternalManagerBase extends Logging {
     readerSlots(slotNum % numReaderSlots).offer(task)
   }
 
-  /**
-   * Send a merger task to the merger pool. Merger tasks can wait for their producer, so they
-   * must not share fixed single-threaded slots where a waiting task can block unrelated mergers.
-   */
+  /** Send a short-lived merger step to the shared merger pool. */
   def queueMergerTask[T](task: Callable[T]): Future[T] = {
     mergerPool.submit(task)
   }
 
-  // Keep the slot-based signature for compatibility. The slot number is intentionally ignored
-  // because merger tasks must not share fixed single-threaded slots.
+  // Keep the slot-based signature for compatibility. Cooperative merger steps do not need
+  // affinity, so the slot number is intentionally ignored.
   def queueMergerTask[T](_slotNum: Int, task: Callable[T]): Future[T] = {
     queueMergerTask(task)
   }
+
+  def executeMergerTask(task: Runnable): Unit = mergerPool.execute(task)
 
   def startThreadPoolIfNeeded(
       numWriterThreads: Int,
@@ -246,10 +252,12 @@ object RapidsShuffleInternalManagerBase extends Logging {
           readerSlots.put(slotNum, new Slot(slotNum, "reader"))
         }
       }
-      mergerPool = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-        .setNameFormat("rapids-shuffle-merger-%d")
-        .setDaemon(true)
-        .build())
+      if (numWriterThreads > 0) {
+        mergerPool = Executors.newFixedThreadPool(numWriterThreads, new ThreadFactoryBuilder()
+          .setNameFormat("rapids-shuffle-merger-%d")
+          .setDaemon(true)
+          .build())
+      }
     }
   }
 
@@ -342,20 +350,169 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     remainingQuota: Long)
 
   /**
+   * Cooperatively writes one GPU batch without occupying a merger thread while waiting for work.
+   * At most one step is scheduled for this merger. A step drains all currently ready records and
+   * yields when it reaches an empty queue or an unfinished compression future.
+   */
+  private class BatchMerger(
+      writer: ShuffleMapOutputWriter,
+      partitionRecords: ConcurrentHashMap[Int,
+        ConcurrentLinkedQueue[Future[CompressedRecord]]],
+      maxPartitionIdQueued: AtomicInteger) {
+    val completionFuture = new CompletableFuture[Void]()
+
+    private val scheduled = new AtomicBoolean(false)
+    private val stepFuture = new AtomicReference[FutureTask[Void]]()
+    private var currentPartitionToWrite = 0
+    private var outputStream: OutputStream = _
+
+    def schedule(): Unit = {
+      if (!completionFuture.isDone && scheduled.compareAndSet(false, true)) {
+        val task = new FutureTask[Void](new Callable[Void] {
+          override def call(): Void = {
+            runStep()
+            null
+          }
+        })
+        stepFuture.set(task)
+        try {
+          RapidsShuffleInternalManagerBase.executeMergerTask(task)
+        } catch {
+          case t: Throwable =>
+            stepFuture.compareAndSet(task, null)
+            scheduled.set(false)
+            fail(t)
+        }
+      }
+    }
+
+    def cancel(): Unit = {
+      completionFuture.cancel(true)
+      Option(stepFuture.get()).foreach(_.cancel(true))
+      synchronized {
+        closeOutputStreamQuietly()
+      }
+    }
+
+    private def runStep(): Unit = synchronized {
+      try {
+        var keepDraining = true
+        while (keepDraining && !completionFuture.isDone) {
+          if (currentPartitionToWrite >= numPartitions) {
+            completionFuture.complete(null)
+            keepDraining = false
+          } else if (currentPartitionToWrite > maxPartitionIdQueued.get()) {
+            keepDraining = false
+          } else {
+            val recordQueue = partitionRecords.get(currentPartitionToWrite)
+            if (recordQueue == null) {
+              // The producer has advanced beyond this partition without adding records.
+              writer.getPartitionWriter(currentPartitionToWrite).openStream().close()
+              currentPartitionToWrite += 1
+            } else {
+              val future = recordQueue.peek()
+              if (future != null && future.isDone) {
+                if (outputStream == null) {
+                  outputStream = writer.getPartitionWriter(currentPartitionToWrite).openStream()
+                }
+                recordQueue.poll()
+                writeRecord(future.get())
+              } else if (future == null &&
+                  currentPartitionToWrite < maxPartitionIdQueued.get()) {
+                closeOutputStream()
+                partitionRecords.remove(currentPartitionToWrite)
+                currentPartitionToWrite += 1
+              } else {
+                // The producer or compression task will schedule another step when work is ready.
+                keepDraining = false
+              }
+            }
+          }
+        }
+
+        if (currentPartitionToWrite >= numPartitions) {
+          completionFuture.complete(null)
+        }
+      } catch {
+        case ee: ExecutionException => fail(ee.getCause)
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+          completionFuture.cancel(true)
+        case t: Throwable => fail(t)
+      } finally {
+        stepFuture.set(null)
+        scheduled.set(false)
+        if (completionFuture.isDone) {
+          closeOutputStreamQuietly()
+        }
+
+        // Recheck after clearing scheduled to avoid losing work queued during the transition.
+        if (!completionFuture.isDone && hasReadyWork) {
+          schedule()
+        }
+      }
+    }
+
+    private def hasReadyWork: Boolean = {
+      if (currentPartitionToWrite >= numPartitions) {
+        true
+      } else {
+        val maxQueued = maxPartitionIdQueued.get()
+        if (currentPartitionToWrite > maxQueued) {
+          false
+        } else {
+          val recordQueue = partitionRecords.get(currentPartitionToWrite)
+          recordQueue == null ||
+            Option(recordQueue.peek()).exists(_.isDone) ||
+            (recordQueue.isEmpty && currentPartitionToWrite < maxQueued)
+        }
+      }
+    }
+
+    private def writeRecord(record: CompressedRecord): Unit = {
+      if (record.compressedSize > 0) {
+        outputStream.write(record.buffer.getBuf, 0, record.compressedSize.toInt)
+      }
+      record.buffer.close()
+      limiter.release(record.remainingQuota)
+    }
+
+    private def closeOutputStream(): Unit = {
+      if (outputStream != null) {
+        outputStream.close()
+        outputStream = null
+      }
+    }
+
+    private def closeOutputStreamQuietly(): Unit = {
+      try {
+        closeOutputStream()
+      } catch {
+        case _: Exception =>
+      }
+    }
+
+    private def fail(t: Throwable): Unit = {
+      closeOutputStreamQuietly()
+      completionFuture.completeExceptionally(t)
+    }
+  }
+
+  /**
    * Encapsulates all state for processing one GPU batch in the multi-batch shuffle write.
    *
    * In multi-batch mode, each GPU batch gets its own BatchState with independent buffers,
-   * futures, and a dedicated merger thread. This enables pipeline parallelism where:
+   * futures, and a cooperative merger. This enables pipeline parallelism where:
    * - Main thread: processes records and queues compression tasks (non-blocking)
    * - Writer threads: execute compression tasks in parallel (each record gets its own buffer)
-   * - Merger thread: waits for completed compressions and writes partitions sequentially
+   * - Merger steps: write ready partitions sequentially and yield while waiting for work
    *
    * Key design: Each record uses an INDEPENDENT buffer to avoid the 2GB array limit.
    * When a partition has many records, instead of accumulating in one giant buffer,
    * each record's compressed data is in its own small buffer that gets written and
-   * released immediately by the merger thread.
+   * released immediately by a merger step.
    *
-   * The merger thread writes partitions in order (0, 1, 2, ...) because Spark's
+   * The merger writes partitions in order (0, 1, 2, ...) because Spark's
    * ShuffleMapOutputWriter requires sequential partition writes.
    *
    * @param batchId Unique identifier for this batch (for debugging/logging)
@@ -363,10 +520,8 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
    * @param partitionRecords Maps partitionId -> queue of compressed record futures.
    *                         Each future completes with an independent CompressedRecord.
    * @param maxPartitionIdQueued Highest partition ID that main thread has queued tasks for.
-   *                             Merger thread uses this to know when a partition is complete.
-   * @param mergerCondition Condition variable for main thread to wake up merger thread
-   * @param hasNewWork Flag for wait/notify pattern
-   * @param mergerFuture Future representing the merger task, used to wait for completion.
+   *                             The merger uses this to know when a partition is complete.
+   * @param merger Cooperative merger state and completion future.
    */
   private case class BatchState(
     batchId: Int,
@@ -374,12 +529,11 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     partitionRecords: ConcurrentHashMap[Int,
       ConcurrentLinkedQueue[Future[CompressedRecord]]],
     maxPartitionIdQueued: AtomicInteger,
-    mergerCondition: Object,
-    // Flag for classic wait/notify pattern: set to true when new work is available,
-    // reset to false after merger thread wakes up and checks actual data state.
-    // This avoids busy-loop polling and provides clear signal for debugging.
-    hasNewWork: AtomicBoolean,
-    mergerFuture: Future[_])
+    merger: BatchMerger) {
+    def mergerFuture: Future[_] = merger.completionFuture
+    def scheduleMerger(): Unit = merger.schedule()
+    def cancelMerger(): Unit = merger.cancel()
+  }
 
   /**
    * Increment the reference count and get the memory size for a value.
@@ -432,143 +586,20 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       ConcurrentLinkedQueue[Future[CompressedRecord]]]()
 
 
-    // Synchronization strategy for maxPartitionIdQueued and mergerCondition:
-    //
     // maxPartitionIdQueued: Tracks the highest partition ID queued by main thread.
     //   - Main thread: updates via set() after adding futures
-    //   - Merger thread: reads via get() to check if current partition is complete
+    //   - Merger step: reads via get() to check if current partition is complete
     //     (currentPartition < maxPartitionIdQueued means all data for currentPartition
     //     has been queued)
-    //
-    // mergerCondition: Condition variable for merger thread to wait on.
-    //   - Main thread: sets hasNewWork=true and calls notifyAll() after queuing new tasks
-    //   - Merger thread: uses classic flag pattern (while !hasNewWork wait()) to avoid
-    //     busy-loop polling and provide clear debugging signal
     val maxPartitionIdQueued = new AtomicInteger(-1)
-    val mergerCondition = new Object()
-    val hasNewWork = new AtomicBoolean(false)
-
-    // Merger task: writes compressed records to disk in partition order.
-    // Each record has its own buffer. For each partition, we:
-    // 1. Poll compressed records from the queue
-    // 2. Write buffer content to output stream
-    // 3. Close buffer immediately after writing
-    // 4. Release quota to allow more compression tasks to proceed
-    val mergerTask = new Runnable {
-      override def run(): Unit = {
-        var currentPartitionToWrite = 0
-        // Check for thread interruption to allow graceful shutdown
-        while (currentPartitionToWrite < numPartitions && !Thread.currentThread().isInterrupted) {
-          // Check if this partition has been queued by main thread
-          if (currentPartitionToWrite <= maxPartitionIdQueued.get()) {
-            val recordQueue = partitionRecords.get(currentPartitionToWrite)
-
-            if (recordQueue != null) {
-              // Open output stream for this partition (one stream per partition)
-              val outputStream = writer.getPartitionWriter(currentPartitionToWrite).openStream()
-              try {
-                // Process records until partition is complete
-                var partitionComplete = false
-                while (!partitionComplete && !Thread.currentThread().isInterrupted) {
-                  // Check if all data for this partition has been queued
-                  val isLastForPartition = maxPartitionIdQueued.synchronized {
-                    currentPartitionToWrite < maxPartitionIdQueued.get()
-                  }
-
-                  // Process all available records in the queue
-                  var madeProgress = false
-                  var future = recordQueue.poll()
-                  while (future != null) {
-                    madeProgress = true
-                    // Wait for compression to complete and get the record
-                    val record = future.get()
-
-                    // Write compressed data to output stream
-                    if (record.compressedSize > 0) {
-                      outputStream.write(record.buffer.getBuf, 0, record.compressedSize.toInt)
-                    }
-
-                    // Close buffer immediately after writing to release memory
-                    record.buffer.close()
-
-                    // Release quota after data is written to output stream
-                    limiter.release(record.remainingQuota)
-
-                    // Get next record
-                    future = recordQueue.poll()
-                  }
-
-                  if (isLastForPartition && recordQueue.isEmpty) {
-                    // All records for this partition have been processed
-                    partitionComplete = true
-                  } else if (!madeProgress) {
-                    // No records were processed, wait for main thread to queue more.
-                    // Use classic condition flag pattern to avoid busy-loop polling.
-                    // Also check interrupt flag to handle task cancellation gracefully.
-                    mergerCondition.synchronized {
-                      while (!hasNewWork.get() && !Thread.currentThread().isInterrupted) {
-                        try {
-                          mergerCondition.wait()
-                        } catch {
-                          case _: InterruptedException =>
-                            Thread.currentThread().interrupt()
-                            return
-                        }
-                      }
-                      if (Thread.currentThread().isInterrupted) {
-                        return
-                      }
-                      hasNewWork.set(false)
-                    }
-                  }
-                  // If madeProgress, loop back to process more records
-                }
-              } finally {
-                outputStream.close()
-              }
-              partitionRecords.remove(currentPartitionToWrite)
-              currentPartitionToWrite += 1
-            } else {
-              // No records for this partition, write empty partition
-              val partWriter = writer.getPartitionWriter(currentPartitionToWrite)
-              partWriter.openStream().close()
-              currentPartitionToWrite += 1
-            }
-          } else {
-            // Current partition hasn't been queued yet by main thread, wait for it.
-            mergerCondition.synchronized {
-              while (!hasNewWork.get() && !Thread.currentThread().isInterrupted) {
-                try {
-                  mergerCondition.wait()
-                } catch {
-                  case _: InterruptedException =>
-                    Thread.currentThread().interrupt()
-                    return
-                }
-              }
-              if (Thread.currentThread().isInterrupted) {
-                return
-              }
-              hasNewWork.set(false)
-            }
-          }
-        }
-      }
-    }
-
-    val mergerFuture = RapidsShuffleInternalManagerBase.queueMergerTask(() => {
-      mergerTask.run()
-      null
-    })
+    val merger = new BatchMerger(writer, partitionRecords, maxPartitionIdQueued)
 
     BatchState(
       batchId,
       writer,
       partitionRecords,
       maxPartitionIdQueued,
-      mergerCondition,
-      hasNewWork,
-      mergerFuture)
+      merger)
   }
 
   override def write(records: Iterator[Product2[K, V]]): Unit = {
@@ -677,13 +708,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           // Signal current batch is complete by setting maxPartitionIdQueued to numPartitions.
           // This tells the merger thread that all partitions (0 to numPartitions-1) have been
           // queued, so it can finish writing remaining partitions without waiting.
-          // We notify the merger thread in case it's waiting for more work.
+          // Schedule the merger in case it yielded while waiting for more work.
           // Note: We don't block here - the merger runs in parallel while we start next batch.
           currentBatch.maxPartitionIdQueued.set(numPartitions)
-          currentBatch.mergerCondition.synchronized {
-            currentBatch.hasNewWork.set(true)
-            currentBatch.mergerCondition.notifyAll()
-          }
+          currentBatch.scheduleMerger()
 
           // Add to list for later finalization
           batchStates += currentBatch
@@ -721,49 +749,58 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         // all tasks for the same partition run serially in the same slot
         val slotNum = partitionSlots.computeIfAbsent(reducePartitionId,
           _ => RapidsShuffleInternalManagerBase.getNextWriterSlot)
-        val future = RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, () => {
-          try {
-            withResource(cb) { _ =>
-              // Create a new buffer for this record.
-              // The buffer is closed by the merger thread after writing to disk.
-              val buffer = new OpenByteArrayOutputStream()
+        val batchForRecord = currentBatch
+        val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
+          override def call(): CompressedRecord = {
+            try {
+              withResource(cb) { _ =>
+                // Create a new buffer for this record.
+                // The buffer is closed by the merger thread after writing to disk.
+                val buffer = new OpenByteArrayOutputStream()
 
-              // Serialize + compress + encryption to memory buffer
-              val compressedOutputStream = blockManager.serializerManager.wrapStream(
-                ShuffleBlockId(shuffleId, mapId, reducePartitionId), buffer)
+                // Serialize + compress + encryption to memory buffer
+                val compressedOutputStream = blockManager.serializerManager.wrapStream(
+                  ShuffleBlockId(shuffleId, mapId, reducePartitionId), buffer)
 
-              val serializationStream = serializerInstance.serializeStream(
-                compressedOutputStream)
-              withResource(serializationStream) { serializer =>
-                serializer.writeKey(key.asInstanceOf[Any])
-                serializer.writeValue(value.asInstanceOf[Any])
+                val serializationStream = serializerInstance.serializeStream(
+                  compressedOutputStream)
+                withResource(serializationStream) { serializer =>
+                  serializer.writeKey(key.asInstanceOf[Any])
+                  serializer.writeValue(value.asInstanceOf[Any])
+                }
+
+                // Track total written data size (compressed size)
+                val compressedSize = buffer.getCount.toLong
+                totalCompressedSize.addAndGet(compressedSize)
+
+                // Release excess quota immediately after compression.
+                // Data is now in OpenByteArrayOutputStream (heap), only need to hold
+                // compressedSize quota until Merger writes to disk.
+                // Note: excessQuota can be 0 if compression doesn't reduce size (or expands)
+                val excessQuota = math.max(0L, recordSize - compressedSize)
+                if (excessQuota > 0) {
+                  limiter.release(excessQuota)
+                }
+
+                // Return CompressedRecord with buffer and remaining quota for Merger
+                // Total released = excessQuota + remainingQuota should equal recordSize
+                val remainingQuota = recordSize - excessQuota
+                CompressedRecord(buffer, compressedSize, remainingQuota)
               }
-
-              // Track total written data size (compressed size)
-              val compressedSize = buffer.getCount.toLong
-              totalCompressedSize.addAndGet(compressedSize)
-
-              // Release excess quota immediately after compression.
-              // Data is now in OpenByteArrayOutputStream (heap), only need to hold
-              // compressedSize quota until Merger writes to disk.
-              // Note: excessQuota can be 0 if compression doesn't reduce size (or expands)
-              val excessQuota = math.max(0L, recordSize - compressedSize)
-              if (excessQuota > 0) {
-                limiter.release(excessQuota)
-              }
-
-              // Return CompressedRecord with buffer and remaining quota for Merger
-              // Total released = excessQuota + remainingQuota should equal recordSize
-              val remainingQuota = recordSize - excessQuota
-              CompressedRecord(buffer, compressedSize, remainingQuota)
+            } catch {
+              case e: Exception =>
+                throw new IOException(
+                  s"Failed compression task for shuffle $shuffleId, map $mapId, " +
+                    s"partition $reducePartitionId", e)
             }
-          } catch {
-            case e: Exception =>
-              throw new IOException(
-                s"Failed compression task for shuffle $shuffleId, map $mapId, " +
-                  s"partition $reducePartitionId", e)
           }
-        })
+        }) {
+          override def done(): Unit = {
+            // FutureTask invokes done only after isDone becomes true.
+            batchForRecord.scheduleMerger()
+          }
+        }
+        val future = RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, compressionTask)
 
         currentBatch.maxPartitionIdQueued.synchronized {
           recordQueue.add(future)
@@ -771,13 +808,8 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
             math.max(currentBatch.maxPartitionIdQueued.get(), reducePartitionId))
         }
 
-        // Wake up merger thread to process newly queued compression task.
-        // This enables pipeline parallelism: main thread continues to next record
-        // while merger thread processes completed compressions in parallel.
-        currentBatch.mergerCondition.synchronized {
-          currentBatch.hasNewWork.set(true)
-          currentBatch.mergerCondition.notifyAll()
-        }
+        // Schedule a merger step to process this record when compression is ready.
+        currentBatch.scheduleMerger()
 
         // Reset timer for next iteration's hasNext/next
         inputFetchStart = System.nanoTime()
@@ -786,13 +818,9 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       inputFetchTimeNs += System.nanoTime() - inputFetchStart
 
       // Mark end of last batch by setting maxPartitionIdQueued to numPartitions.
-      // This signals the merger thread that all partitions have been queued.
-      // Notify ensures merger wakes up to finish any remaining work.
+      // This signals the merger that all partitions have been queued.
       currentBatch.maxPartitionIdQueued.set(numPartitions)
-      currentBatch.mergerCondition.synchronized {
-        currentBatch.hasNewWork.set(true)
-        currentBatch.mergerCondition.notifyAll()
-      }
+      currentBatch.scheduleMerger()
 
       // Add last batch to list
       batchStates += currentBatch
@@ -832,8 +860,8 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     } finally {
       // Helper to cleanup a single batch
       def cleanupBatch(batch: BatchState): Unit = {
-        // Cancel merger future if still running
-        batch.mergerFuture.cancel(true)
+        // Cancel merger completion and any currently scheduled step.
+        batch.cancelMerger()
 
         // Cancel pending futures and close their buffers
         batch.partitionRecords.values().asScala.foreach { recordQueue =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -192,6 +192,7 @@ object RapidsShuffleInternalManagerBase extends Logging {
   // used by callers to obtain a unique slot
   private val writerSlotNumber = new AtomicInteger(0)
   private val readerSlotNumber= new AtomicInteger(0)
+  private val mergerSlotNumber = new AtomicInteger(0)
 
   private var mtShuffleInitialized: Boolean = false
 
@@ -277,10 +278,12 @@ object RapidsShuffleInternalManagerBase extends Logging {
     // Reset slot counters to ensure clean state for next initialization
     writerSlotNumber.set(0)
     readerSlotNumber.set(0)
+    mergerSlotNumber.set(0)
   }
 
   def getNextWriterSlot: Int = Math.abs(writerSlotNumber.incrementAndGet())
   def getNextReaderSlot: Int = Math.abs(readerSlotNumber.incrementAndGet())
+  def getNextMergerSlot: Int = Math.abs(mergerSlotNumber.incrementAndGet())
 }
 
 trait RapidsShuffleWriterShimHelper {
@@ -366,6 +369,15 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     private var currentPartitionToWrite = 0
     private var outputStream: OutputStream = _
 
+    private sealed trait WorkState
+    private case object Complete extends WorkState
+    private case object NotReady extends WorkState
+    private case object EmptyPartition extends WorkState
+    private case class ReadyRecord(
+        queue: ConcurrentLinkedQueue[Future[CompressedRecord]],
+        future: Future[CompressedRecord]) extends WorkState
+    private case object FinishedPartition extends WorkState
+
     def schedule(): Unit = {
       if (!completionFuture.isDone && scheduled.compareAndSet(false, true)) {
         val task = new FutureTask[Void](new Callable[Void] {
@@ -398,35 +410,26 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       try {
         var keepDraining = true
         while (keepDraining && !completionFuture.isDone) {
-          if (currentPartitionToWrite >= numPartitions) {
-            completionFuture.complete(null)
-            keepDraining = false
-          } else if (currentPartitionToWrite > maxPartitionIdQueued.get()) {
-            keepDraining = false
-          } else {
-            val recordQueue = partitionRecords.get(currentPartitionToWrite)
-            if (recordQueue == null) {
+          currentWorkState match {
+            case Complete =>
+              completionFuture.complete(null)
+              keepDraining = false
+            case NotReady =>
+              keepDraining = false
+            case EmptyPartition =>
               // The producer has advanced beyond this partition without adding records.
               writer.getPartitionWriter(currentPartitionToWrite).openStream().close()
               currentPartitionToWrite += 1
-            } else {
-              val future = recordQueue.peek()
-              if (future != null && future.isDone) {
-                if (outputStream == null) {
-                  outputStream = writer.getPartitionWriter(currentPartitionToWrite).openStream()
-                }
-                recordQueue.poll()
-                writeRecord(future.get())
-              } else if (future == null &&
-                  currentPartitionToWrite < maxPartitionIdQueued.get()) {
-                closeOutputStream()
-                partitionRecords.remove(currentPartitionToWrite)
-                currentPartitionToWrite += 1
-              } else {
-                // The producer or compression task will schedule another step when work is ready.
-                keepDraining = false
+            case ReadyRecord(recordQueue, future) =>
+              if (outputStream == null) {
+                outputStream = writer.getPartitionWriter(currentPartitionToWrite).openStream()
               }
-            }
+              recordQueue.poll()
+              writeRecord(future.get())
+            case FinishedPartition =>
+              closeOutputStream()
+              partitionRecords.remove(currentPartitionToWrite)
+              currentPartitionToWrite += 1
           }
         }
 
@@ -453,21 +456,32 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       }
     }
 
-    private def hasReadyWork: Boolean = {
+    private def currentWorkState: WorkState = {
       if (currentPartitionToWrite >= numPartitions) {
-        true
+        Complete
       } else {
         val maxQueued = maxPartitionIdQueued.get()
         if (currentPartitionToWrite > maxQueued) {
-          false
+          NotReady
         } else {
           val recordQueue = partitionRecords.get(currentPartitionToWrite)
-          recordQueue == null ||
-            Option(recordQueue.peek()).exists(_.isDone) ||
-            (recordQueue.isEmpty && currentPartitionToWrite < maxQueued)
+          if (recordQueue == null) {
+            EmptyPartition
+          } else {
+            val future = recordQueue.peek()
+            if (future != null && future.isDone) {
+              ReadyRecord(recordQueue, future)
+            } else if (future == null && currentPartitionToWrite < maxQueued) {
+              FinishedPartition
+            } else {
+              NotReady
+            }
+          }
         }
       }
     }
+
+    private def hasReadyWork: Boolean = currentWorkState != NotReady
 
     private def writeRecord(record: CompressedRecord): Unit = {
       if (record.compressedSize > 0) {
@@ -632,23 +646,23 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
    *    spark.rapids.shuffle.partitioning.maxCpuBatchSize) -> Main thread acquires limiter quota
    * 2. Writer thread: serialize + compress -> OpenByteArrayOutputStream (JVM heap)
    * 3. Writer thread: release excess quota (recordSize - compressedSize)
-   * 4. Merger thread: heap buffer -> ShuffleMapOutputWriter (via SpillablePartialFileHandle)
+   * 4. Merger step: heap buffer -> ShuffleMapOutputWriter (via SpillablePartialFileHandle)
    *    - If MEMORY_WITH_SPILL mode: data may stay in host memory until spill/commit
    *    - If FILE_ONLY mode or spilled: data goes to disk
-   * 5. Merger thread: release remaining quota after writing to output stream
+   * 5. Merger step: release remaining quota after writing to output stream
    * 6. (Multi-batch only) Main thread: mergePartialFiles() combines all batch outputs into
    *    final shuffle file, reading from each SpillablePartialFileHandle sequentially
    *
    * Threading model (same for both scenarios):
    * - Main thread: Processes all records without blocking, queues compression tasks
-   * - Background merger thread(s): Wait for compression tasks to complete and write
-   *   partitions to disk in order
+   * - Merger steps: Run on a shared bounded pool, write ready partitions in order, and yield
+   *   when the next compression task is incomplete
    * - Worker threads: Execute compression tasks in parallel
    *
-   * Single batch: One merger thread writes directly to final output file
+   * Single batch: Cooperative merger steps write directly to the final output file
    *
    * Multi-batch: Detects partition ID decreasing (indicates new batch), creates
-   * independent state for each batch (each with its own merger thread running in parallel),
+   * independent state for each batch (each with its own cooperative merger),
    * then merges all batch outputs into final file.
    */
   private def writePartitionedGpuBatches(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -154,53 +154,20 @@ object RapidsShuffleInternalManagerBase extends Logging {
     case other => other
   }
 
-  /**
-   * "slots" are a thread + queue thin wrapper that is used
-   * to execute tasks that need to be done in sequentially.
-   * This is done such that the threaded shuffle posts
-   * tasks that are for writer_i, or reader_i, which are
-   * guaranteed to be processed sequentially for that writer or reader.
-   * Writers/readers that land in a different slot are working independently
-   * and could perform their work in parallel.
-   * @param slotNum this slot's unique number only used to name its executor
-   */
-  private class Slot(slotNum: Int, slotType: String) {
-    private val p = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
-      .setNameFormat(s"rapids-shuffle-$slotType-$slotNum")
-      .setDaemon(true)
-      .build())
-
-    def offer[T](task: Callable[T]): Future[T] = {
-      p.submit(task)
-    }
-
-    def execute(task: Runnable): Unit = p.execute(task)
-
-    def shutdownNow(): Unit = p.shutdownNow()
-  }
-
   // this is set by the executor on startup, when the MULTITHREADED
   // shuffle mode is utilized, as per these configs:
   //   spark.rapids.shuffle.multiThreaded.writer.threads
   //   spark.rapids.shuffle.multiThreaded.reader.threads
-  private var numReaderSlots: Int = 0
-  private lazy val readerSlots = new mutable.HashMap[Int, Slot]()
   private var writerPool: ExecutorService = _
+  private var readerPool: ExecutorService = _
   private var mergerPool: ExecutorService = _
 
-  // used by callers to obtain a unique slot
-  private val readerSlotNumber= new AtomicInteger(0)
+  // Kept for compatibility with callers that used the old slot-based merger API.
   private val mergerSlotNumber = new AtomicInteger(0)
 
   private var mtShuffleInitialized: Boolean = false
 
-  /**
-   * Send a task to a specific write slot.
-   * @param slotNum the slot to submit to
-   * @param task a task to execute
-   * @note there must not be an uncaught exception while calling
-   *      `task`.
-   */
+  /** Send a compression task to the shared writer pool. */
   def queueWriteTask[T](task: Callable[T]): Future[T] = {
     writerPool.submit(task)
   }
@@ -210,15 +177,9 @@ object RapidsShuffleInternalManagerBase extends Logging {
     task
   }
 
-  /**
-   * Send a task to a specific read slot.
-   * @param slotNum the slot to submit to
-   * @param task a task to execute
-   * @note there must not be an uncaught exception while calling
-   *      `task`.
-   */
-  def queueReadTask[T](slotNum: Int, task: Callable[T]): Future[T] = {
-    readerSlots(slotNum % numReaderSlots).offer(task)
+  /** Send a deserialization task to the shared reader pool. */
+  def queueReadTask[T](task: Callable[T]): Future[T] = {
+    readerPool.submit(task)
   }
 
   /** Send a short-lived merger step to the shared merger pool. */
@@ -239,12 +200,6 @@ object RapidsShuffleInternalManagerBase extends Logging {
       numReaderThreads: Int): Unit = synchronized {
     if (!mtShuffleInitialized) {
       mtShuffleInitialized = true
-      numReaderSlots = numReaderThreads
-      if (readerSlots.isEmpty) {
-        (0 until numReaderSlots).foreach { slotNum =>
-          readerSlots.put(slotNum, new Slot(slotNum, "reader"))
-        }
-      }
       if (numWriterThreads > 0) {
         writerPool = Executors.newFixedThreadPool(numWriterThreads, new ThreadFactoryBuilder()
           .setNameFormat("rapids-shuffle-writer-%d")
@@ -252,6 +207,12 @@ object RapidsShuffleInternalManagerBase extends Logging {
           .build())
         mergerPool = Executors.newFixedThreadPool(numWriterThreads, new ThreadFactoryBuilder()
           .setNameFormat("rapids-shuffle-merger-%d")
+          .setDaemon(true)
+          .build())
+      }
+      if (numReaderThreads > 0) {
+        readerPool = Executors.newFixedThreadPool(numReaderThreads, new ThreadFactoryBuilder()
+          .setNameFormat("rapids-shuffle-reader-%d")
           .setDaemon(true)
           .build())
       }
@@ -265,20 +226,19 @@ object RapidsShuffleInternalManagerBase extends Logging {
       writerPool = null
     }
 
-    readerSlots.values.foreach(_.shutdownNow())
-    readerSlots.clear()
+    if (readerPool != null) {
+      readerPool.shutdownNow()
+      readerPool = null
+    }
 
     if (mergerPool != null) {
       mergerPool.shutdownNow()
       mergerPool = null
     }
 
-    // Reset slot counters to ensure clean state for next initialization
-    readerSlotNumber.set(0)
     mergerSlotNumber.set(0)
   }
 
-  def getNextReaderSlot: Int = Math.abs(readerSlotNumber.incrementAndGet())
   def getNextMergerSlot: Int = Math.abs(mergerSlotNumber.incrementAndGet())
 }
 
@@ -1450,8 +1410,7 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
     }
 
     private def deserializeTask(blockState: BlockState, acquiredSize: Long): Unit = {
-      val slot = RapidsShuffleInternalManagerBase.getNextReaderSlot
-      futures += RapidsShuffleInternalManagerBase.queueReadTask(slot, () => {
+      futures += RapidsShuffleInternalManagerBase.queueReadTask(() => {
         var success = false
         // Track the size we need to release (starts with the pre-acquired size)
         var sizeToRelease = acquiredSize

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -176,6 +176,13 @@ object RapidsShuffleInternalManagerBase extends Logging {
 
   def executeMergerTask(task: Runnable): Unit = mergerPool.execute(task)
 
+  private def shutdownNow(pool: ExecutorService): Unit = {
+    pool.shutdownNow().asScala.foreach {
+      case future: Future[_] => future.cancel(false)
+      case _ =>
+    }
+  }
+
   def startThreadPoolIfNeeded(
       numWriterThreads: Int,
       numReaderThreads: Int): Unit = synchronized {
@@ -203,17 +210,17 @@ object RapidsShuffleInternalManagerBase extends Logging {
   def stopThreadPool(): Unit = synchronized {
     mtShuffleInitialized = false
     if (writerPool != null) {
-      writerPool.shutdownNow()
+      shutdownNow(writerPool)
       writerPool = null
     }
 
     if (readerPool != null) {
-      readerPool.shutdownNow()
+      shutdownNow(readerPool)
       readerPool = null
     }
 
     if (mergerPool != null) {
-      mergerPool.shutdownNow()
+      shutdownNow(mergerPool)
       mergerPool = null
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.rapids
 
 import java.io.IOException
-import java.util.concurrent.{Callable, ConcurrentHashMap, ConcurrentLinkedQueue, ExecutionException, Executors, Future, LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ConcurrentLinkedQueue, ExecutionException,
+  Executors, ExecutorService, Future, LinkedBlockingQueue, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
 
 import scala.collection.JavaConverters._
@@ -182,15 +183,13 @@ object RapidsShuffleInternalManagerBase extends Logging {
   //   spark.rapids.shuffle.multiThreaded.reader.threads
   private var numWriterSlots: Int = 0
   private var numReaderSlots: Int = 0
-  private var numMergerSlots: Int = 0
   private lazy val writerSlots = new mutable.HashMap[Int, Slot]()
   private lazy val readerSlots = new mutable.HashMap[Int, Slot]()
-  private lazy val mergerSlots = new mutable.HashMap[Int, Slot]()
+  private var mergerPool: ExecutorService = _
 
   // used by callers to obtain a unique slot
   private val writerSlotNumber = new AtomicInteger(0)
   private val readerSlotNumber= new AtomicInteger(0)
-  private val mergerSlotNumber = new AtomicInteger(0)
 
   private var mtShuffleInitialized: Boolean = false
 
@@ -217,14 +216,17 @@ object RapidsShuffleInternalManagerBase extends Logging {
   }
 
   /**
-   * Send a task to a specific merger slot.
-   * @param slotNum the slot to submit to
-   * @param task a task to execute
-   * @note there must not be an uncaught exception while calling
-   *      `task`.
+   * Send a merger task to the merger pool. Merger tasks can wait for their producer, so they
+   * must not share fixed single-threaded slots where a waiting task can block unrelated mergers.
    */
-  def queueMergerTask[T](slotNum: Int, task: Callable[T]): Future[T] = {
-    mergerSlots(slotNum % numMergerSlots).offer(task)
+  def queueMergerTask[T](task: Callable[T]): Future[T] = {
+    mergerPool.submit(task)
+  }
+
+  // Keep the slot-based signature for compatibility. The slot number is intentionally ignored
+  // because merger tasks must not share fixed single-threaded slots.
+  def queueMergerTask[T](_slotNum: Int, task: Callable[T]): Future[T] = {
+    queueMergerTask(task)
   }
 
   def startThreadPoolIfNeeded(
@@ -234,8 +236,6 @@ object RapidsShuffleInternalManagerBase extends Logging {
       mtShuffleInitialized = true
       numWriterSlots = numWriterThreads
       numReaderSlots = numReaderThreads
-      // Use same number of merger slots as writer slots
-      numMergerSlots = numWriterThreads
       if (writerSlots.isEmpty) {
         (0 until numWriterSlots).foreach { slotNum =>
           writerSlots.put(slotNum, new Slot(slotNum, "writer"))
@@ -246,11 +246,10 @@ object RapidsShuffleInternalManagerBase extends Logging {
           readerSlots.put(slotNum, new Slot(slotNum, "reader"))
         }
       }
-      if (mergerSlots.isEmpty) {
-        (0 until numMergerSlots).foreach { slotNum =>
-          mergerSlots.put(slotNum, new Slot(slotNum, "merger"))
-        }
-      }
+      mergerPool = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+        .setNameFormat("rapids-shuffle-merger-%d")
+        .setDaemon(true)
+        .build())
     }
   }
 
@@ -262,18 +261,18 @@ object RapidsShuffleInternalManagerBase extends Logging {
     readerSlots.values.foreach(_.shutdownNow())
     readerSlots.clear()
 
-    mergerSlots.values.foreach(_.shutdownNow())
-    mergerSlots.clear()
+    if (mergerPool != null) {
+      mergerPool.shutdownNow()
+      mergerPool = null
+    }
 
     // Reset slot counters to ensure clean state for next initialization
     writerSlotNumber.set(0)
     readerSlotNumber.set(0)
-    mergerSlotNumber.set(0)
   }
 
   def getNextWriterSlot: Int = Math.abs(writerSlotNumber.incrementAndGet())
   def getNextReaderSlot: Int = Math.abs(readerSlotNumber.incrementAndGet())
-  def getNextMergerSlot: Int = Math.abs(mergerSlotNumber.incrementAndGet())
 }
 
 trait RapidsShuffleWriterShimHelper {
@@ -367,7 +366,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
    *                             Merger thread uses this to know when a partition is complete.
    * @param mergerCondition Condition variable for main thread to wake up merger thread
    * @param hasNewWork Flag for wait/notify pattern
-   * @param mergerSlotNum The merger thread pool slot assigned to this batch.
    * @param mergerFuture Future representing the merger task, used to wait for completion.
    */
   private case class BatchState(
@@ -381,7 +379,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     // reset to false after merger thread wakes up and checks actual data state.
     // This avoids busy-loop polling and provides clear signal for debugging.
     hasNewWork: AtomicBoolean,
-    mergerSlotNum: Int,
     mergerFuture: Future[_])
 
   /**
@@ -450,9 +447,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     val maxPartitionIdQueued = new AtomicInteger(-1)
     val mergerCondition = new Object()
     val hasNewWork = new AtomicBoolean(false)
-
-    // Assign a merger slot for this batch
-    val mergerSlotNum = RapidsShuffleInternalManagerBase.getNextMergerSlot
 
     // Merger task: writes compressed records to disk in partition order.
     // Each record has its own buffer. For each partition, we:
@@ -562,11 +556,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       }
     }
 
-    val mergerFuture = RapidsShuffleInternalManagerBase.queueMergerTask(
-      mergerSlotNum, () => {
-        mergerTask.run()
-        null
-      })
+    val mergerFuture = RapidsShuffleInternalManagerBase.queueMergerTask(() => {
+      mergerTask.run()
+      null
+    })
 
     BatchState(
       batchId,
@@ -575,7 +568,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       maxPartitionIdQueued,
       mergerCondition,
       hasNewWork,
-      mergerSlotNum,
       mergerFuture)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1089,7 +1089,9 @@ class BytesInFlightLimiter(maxBytesInFlight: Long) {
     notifyAll()
   }
 
-  def getBytesInFlight: Long = inFlight
+  def getBytesInFlight: Long = synchronized {
+    inFlight
+  }
 }
 
 abstract class RapidsShuffleThreadedReaderBase[K, C](

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -162,15 +162,7 @@ object RapidsShuffleInternalManagerBase extends Logging {
   private var readerPool: ExecutorService = _
   private var mergerPool: ExecutorService = _
 
-  // Kept for compatibility with callers that used the old slot-based merger API.
-  private val mergerSlotNumber = new AtomicInteger(0)
-
   private var mtShuffleInitialized: Boolean = false
-
-  /** Send a compression task to the shared writer pool. */
-  def queueWriteTask[T](task: Callable[T]): Future[T] = {
-    writerPool.submit(task)
-  }
 
   def queueWriteTask[T](task: FutureTask[T]): Future[T] = {
     writerPool.execute(task)
@@ -180,17 +172,6 @@ object RapidsShuffleInternalManagerBase extends Logging {
   /** Send a deserialization task to the shared reader pool. */
   def queueReadTask[T](task: Callable[T]): Future[T] = {
     readerPool.submit(task)
-  }
-
-  /** Send a short-lived merger step to the shared merger pool. */
-  def queueMergerTask[T](task: Callable[T]): Future[T] = {
-    mergerPool.submit(task)
-  }
-
-  // Keep the slot-based signature for compatibility. Cooperative merger steps do not need
-  // affinity, so the slot number is intentionally ignored.
-  def queueMergerTask[T](_slotNum: Int, task: Callable[T]): Future[T] = {
-    queueMergerTask(task)
   }
 
   def executeMergerTask(task: Runnable): Unit = mergerPool.execute(task)
@@ -235,11 +216,7 @@ object RapidsShuffleInternalManagerBase extends Logging {
       mergerPool.shutdownNow()
       mergerPool = null
     }
-
-    mergerSlotNumber.set(0)
   }
-
-  def getNextMergerSlot: Int = Math.abs(mergerSlotNumber.incrementAndGet())
 }
 
 trait RapidsShuffleWriterShimHelper {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -183,14 +183,12 @@ object RapidsShuffleInternalManagerBase extends Logging {
   // shuffle mode is utilized, as per these configs:
   //   spark.rapids.shuffle.multiThreaded.writer.threads
   //   spark.rapids.shuffle.multiThreaded.reader.threads
-  private var numWriterSlots: Int = 0
   private var numReaderSlots: Int = 0
-  private lazy val writerSlots = new mutable.HashMap[Int, Slot]()
   private lazy val readerSlots = new mutable.HashMap[Int, Slot]()
+  private var writerPool: ExecutorService = _
   private var mergerPool: ExecutorService = _
 
   // used by callers to obtain a unique slot
-  private val writerSlotNumber = new AtomicInteger(0)
   private val readerSlotNumber= new AtomicInteger(0)
   private val mergerSlotNumber = new AtomicInteger(0)
 
@@ -203,12 +201,12 @@ object RapidsShuffleInternalManagerBase extends Logging {
    * @note there must not be an uncaught exception while calling
    *      `task`.
    */
-  def queueWriteTask[T](slotNum: Int, task: Callable[T]): Future[T] = {
-    writerSlots(slotNum % numWriterSlots).offer(task)
+  def queueWriteTask[T](task: Callable[T]): Future[T] = {
+    writerPool.submit(task)
   }
 
-  def queueWriteTask[T](slotNum: Int, task: FutureTask[T]): Future[T] = {
-    writerSlots(slotNum % numWriterSlots).execute(task)
+  def queueWriteTask[T](task: FutureTask[T]): Future[T] = {
+    writerPool.execute(task)
     task
   }
 
@@ -241,19 +239,17 @@ object RapidsShuffleInternalManagerBase extends Logging {
       numReaderThreads: Int): Unit = synchronized {
     if (!mtShuffleInitialized) {
       mtShuffleInitialized = true
-      numWriterSlots = numWriterThreads
       numReaderSlots = numReaderThreads
-      if (writerSlots.isEmpty) {
-        (0 until numWriterSlots).foreach { slotNum =>
-          writerSlots.put(slotNum, new Slot(slotNum, "writer"))
-        }
-      }
       if (readerSlots.isEmpty) {
         (0 until numReaderSlots).foreach { slotNum =>
           readerSlots.put(slotNum, new Slot(slotNum, "reader"))
         }
       }
       if (numWriterThreads > 0) {
+        writerPool = Executors.newFixedThreadPool(numWriterThreads, new ThreadFactoryBuilder()
+          .setNameFormat("rapids-shuffle-writer-%d")
+          .setDaemon(true)
+          .build())
         mergerPool = Executors.newFixedThreadPool(numWriterThreads, new ThreadFactoryBuilder()
           .setNameFormat("rapids-shuffle-merger-%d")
           .setDaemon(true)
@@ -264,8 +260,10 @@ object RapidsShuffleInternalManagerBase extends Logging {
 
   def stopThreadPool(): Unit = synchronized {
     mtShuffleInitialized = false
-    writerSlots.values.foreach(_.shutdownNow())
-    writerSlots.clear()
+    if (writerPool != null) {
+      writerPool.shutdownNow()
+      writerPool = null
+    }
 
     readerSlots.values.foreach(_.shutdownNow())
     readerSlots.clear()
@@ -276,12 +274,10 @@ object RapidsShuffleInternalManagerBase extends Logging {
     }
 
     // Reset slot counters to ensure clean state for next initialization
-    writerSlotNumber.set(0)
     readerSlotNumber.set(0)
     mergerSlotNumber.set(0)
   }
 
-  def getNextWriterSlot: Int = Math.abs(writerSlotNumber.incrementAndGet())
   def getNextReaderSlot: Int = Math.abs(readerSlotNumber.incrementAndGet())
   def getNextMergerSlot: Int = Math.abs(mergerSlotNumber.incrementAndGet())
 }
@@ -686,11 +682,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     var previousMaxPartition: Int = -1
     var isMultiBatch: Boolean = false
 
-    // Maps partitionId -> writer slot number. Ensures all compression tasks for the same
-    // partition run serially in the same single-threaded slot, preventing concurrent writes
-    // to the same partition buffer. Different partitions can still run in parallel.
-    val partitionSlots = new ConcurrentHashMap[Int, Int]()
-
     // Create initial batch state
     var currentBatch = createBatchState(currentBatchId, mapOutputWriter)
 
@@ -759,10 +750,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         limiter.acquireOrBlock(recordSize)
         waitTimeOnLimiterNs += System.nanoTime() - waitOnLimiterStart
 
-        // Get or assign a slot number for this partition to ensure
-        // all tasks for the same partition run serially in the same slot
-        val slotNum = partitionSlots.computeIfAbsent(reducePartitionId,
-          _ => RapidsShuffleInternalManagerBase.getNextWriterSlot)
         val batchForRecord = currentBatch
         val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
           override def call(): CompressedRecord = {
@@ -814,7 +801,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
             batchForRecord.scheduleMerger()
           }
         }
-        val future = RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, compressionTask)
+        val future = RapidsShuffleInternalManagerBase.queueWriteTask(compressionTask)
 
         currentBatch.maxPartitionIdQueued.synchronized {
           recordQueue.add(future)

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
@@ -40,8 +40,10 @@ package org.apache.spark.sql.rapids
 import java.io.{ByteArrayOutputStream, InputStream}
 import java.nio.ByteBuffer
 
-import ai.rapids.cudf.HostMemoryBuffer
-import com.nvidia.spark.rapids.{GpuColumnarBatchSerializer, GpuColumnVector, GpuMetric, LocalGpuMetric, NoopMetric, RapidsConf, SlicedSerializedColumnVector, SparkSessionHolder}
+import ai.rapids.cudf.{HostColumnVector, HostMemoryBuffer}
+import com.nvidia.spark.rapids.{GpuColumnarBatchSerializer, GpuColumnVector, GpuMetric,
+  LocalGpuMetric, NoopMetric, RapidsConf, RapidsHostColumnVector, SlicedSerializedColumnVector,
+  SparkSessionHolder}
 import com.nvidia.spark.rapids.Arm.withResource
 import org.mockito.ArgumentMatchers.{eq => meq}
 import org.mockito.Mockito.{mock, when}
@@ -55,6 +57,7 @@ import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase
 import org.apache.spark.sql.rapids.shims.RapidsShuffleThreadedReader
+import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.{BlockManager, BlockManagerId, ShuffleBlockId}
 
@@ -139,13 +142,11 @@ class RapidsShuffleThreadedReaderSuite
       val serializationStream = serializer.newInstance().serializeStream(byteOutputStream)
       (0 until keyValuePairsPerMap).foreach { i =>
         if (useNonEmptyBatches) {
-          withResource(HostMemoryBuffer.allocate(128)) { hmb =>
-            withResource(new SlicedSerializedColumnVector(hmb, 0, 128)) { cv =>
-              withResource(new ColumnarBatch(Array(cv))) { batch =>
-                serializationStream.writeKey(i)
-                serializationStream.writeValue(SlicedSerializedColumnVector.incRefCount(batch))
-              }
-            }
+          val hostColumn = new RapidsHostColumnVector(
+            IntegerType, HostColumnVector.fromInts(i))
+          withResource(new ColumnarBatch(Array(hostColumn), 1)) { batch =>
+            serializationStream.writeKey(i)
+            serializationStream.writeValue(batch)
           }
         } else {
           withResource(GpuColumnVector.emptyBatchFromTypes(Array.empty)) { emptyBatch =>
@@ -154,6 +155,7 @@ class RapidsShuffleThreadedReaderSuite
           }
         }
       }
+      serializationStream.close()
 
       // Setup the mocked BlockManager to return RecordingManagedBuffers.
       val localBlockManagerId = BlockManagerId("test-client", "test-client", 1)
@@ -233,7 +235,17 @@ class RapidsShuffleThreadedReaderSuite
         }
         taskContext.markTaskCompleted(Some(e))
       } else {
-        assert(shuffleReader.read().length === keyValuePairsPerMap * numMaps)
+        val results = shuffleReader.read().toArray
+        try {
+          assert(results.length === keyValuePairsPerMap * numMaps)
+        } finally {
+          results.foreach { result =>
+            result.asInstanceOf[Product2[Any, Any]]._2 match {
+              case batch: ColumnarBatch => batch.close()
+              case _ =>
+            }
+          }
+        }
         taskContext.markTaskCompleted(None)
       }
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
@@ -52,6 +52,8 @@ import org.apache.spark._
 import org.apache.spark.internal.config
 import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.serializer.SerializerManager
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase
 import org.apache.spark.sql.rapids.shims.RapidsShuffleThreadedReader
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.{BlockManager, BlockManagerId, ShuffleBlockId}
@@ -108,7 +110,11 @@ class RapidsShuffleThreadedReaderSuite
     RapidsShuffleInternalManagerBase.stopThreadPool()
   }
 
-  def runShuffleRead(numReaderThreads: Int, injectError: Boolean = false): Unit = {
+  def runShuffleRead(
+      numReaderThreads: Int,
+      injectError: Boolean = false,
+      maxBytesInFlight: Long = 1024 * 1024,
+      useNonEmptyBatches: Boolean = false): Unit = {
     val testConf = new SparkConf(false)
     // this sets the session and the SparkEnv
     SparkSessionHolder.withSparkSession(testConf, _ => {
@@ -131,10 +137,21 @@ class RapidsShuffleThreadedReaderSuite
       // from each mappers (all mappers return the same shuffle data).
       val byteOutputStream = new ByteArrayOutputStream()
       val serializationStream = serializer.newInstance().serializeStream(byteOutputStream)
-      withResource(GpuColumnVector.emptyBatchFromTypes(Array.empty)) { emptyBatch =>
-        (0 until keyValuePairsPerMap).foreach { i =>
-          serializationStream.writeKey(i)
-          serializationStream.writeValue(GpuColumnVector.incRefCounts(emptyBatch))
+      (0 until keyValuePairsPerMap).foreach { i =>
+        if (useNonEmptyBatches) {
+          withResource(HostMemoryBuffer.allocate(128)) { hmb =>
+            withResource(new SlicedSerializedColumnVector(hmb, 0, 128)) { cv =>
+              withResource(new ColumnarBatch(Array(cv))) { batch =>
+                serializationStream.writeKey(i)
+                serializationStream.writeValue(SlicedSerializedColumnVector.incRefCount(batch))
+              }
+            }
+          }
+        } else {
+          withResource(GpuColumnVector.emptyBatchFromTypes(Array.empty)) { emptyBatch =>
+            serializationStream.writeKey(i)
+            serializationStream.writeValue(GpuColumnVector.incRefCounts(emptyBatch))
+          }
         }
       }
 
@@ -168,13 +185,17 @@ class RapidsShuffleThreadedReaderSuite
       }
 
       // Create a mocked shuffle handle to pass into HashShuffleReader.
+      val limiterAcquireFailCount = new SQLMetric("sum", 0)
       val shuffleHandle = {
         val dependency = mock(classOf[GpuShuffleDependency[Int, Int, Int]])
         when(dependency.serializer).thenReturn(serializer)
         when(dependency.aggregator).thenReturn(None)
         when(dependency.keyOrdering).thenReturn(None)
         new ShuffleHandleWithMetrics[Int, Int, Int](
-          shuffleId, Map.empty, dependency)
+          shuffleId,
+          Map(GpuShuffleExchangeExecBase.METRIC_THREADED_READER_LIMITER_ACQUIRE_FAIL_COUNT ->
+            limiterAcquireFailCount),
+          dependency)
       }
 
       val serializerManager = new SerializerManager(
@@ -193,7 +214,7 @@ class RapidsShuffleThreadedReaderSuite
         shuffleHandle,
         taskContext,
         metrics,
-        1024 * 1024,
+        maxBytesInFlight,
         serializerManager,
         blockManager,
         mapOutputTracker = mapOutputTracker,
@@ -222,7 +243,15 @@ class RapidsShuffleThreadedReaderSuite
         assert(buffer.callsToRetain === 1)
         assert(buffer.callsToRelease === 1)
       }
+      if (useNonEmptyBatches) {
+        assert(limiterAcquireFailCount.value > 0,
+          "Expected a BlockState to pause when the limiter rejected its next batch")
+      }
     })
+  }
+
+  test("reader pool safely resumes a BlockState after a limiter pause") {
+    runShuffleRead(numReaderThreads = 2, maxBytesInFlight = 128, useNonEmptyBatches = true)
   }
 
   /**

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -284,6 +284,22 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     keys.toSeq
   }
 
+  private def countThreads(prefix: String): Int = {
+    Thread.getAllStackTraces.keySet().toArray.count {
+      case thread: Thread => thread.isAlive && thread.getName.startsWith(prefix)
+      case _ => false
+    }
+  }
+
+  private def waitForThreadCount(prefix: String, expectedMaximum: Int): Unit = {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (countThreads(prefix) > expectedMaximum && System.nanoTime() < deadline) {
+      Thread.sleep(10)
+    }
+    assert(countThreads(prefix) <= expectedMaximum,
+      s"Threads with prefix $prefix did not fall to $expectedMaximum or fewer")
+  }
+
   /**
    * Verify write results including partition data presence.
    * @param partitionsWithData Set of partition IDs that should have data
@@ -603,6 +619,69 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     writer.write(createTestRecords(Iterator(0, 6, 7, 14)))
     writer.stop(true)
     assert(readPartitionKeys(writer, 0) === Seq(0, 7, 14))
+  }
+
+  test("shuffle pools remain bounded across shutdown and reinitialization") {
+    val writerThreads = 2
+    val readerThreads = 3
+    RapidsShuffleInternalManagerBase.stopThreadPool()
+    waitForThreadCount("rapids-shuffle-writer-", 0)
+    waitForThreadCount("rapids-shuffle-reader-", 0)
+    waitForThreadCount("rapids-shuffle-merger-", 0)
+
+    try {
+      RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(writerThreads, readerThreads)
+      val writerStarted = new CountDownLatch(writerThreads)
+      val readerStarted = new CountDownLatch(readerThreads)
+      val mergerStarted = new CountDownLatch(writerThreads)
+      val releaseTasks = new CountDownLatch(1)
+      val writerTasks = (0 until writerThreads * 2).map { _ =>
+        RapidsShuffleInternalManagerBase.queueWriteTask(() => {
+          writerStarted.countDown()
+          releaseTasks.await()
+          null
+        })
+      }
+      val readerTasks = (0 until readerThreads * 2).map { _ =>
+        RapidsShuffleInternalManagerBase.queueReadTask(() => {
+          readerStarted.countDown()
+          releaseTasks.await()
+          null
+        })
+      }
+      val mergerTasks = (0 until writerThreads * 2).map { _ =>
+        RapidsShuffleInternalManagerBase.queueMergerTask(() => {
+          mergerStarted.countDown()
+          releaseTasks.await()
+          null
+        })
+      }
+
+      assert(writerStarted.await(5, TimeUnit.SECONDS), "writer pool did not reach its limit")
+      assert(readerStarted.await(5, TimeUnit.SECONDS), "reader pool did not reach its limit")
+      assert(mergerStarted.await(5, TimeUnit.SECONDS), "merger pool did not reach its limit")
+      assert(countThreads("rapids-shuffle-writer-") <= writerThreads)
+      assert(countThreads("rapids-shuffle-reader-") <= readerThreads)
+      assert(countThreads("rapids-shuffle-merger-") <= writerThreads)
+
+      releaseTasks.countDown()
+      (writerTasks ++ readerTasks ++ mergerTasks).foreach(_.get(5, TimeUnit.SECONDS))
+      RapidsShuffleInternalManagerBase.stopThreadPool()
+      waitForThreadCount("rapids-shuffle-writer-", 0)
+      waitForThreadCount("rapids-shuffle-reader-", 0)
+      waitForThreadCount("rapids-shuffle-merger-", 0)
+
+      RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(1, 1)
+      RapidsShuffleInternalManagerBase.queueWriteTask(() => null).get(5, TimeUnit.SECONDS)
+      RapidsShuffleInternalManagerBase.queueReadTask(() => null).get(5, TimeUnit.SECONDS)
+      RapidsShuffleInternalManagerBase.queueMergerTask(() => null).get(5, TimeUnit.SECONDS)
+      assert(countThreads("rapids-shuffle-writer-") <= 1)
+      assert(countThreads("rapids-shuffle-reader-") <= 1)
+      assert(countThreads("rapids-shuffle-merger-") <= 1)
+    } finally {
+      RapidsShuffleInternalManagerBase.stopThreadPool()
+      RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(numWriterThreads, 0)
+    }
   }
 
   test("mergers yield while producers are blocked") {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -46,7 +46,7 @@ package org.apache.spark.sql.rapids
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
-import java.util.concurrent.{CountDownLatch, FutureTask, TimeUnit}
+import java.util.concurrent.{CancellationException, CountDownLatch, Future, FutureTask, TimeUnit}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -316,6 +316,12 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     })
     RapidsShuffleInternalManagerBase.executeMergerTask(task)
     task
+  }
+
+  private def assertCancelled(future: Future[_]): Unit = {
+    assert(future.isDone)
+    assert(future.isCancelled)
+    assertThrows[CancellationException](future.get())
   }
 
   /**
@@ -887,40 +893,55 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
   // ==================== Cancellation Tests ====================
 
-  test("merger thread responds to cancellation during write") {
-    // Test that merger thread properly exits when task is cancelled.
-    // This validates the fix for zombie merger thread issue where
-    // merger could get stuck in wait() when task is killed.
-    val writer = createWriter()
+  test("shuffle pool shutdown cancels queued tasks") {
+    val numReaderThreads = 2
+    RapidsShuffleInternalManagerBase.stopThreadPool()
+    RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(
+      numWriterThreads, numReaderThreads)
 
-    // Start writing in a separate thread to simulate async operation
-    val writeThread = new Thread(() => {
-      try {
-        // Write some data that will keep merger busy
-        writer.write(createTestRecords(Iterator(0, 1, 2, 3, 4, 5, 6)))
-      } catch {
-        case _: Exception => // Expected if cancelled
+    val writerBlockersStarted = new CountDownLatch(numWriterThreads)
+    val readerBlockersStarted = new CountDownLatch(numReaderThreads)
+    val mergerBlockersStarted = new CountDownLatch(numWriterThreads)
+    val releaseBlockers = new CountDownLatch(1)
+
+    try {
+      (0 until numWriterThreads).foreach { _ =>
+        submitWriterTask {
+          writerBlockersStarted.countDown()
+          releaseBlockers.await()
+        }
       }
-    })
-    writeThread.start()
+      (0 until numReaderThreads).foreach { _ =>
+        RapidsShuffleInternalManagerBase.queueReadTask(() => {
+          readerBlockersStarted.countDown()
+          releaseBlockers.await()
+          null
+        })
+      }
+      (0 until numWriterThreads).foreach { _ =>
+        submitMergerTask {
+          mergerBlockersStarted.countDown()
+          releaseBlockers.await()
+        }
+      }
 
-    // Give writer time to start processing
-    Thread.sleep(100)
+      assert(writerBlockersStarted.await(5, TimeUnit.SECONDS))
+      assert(readerBlockersStarted.await(5, TimeUnit.SECONDS))
+      assert(mergerBlockersStarted.await(5, TimeUnit.SECONDS))
 
-    // Simulate task cancellation by calling stop(false)
-    // This should trigger cleanup and cancel merger futures
-    val stopStartTime = System.currentTimeMillis()
-    writer.stop(false)
-    val stopDuration = System.currentTimeMillis() - stopStartTime
+      val queuedWriter = submitWriterTask(())
+      val queuedReader = RapidsShuffleInternalManagerBase.queueReadTask(() => null)
+      val queuedMerger = submitMergerTask(())
 
-    // Wait for write thread to finish
-    writeThread.join(5000)
+      RapidsShuffleInternalManagerBase.stopThreadPool()
 
-    // Verify stop() completed in reasonable time (not stuck waiting for merger)
-    // If merger thread was stuck in wait(), stop() would hang
-    assert(stopDuration < 3000,
-      s"stop() took ${stopDuration}ms, suggesting merger thread may be stuck")
-    assert(!writeThread.isAlive, "Write thread should have finished")
+      assertCancelled(queuedWriter)
+      assertCancelled(queuedReader)
+      assertCancelled(queuedMerger)
+    } finally {
+      releaseBlockers.countDown()
+      RapidsShuffleInternalManagerBase.stopThreadPool()
+    }
   }
 
   test("merger thread handles interrupt flag correctly") {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -488,33 +488,144 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
   // ==================== Merger Pool Tests ====================
 
-  test("waiting merger tasks do not block unrelated mergers") {
-    val blockersStarted = new CountDownLatch(numWriterThreads)
-    val mergerCanFinish = new CountDownLatch(1)
-    val blockers = (0 until numWriterThreads).map { slotNum =>
-      RapidsShuffleInternalManagerBase.queueMergerTask(slotNum, () => {
-        blockersStarted.countDown()
-        mergerCanFinish.await()
-        null
+  test("mergers yield while producers are blocked") {
+    val producersBlocked = new CountDownLatch(numWriterThreads)
+    val releaseProducers = new CountDownLatch(1)
+    val blockedWriters = (0 until numWriterThreads).map(_ => createWriter())
+    val blockedRecords = (0 until numWriterThreads).map(createTestBatch)
+    val blockedThreads = blockedWriters.zip(blockedRecords).map { case (writer, batch) =>
+      val input = new Iterator[(Int, ColumnarBatch)] {
+        private var hasNextCalls = 0
+        private var recordReturned = false
+
+        override def hasNext: Boolean = {
+          hasNextCalls += 1
+          if (hasNextCalls <= 2) {
+            true
+          } else {
+            producersBlocked.countDown()
+            releaseProducers.await()
+            false
+          }
+        }
+
+        override def next(): (Int, ColumnarBatch) = {
+          require(!recordReturned)
+          recordReturned = true
+          (0, batch)
+        }
+      }
+      new Thread(() => {
+        try {
+          writer.write(input)
+        } catch {
+          case NonFatal(_) => // Expected when the blocked writer is cancelled during cleanup.
+        }
       })
     }
 
+    val unrelatedWriter = createWriter()
+    var unrelatedStopped = false
+    @volatile var unrelatedFailure: Throwable = null
+    val unrelatedThread = new Thread(() => {
+      try {
+        unrelatedWriter.write(createTestRecords(Iterator(1)))
+      } catch {
+        case t: Throwable => unrelatedFailure = t
+      }
+    })
     try {
-      assert(blockersStarted.await(5, TimeUnit.SECONDS), "merger blockers did not start")
+      blockedThreads.foreach(_.start())
+      assert(producersBlocked.await(5, TimeUnit.SECONDS), "producers did not block")
 
-      // With fixed merger slots, this task is queued behind the first blocker. The blockers wait
-      // for this task to release them, forming the same cycle as a merger waiting for a producer
-      // whose task cannot start. A dedicated cached merger pool allows this task to run.
-      val unrelatedMerger = RapidsShuffleInternalManagerBase.queueMergerTask(
-        numWriterThreads, () => {
-          mergerCanFinish.countDown()
-          true
-        })
-      assert(unrelatedMerger.get(5, TimeUnit.SECONDS),
-        "unrelated merger was blocked by waiting merger tasks")
+      // Wait until both mergers have written their first record. In the old implementation they
+      // then occupy all merger slots waiting for their blocked producers. Cooperative mergers
+      // yield at this point and leave the bounded pool available for unrelated work.
+      val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+      while (blockedWriters.exists(_.getBytesInFlight != 0) && System.nanoTime() < deadline) {
+        Thread.sleep(10)
+      }
+      assert(blockedWriters.forall(_.getBytesInFlight == 0),
+        "blocking mergers did not drain their first records")
+
+      unrelatedThread.start()
+      unrelatedThread.join(5000)
+      assert(!unrelatedThread.isAlive, "unrelated merger was blocked by waiting producers")
+      if (unrelatedFailure != null) {
+        throw unrelatedFailure
+      }
+      unrelatedWriter.stop(true)
+      unrelatedStopped = true
+
+      val mergerThreadCount = Thread.getAllStackTraces.keySet().toArray.count {
+        case thread: Thread => thread.getName.startsWith("rapids-shuffle-merger-")
+        case _ => false
+      }
+      assert(mergerThreadCount <= numWriterThreads,
+        s"Expected at most $numWriterThreads merger threads, found $mergerThreadCount")
     } finally {
-      mergerCanFinish.countDown()
-      blockers.foreach(_.get(5, TimeUnit.SECONDS))
+      if (!unrelatedStopped) {
+        unrelatedWriter.stop(false)
+      }
+      blockedWriters.foreach(_.stop(false))
+      releaseProducers.countDown()
+      blockedThreads.foreach(_.join(5000))
+      if (unrelatedThread.isAlive) {
+        unrelatedThread.join(5000)
+      }
+    }
+  }
+
+  test("merger resumes after compression future completes") {
+    val blockersStarted = new CountDownLatch(numWriterThreads)
+    val releaseBlockers = new CountDownLatch(1)
+    val writerBlockers = (0 until numWriterThreads).map { slotNum =>
+      RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, () => {
+        blockersStarted.countDown()
+        releaseBlockers.await()
+        null
+      })
+    }
+    assert(blockersStarted.await(5, TimeUnit.SECONDS), "writer blockers did not start")
+
+    val writer = createWriter()
+    var writerStopped = false
+    @volatile var writeFailure: Throwable = null
+    val writeThread = new Thread(() => {
+      try {
+        writer.write(createTestRecords(Iterator(0)))
+      } catch {
+        case t: Throwable => writeFailure = t
+      }
+    })
+
+    try {
+      writeThread.start()
+      val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+      while (writer.getBytesInFlight == 0 && System.nanoTime() < deadline) {
+        Thread.sleep(10)
+      }
+      assert(writer.getBytesInFlight > 0, "compression future was not queued")
+
+      // The merger has yielded because the compression future is incomplete. FutureTask.done
+      // must schedule another merger step after the writer slot is released.
+      releaseBlockers.countDown()
+      writeThread.join(5000)
+      assert(!writeThread.isAlive, "merger did not resume after compression completed")
+      if (writeFailure != null) {
+        throw writeFailure
+      }
+      writer.stop(true)
+      writerStopped = true
+    } finally {
+      releaseBlockers.countDown()
+      writerBlockers.foreach(_.get(5, TimeUnit.SECONDS))
+      if (!writerStopped) {
+        writer.stop(false)
+      }
+      if (writeThread.isAlive) {
+        writeThread.join(5000)
+      }
     }
   }
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -45,8 +45,10 @@ package org.apache.spark.sql.rapids
 
 import java.io._
 import java.nio.ByteBuffer
+import java.util.Optional
 import java.util.UUID
 import java.util.concurrent.{CancellationException, CountDownLatch, Future, FutureTask, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -68,8 +70,10 @@ import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer._
 import org.apache.spark.shuffle.IndexShuffleBlockResolver
-import org.apache.spark.shuffle.api.ShuffleExecutorComponents
-import org.apache.spark.shuffle.sort.io.RapidsLocalDiskShuffleExecutorComponents
+import org.apache.spark.shuffle.api.{ShuffleExecutorComponents, ShuffleMapOutputWriter,
+  ShufflePartitionWriter, WritableByteChannelWrapper}
+import org.apache.spark.shuffle.sort.io.{RapidsLocalDiskShuffleExecutorComponents,
+  RapidsLocalDiskShuffleMapOutputWriter}
 import org.apache.spark.sql.rapids.shims.RapidsShuffleThreadedWriter
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage._
@@ -322,6 +326,59 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     assert(future.isDone)
     assert(future.isCancelled)
     assertThrows[CancellationException](future.get())
+  }
+
+  private def useOutOfOrderBatchCompletion(
+      firstBatchBlocked: CountDownLatch,
+      releaseFirstBatch: CountDownLatch,
+      secondBatchCompleted: CountDownLatch): Unit = {
+    val nextWriterNumber = new AtomicInteger(0)
+    shuffleExecutorComponents = new RapidsLocalDiskShuffleExecutorComponents(
+      conf, blockManager, blockResolver) {
+      override def createMapOutputWriter(
+          shuffleId: Int,
+          mapTaskId: Long,
+          numPartitions: Int): ShuffleMapOutputWriter = {
+        val writerNumber = nextWriterNumber.getAndIncrement()
+        new RapidsLocalDiskShuffleMapOutputWriter(
+          shuffleId, mapTaskId, numPartitions, blockResolver, conf) {
+          override def getPartitionWriter(reducePartitionId: Int): ShufflePartitionWriter = {
+            val delegate = super.getPartitionWriter(reducePartitionId)
+            new ShufflePartitionWriter {
+              override def openStream(): OutputStream = {
+                new FilterOutputStream(delegate.openStream()) {
+                  override def write(bytes: Array[Byte], offset: Int, length: Int): Unit = {
+                    if (writerNumber == 0 && reducePartitionId == 0) {
+                      firstBatchBlocked.countDown()
+                      assert(releaseFirstBatch.await(5, TimeUnit.SECONDS),
+                        "second batch merger did not complete")
+                    }
+                    super.write(bytes, offset, length)
+                  }
+
+                  override def close(): Unit = {
+                    super.close()
+                    if (writerNumber == 1 && reducePartitionId == numPartitions - 1) {
+                      // Batch 1 occupies the other merger thread. This marker cannot run until
+                      // the current batch 2 merger step returns and completes its future.
+                      RapidsShuffleInternalManagerBase.executeMergerTask(() => {
+                        secondBatchCompleted.countDown()
+                        releaseFirstBatch.countDown()
+                      })
+                    }
+                  }
+                }
+              }
+
+              override def openChannelWrapper(): Optional[WritableByteChannelWrapper] =
+                delegate.openChannelWrapper()
+
+              override def getNumBytesWritten(): Long = delegate.getNumBytesWritten
+            }
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -637,12 +694,31 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     }
   }
 
-  test("writer pool preserves record order across multiple batches") {
+  test("writer preserves record order when batch mergers complete out of order") {
     useUncompressedShuffleOutput()
+    val firstBatchBlocked = new CountDownLatch(1)
+    val releaseFirstBatch = new CountDownLatch(1)
+    val secondBatchCompleted = new CountDownLatch(1)
+    useOutOfOrderBatchCompletion(
+      firstBatchBlocked, releaseFirstBatch, secondBatchCompleted)
+
+    val keys = Iterator(0, 6, 7, 14).zipWithIndex.map { case (key, index) =>
+      if (index == 1) {
+        assert(firstBatchBlocked.await(5, TimeUnit.SECONDS), "first batch merger did not block")
+      }
+      key
+    }
     val writer = createWriter()
-    writer.write(createTestRecords(Iterator(0, 6, 7, 14)))
-    writer.stop(true)
-    assert(readPartitionKeys(writer, 0) === Seq(0, 7, 14))
+    try {
+      writer.write(createTestRecords(keys))
+      assert(secondBatchCompleted.await(5, TimeUnit.SECONDS),
+        "second batch merger did not finish before the first")
+      writer.stop(true)
+      assert(readPartitionKeys(writer, 0) === Seq(0, 7, 14))
+    } finally {
+      releaseFirstBatch.countDown()
+      writer.stop(false)
+    }
   }
 
   test("shuffle pools remain bounded across shutdown and reinitialization") {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -94,6 +94,35 @@ class FailingTestColumnarBatchSerializer extends TestColumnarBatchSerializer {
   }
 }
 
+class OutOfOrderTestColumnarBatchSerializer(
+    firstStarted: CountDownLatch,
+    secondSerialized: CountDownLatch,
+    releaseFirst: CountDownLatch) extends TestColumnarBatchSerializer {
+  override def newInstance(): SerializerInstance = new TestColumnarBatchSerializerInstance() {
+    override def serializeStream(s: OutputStream): SerializationStream =
+      new TestColumnarBatchSerializationStream(s) {
+        private var key = -1
+
+        override def writeKey[T: ClassTag](value: T): SerializationStream = {
+          key = value.asInstanceOf[Int]
+          if (key == 0) {
+            firstStarted.countDown()
+            releaseFirst.await()
+          }
+          super.writeKey(value)
+        }
+
+        override def writeValue[T: ClassTag](value: T): SerializationStream = {
+          val result = super.writeValue(value)
+          if (key == 7) {
+            secondSerialized.countDown()
+          }
+          result
+        }
+      }
+  }
+}
+
 class TestColumnarBatchSerializerInstance extends SerializerInstance {
   override def serialize[T: ClassTag](t: T): ByteBuffer = {
     val bos = new ByteArrayOutputStream()
@@ -225,6 +254,36 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       1024 * 1024, shuffleExecutorComponents, numWriterThreads)
   }
 
+  private def useUncompressedShuffleOutput(): Unit = {
+    conf.set("spark.shuffle.compress", "false")
+    when(blockManager.serializerManager)
+      .thenReturn(new SerializerManager(new TestColumnarBatchSerializer(), conf))
+  }
+
+  private def readPartitionKeys(
+      writer: RapidsShuffleThreadedWriter[Int, ColumnarBatch],
+      partitionId: Int): Seq[Int] = {
+    val lengths = writer.getPartitionLengths
+    val partitionStart = lengths.take(partitionId).sum
+    val partitionEnd = partitionStart + lengths(partitionId)
+    val keys = new ArrayBuffer[Int]()
+    val input = new RandomAccessFile(outputFile, "r")
+    try {
+      input.seek(partitionStart)
+      while (input.getFilePointer < partitionEnd) {
+        keys += input.readInt()
+        val numColumns = input.readInt()
+        (0 until numColumns).foreach { _ =>
+          val size = input.readInt()
+          input.seek(input.getFilePointer + size)
+        }
+      }
+    } finally {
+      input.close()
+    }
+    keys.toSeq
+  }
+
   /**
    * Verify write results including partition data presence.
    * @param partitionsWithData Set of partition IDs that should have data
@@ -285,6 +344,7 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(numWriterThreads, 0)
     TaskContext.setTaskContext(taskContext)
     MockitoAnnotations.openMocks(this).close()
+    conf.set("spark.shuffle.compress", "true")
     tempDir = Utils.createTempDir()
     outputFile = File.createTempFile("shuffle", null, tempDir)
     taskMetrics = spy(new TaskMetrics)
@@ -498,6 +558,53 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
   // ==================== Merger Pool Tests ====================
 
+  test("writer pool preserves partition order when compression completes out of order") {
+    useUncompressedShuffleOutput()
+    val firstStarted = new CountDownLatch(1)
+    val secondSerialized = new CountDownLatch(1)
+    val releaseFirst = new CountDownLatch(1)
+    when(dependency.serializer).thenReturn(
+      new OutOfOrderTestColumnarBatchSerializer(firstStarted, secondSerialized, releaseFirst))
+    val writer = createWriter()
+    @volatile var writeFailure: Throwable = null
+    val writeThread = new Thread(() => {
+      try {
+        writer.write(createTestRecords(Iterator(0, 7)))
+      } catch {
+        case t: Throwable => writeFailure = t
+      }
+    })
+
+    try {
+      writeThread.start()
+      assert(firstStarted.await(5, TimeUnit.SECONDS), "first compression task did not start")
+      assert(secondSerialized.await(5, TimeUnit.SECONDS),
+        "second compression task did not complete ahead of the first")
+      releaseFirst.countDown()
+      writeThread.join(5000)
+      assert(!writeThread.isAlive, "writer did not finish")
+      if (writeFailure != null) {
+        throw writeFailure
+      }
+      writer.stop(true)
+      assert(readPartitionKeys(writer, 0) === Seq(0, 7))
+    } finally {
+      releaseFirst.countDown()
+      writer.stop(false)
+      if (writeThread.isAlive) {
+        writeThread.join(5000)
+      }
+    }
+  }
+
+  test("writer pool preserves record order across multiple batches") {
+    useUncompressedShuffleOutput()
+    val writer = createWriter()
+    writer.write(createTestRecords(Iterator(0, 6, 7, 14)))
+    writer.stop(true)
+    assert(readPartitionKeys(writer, 0) === Seq(0, 7, 14))
+  }
+
   test("mergers yield while producers are blocked") {
     val producersBlocked = new CountDownLatch(numWriterThreads)
     val releaseProducers = new CountDownLatch(1)
@@ -589,8 +696,8 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
   test("merger resumes after compression future completes") {
     val blockersStarted = new CountDownLatch(numWriterThreads)
     val releaseBlockers = new CountDownLatch(1)
-    val writerBlockers = (0 until numWriterThreads).map { slotNum =>
-      RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, () => {
+    val writerBlockers = (0 until numWriterThreads).map { _ =>
+      RapidsShuffleInternalManagerBase.queueWriteTask(() => {
         blockersStarted.countDown()
         releaseBlockers.await()
         null
@@ -642,8 +749,8 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
   test("merger propagates an exceptional compression future without hanging") {
     val blockersStarted = new CountDownLatch(numWriterThreads)
     val releaseBlockers = new CountDownLatch(1)
-    val writerBlockers = (0 until numWriterThreads).map { slotNum =>
-      RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, () => {
+    val writerBlockers = (0 until numWriterThreads).map { _ =>
+      RapidsShuffleInternalManagerBase.queueWriteTask(() => {
         blockersStarted.countDown()
         releaseBlockers.await()
         null

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -84,6 +84,16 @@ class TestColumnarBatchSerializer extends Serializer with Serializable {
   override def supportsRelocationOfSerializedObjects: Boolean = true
 }
 
+class FailingTestColumnarBatchSerializer extends TestColumnarBatchSerializer {
+  override def newInstance(): SerializerInstance = new TestColumnarBatchSerializerInstance() {
+    override def serializeStream(s: OutputStream): SerializationStream =
+      new TestColumnarBatchSerializationStream(s) {
+        override def writeValue[T: ClassTag](value: T): SerializationStream =
+          throw new IOException("injected serialization failure")
+      }
+  }
+}
+
 class TestColumnarBatchSerializerInstance extends SerializerInstance {
   override def serialize[T: ClassTag](t: T): ByteBuffer = {
     val bos = new ByteArrayOutputStream()
@@ -623,6 +633,52 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       if (!writerStopped) {
         writer.stop(false)
       }
+      if (writeThread.isAlive) {
+        writeThread.join(5000)
+      }
+    }
+  }
+
+  test("merger propagates an exceptional compression future without hanging") {
+    val blockersStarted = new CountDownLatch(numWriterThreads)
+    val releaseBlockers = new CountDownLatch(1)
+    val writerBlockers = (0 until numWriterThreads).map { slotNum =>
+      RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, () => {
+        blockersStarted.countDown()
+        releaseBlockers.await()
+        null
+      })
+    }
+    assert(blockersStarted.await(5, TimeUnit.SECONDS), "writer blockers did not start")
+
+    when(dependency.serializer).thenReturn(new FailingTestColumnarBatchSerializer())
+    val writer = createWriter()
+    @volatile var writeFailure: Throwable = null
+    val writeThread = new Thread(() => {
+      try {
+        writer.write(createTestRecords(Iterator(0)))
+      } catch {
+        case t: Throwable => writeFailure = t
+      }
+    })
+
+    try {
+      writeThread.start()
+      val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+      while (writer.getBytesInFlight == 0 && System.nanoTime() < deadline) {
+        Thread.sleep(10)
+      }
+      assert(writer.getBytesInFlight > 0, "compression future was not queued")
+
+      releaseBlockers.countDown()
+      writeThread.join(5000)
+      assert(!writeThread.isAlive, "exceptional compression future left the merger waiting")
+      assert(writeFailure.isInstanceOf[IOException],
+        s"Expected IOException, got ${Option(writeFailure).map(_.getClass.getName)}")
+    } finally {
+      releaseBlockers.countDown()
+      writerBlockers.foreach(_.get(5, TimeUnit.SECONDS))
+      writer.stop(false)
       if (writeThread.isAlive) {
         writeThread.join(5000)
       }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -46,7 +46,7 @@ package org.apache.spark.sql.rapids
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{CountDownLatch, FutureTask, TimeUnit}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -298,6 +298,24 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     }
     assert(countThreads(prefix) <= expectedMaximum,
       s"Threads with prefix $prefix did not fall to $expectedMaximum or fewer")
+  }
+
+  private def submitWriterTask(body: => Unit): FutureTask[Void] = {
+    val task = new FutureTask[Void](() => {
+      body
+      null
+    })
+    RapidsShuffleInternalManagerBase.queueWriteTask(task)
+    task
+  }
+
+  private def submitMergerTask(body: => Unit): FutureTask[Void] = {
+    val task = new FutureTask[Void](() => {
+      body
+      null
+    })
+    RapidsShuffleInternalManagerBase.executeMergerTask(task)
+    task
   }
 
   /**
@@ -636,11 +654,10 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       val mergerStarted = new CountDownLatch(writerThreads)
       val releaseTasks = new CountDownLatch(1)
       val writerTasks = (0 until writerThreads * 2).map { _ =>
-        RapidsShuffleInternalManagerBase.queueWriteTask(() => {
+        submitWriterTask {
           writerStarted.countDown()
           releaseTasks.await()
-          null
-        })
+        }
       }
       val readerTasks = (0 until readerThreads * 2).map { _ =>
         RapidsShuffleInternalManagerBase.queueReadTask(() => {
@@ -650,11 +667,10 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
         })
       }
       val mergerTasks = (0 until writerThreads * 2).map { _ =>
-        RapidsShuffleInternalManagerBase.queueMergerTask(() => {
+        submitMergerTask {
           mergerStarted.countDown()
           releaseTasks.await()
-          null
-        })
+        }
       }
 
       assert(writerStarted.await(5, TimeUnit.SECONDS), "writer pool did not reach its limit")
@@ -672,9 +688,9 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       waitForThreadCount("rapids-shuffle-merger-", 0)
 
       RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(1, 1)
-      RapidsShuffleInternalManagerBase.queueWriteTask(() => null).get(5, TimeUnit.SECONDS)
+      submitWriterTask(()).get(5, TimeUnit.SECONDS)
       RapidsShuffleInternalManagerBase.queueReadTask(() => null).get(5, TimeUnit.SECONDS)
-      RapidsShuffleInternalManagerBase.queueMergerTask(() => null).get(5, TimeUnit.SECONDS)
+      submitMergerTask(()).get(5, TimeUnit.SECONDS)
       assert(countThreads("rapids-shuffle-writer-") <= 1)
       assert(countThreads("rapids-shuffle-reader-") <= 1)
       assert(countThreads("rapids-shuffle-merger-") <= 1)
@@ -776,11 +792,10 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     val blockersStarted = new CountDownLatch(numWriterThreads)
     val releaseBlockers = new CountDownLatch(1)
     val writerBlockers = (0 until numWriterThreads).map { _ =>
-      RapidsShuffleInternalManagerBase.queueWriteTask(() => {
+      submitWriterTask {
         blockersStarted.countDown()
         releaseBlockers.await()
-        null
-      })
+      }
     }
     assert(blockersStarted.await(5, TimeUnit.SECONDS), "writer blockers did not start")
 
@@ -829,11 +844,10 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     val blockersStarted = new CountDownLatch(numWriterThreads)
     val releaseBlockers = new CountDownLatch(1)
     val writerBlockers = (0 until numWriterThreads).map { _ =>
-      RapidsShuffleInternalManagerBase.queueWriteTask(() => {
+      submitWriterTask {
         blockersStarted.countDown()
         releaseBlockers.await()
-        null
-      })
+      }
     }
     assert(blockersStarted.await(5, TimeUnit.SECONDS), "writer blockers did not start")
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -46,6 +46,7 @@ package org.apache.spark.sql.rapids
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -483,6 +484,38 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     writer.stop(true)
     // batch1: 2,4,6; batch2: 1,3,5; batch3: 0 -> all partitions
     verifyWrite(writer, expectedRecords = 7, partitionsWithData = Set(0, 1, 2, 3, 4, 5, 6))
+  }
+
+  // ==================== Merger Pool Tests ====================
+
+  test("waiting merger tasks do not block unrelated mergers") {
+    val blockersStarted = new CountDownLatch(numWriterThreads)
+    val mergerCanFinish = new CountDownLatch(1)
+    val blockers = (0 until numWriterThreads).map { slotNum =>
+      RapidsShuffleInternalManagerBase.queueMergerTask(slotNum, () => {
+        blockersStarted.countDown()
+        mergerCanFinish.await()
+        null
+      })
+    }
+
+    try {
+      assert(blockersStarted.await(5, TimeUnit.SECONDS), "merger blockers did not start")
+
+      // With fixed merger slots, this task is queued behind the first blocker. The blockers wait
+      // for this task to release them, forming the same cycle as a merger waiting for a producer
+      // whose task cannot start. A dedicated cached merger pool allows this task to run.
+      val unrelatedMerger = RapidsShuffleInternalManagerBase.queueMergerTask(
+        numWriterThreads, () => {
+          mergerCanFinish.countDown()
+          true
+        })
+      assert(unrelatedMerger.get(5, TimeUnit.SECONDS),
+        "unrelated merger was blocked by waiting merger tasks")
+    } finally {
+      mergerCanFinish.countDown()
+      blockers.foreach(_.get(5, TimeUnit.SECONDS))
+    }
   }
 
   // ==================== Cancellation Tests ====================


### PR DESCRIPTION
Addresses a deadlock in the multithreaded shuffle writer.

### Description

The multithreaded shuffle writer assigned each batch merger to one of a fixed number of
single-threaded merger slots. Because a merger can wait for its producer while continuing to
occupy its slot, unrelated merger tasks assigned to that slot may never start.

This change keeps merger concurrency bounded by the configured writer thread count, but replaces
each long-lived blocking merger with a cooperative state machine. A merger step drains all ready
records and yields its executor thread when it reaches an empty queue or an unfinished compression
future. Record enqueue, compression completion, and batch finalization reschedule the merger.

The writer, reader, and merger slot executors are replaced with shared fixed-size pools. Writer
and reader concurrency continue to use their configured thread counts, while merger concurrency
matches the writer pool. The slot maps, counters, affinity parameters, and unused slot-based queue
APIs are removed; FIFO record queues preserve partition record order without executor affinity.
Pool shutdown cancels queued futures returned by `shutdownNow()` so callers cannot wait
indefinitely on tasks that never started.

An atomic scheduled flag prevents concurrent merger steps for the same batch and coalesces repeated
wakeups.

<details>
<summary>Root cause</summary>

Each GPU batch has an independent `BatchState`. Creating the state immediately submits a
long-lived merger task that consumes compressed records and writes partitions in order.

The old implementation assigned each merger to a fixed single-threaded slot:

```text
merger slot = merger sequence number % number of writer threads
```

A merger waits on `mergerCondition` when its current record queue is empty but the producer has
not yet indicated that the partition or batch is complete. Although the waiting merger is not
performing any work, it continues to occupy the only thread in that slot. Any later merger mapped
to the same slot remains queued behind it.

Fetching the next input record may require GPU work. The producer task can therefore block while
acquiring the GPU semaphore. At the same time, another Spark task may have finished producing GPU
data but still hold its GPU semaphore permit until its shuffle write completes. That task waits for
its merger future before returning from the shuffle writer.

This can form the following cycle:

```text
Spark tasks holding GPU semaphore permits
  -> wait for their merger futures
  -> their mergers wait for fixed merger slots
  -> those slots are occupied by mergers waiting for more records
  -> the corresponding producers wait for the GPU semaphore
  -> the semaphore permits are held by the first group of Spark tasks
```

Once all GPU semaphore permits participate in this cycle, no task can make progress:

1. The semaphore holders cannot finish until their queued mergers run.
2. The queued mergers cannot run until an occupied merger slot becomes available.
3. The running mergers do not release their slots because they are waiting for their producers.
4. The producers cannot enqueue more records because they cannot acquire the GPU semaphore.

The deadlock is intermittent because it requires concurrent multi-batch shuffle writes, GPU
semaphore pressure, and a collision between queued mergers and slots occupied by mergers waiting
for producers. The global round-robin slot assignment makes these collisions more likely as an
executor processes more batches.

The existing memory-allocation watchdog cannot break the cycle because none of the blocking edges
is an RMM allocation retry or a registered memory-pool wait. The threads are blocked in
`Future.get`, `Object.wait`, and GPU semaphore acquisition.

The fix removes blocking waits from merger executor threads. A merger retains its partition and
output-stream state, drains all currently ready records, and returns when it needs more producer or
compression work. Its completion future remains incomplete across yields and is completed only
after every partition has been written.

The merger executor is a fixed-size pool with the same thread count as the previous implementation.
Because waiting batches no longer occupy those threads, an unrelated merger can run, allow its
Spark task to release the GPU semaphore, and break the cycle without creating unbounded threads.

Scheduling uses an atomic compare-and-set guard. After a step clears that guard, it rechecks for
ready work to avoid a lost wakeup during the transition. Compression uses a `FutureTask.done()`
callback so the merger is rescheduled only after `Future.isDone` becomes true.

</details>

<details>
<summary>Test case: why the old implementation hangs and the new implementation passes</summary>

`mergers yield while producers are blocked` reproduces the fixed-slot starvation with real shuffle
writers rather than directly blocking executor APIs.

The test starts one writer per merger thread. Each writer produces one record and then blocks its
input iterator before finalizing the batch. The test waits until every first record has been written,
which establishes the following state in the old implementation:

```text
all merger slots contain running merger tasks
  -> each merger has drained its first record
  -> each merger waits for its blocked producer to provide more records
  -> no merger slot is available
```

The test then starts an unrelated writer and gives it five seconds to complete.

With the old implementation, the unrelated writer's merger is queued behind one of the waiting
mergers. Its writer thread remains alive after the timeout, so the test fails with:

```text
unrelatedThread.isAlive() was true
unrelated merger was blocked by waiting producers
```

With the new implementation, each initial merger drains its first record and yields. The bounded
pool therefore has capacity to run the unrelated merger, and the unrelated writer completes before
the timeout. The test also counts `rapids-shuffle-merger-*` threads and verifies that the count does
not exceed the configured writer thread count.

`merger resumes after compression future completes` covers the completion wakeup race. It occupies
all writer slots so a compression future remains incomplete, starts a shuffle writer, and confirms
that the merger yields. Releasing the writer slots completes the compression future. The
`FutureTask.done()` callback must then reschedule the merger and allow the writer to finish.

Two additional deterministic tests cover the review findings. `writer preserves record order when
batch mergers complete out of order` blocks the first batch merger, forces the second batch merger
to complete first, and verifies partition record order. `shuffle pool shutdown cancels queued
tasks` saturates the writer, reader, and merger pools, then verifies that shutdown cancels every
queued future.

Old implementation result:

```text
mergers yield while producers are blocked *** FAILED ***
unrelatedThread.isAlive() was true unrelated merger was blocked by waiting producers
```

Fixed implementation result:

```text
mergers yield while producers are blocked
merger resumes after compression future completes
All tests passed.
```

</details>

Testing:

- Scala 2.12 / Spark 3.3:

  ```bash
  mvn package -pl tests -am \
    -Dbuildver=330 \
    -DwildcardSuites=org.apache.spark.sql.rapids.RapidsShuffleThreadedWriterSuite
  ```

  All 20 ScalaTest executions passed.

- Scala 2.13 / Spark 3.5:

  ```bash
  mvn package -f scala2.13/ -pl tests -am \
    -Dbuildver=350 \
    -DwildcardSuites=org.apache.spark.sql.rapids.RapidsShuffleThreadedWriterSuite
  ```

  All 20 ScalaTest executions passed.

- The same regression test against the old implementation consistently failed because the
  unrelated writer remained blocked after five seconds, as expected.

### Perf test

NDS on a 10-worker cluster:

|skipMerge| Version    | Run 1 | Run 2 | Run 3 | Average   |
|---------------|------------|-------|-------|-------|-----------|
|false| Baseline   | 180 s | 176 s | 174 s | 176.67 s  |
|false| Fix        | 172 s | 171 s | 174 s | 172.33 s  |
|true |Baseline |172 s |174 s |173 s |173.00 s |
|true |Fix |178 s |170 s |172 s |173.33 s |

For skipMerge=false, fix was approximately 2.51% faster overall. AB reported a 1.03x speedup.
For skipMerge=true, fix was approximately 0.19% slower than baseline. AB reported 1.00x overall, this matches the expected code path: skipMerge=true bypasses the merger path modified by the PR.

Integrity checks:

  - 6/6 applications completed successfully
  - 0 failed jobs
  - 0 failed stages
  - 0 non-successful tasks
  - 0 executor removals
  - No ERROR entries in the driver log
  - All six eventlogs passed SHA-256 verification

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required

