### PR TITLE
[AutoSparkUT] Fix ORC reads with missing nested fields [databricks]

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -615,6 +615,42 @@ def test_read_nested_pruning(spark_tmp_path, data_gen, read_schema, reader_confs
             conf=all_confs)
 
 
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_read_orc_with_all_nested_fields_missing(
+        spark_tmp_path, reader_confs, v1_enabled_list):
+    data_path = spark_tmp_path + '/ORC_DATA'
+    with_cpu_session(
+        lambda spark: spark.sql("""
+            SELECT named_struct('first', 'Janet', 'last', 'Jones') AS name
+            UNION ALL SELECT cast(null AS struct<first:string,last:string>)
+            """).write.orc(data_path))
+    read_schema = StructType([StructField('name', StructType([
+        StructField('middle', StringType())]))])
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(read_schema).orc(data_path), conf=all_confs)
+
+    array_data_path = spark_tmp_path + '/ORC_ARRAY_DATA'
+    with_cpu_session(
+        lambda spark: spark.sql("""
+            SELECT named_struct('history', array(1, 2)) AS name
+            UNION ALL SELECT cast(null AS struct<history:array<int>>)
+            """).write.orc(array_data_path))
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(read_schema).orc(array_data_path), conf=all_confs)
+
+    map_data_path = spark_tmp_path + '/ORC_MAP_DATA'
+    with_cpu_session(
+        lambda spark: spark.sql("""
+            SELECT named_struct('attrs', map('a', 1)) AS name
+            UNION ALL SELECT cast(null AS struct<attrs:map<string,int>>)
+            """).write.orc(map_data_path))
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(read_schema).orc(map_data_path), conf=all_confs)
+
+
 # This is for the corner case of reading only a struct column that has no nulls.
 # Then there will be no streams in a stripe connecting to this column (Its ROW_INDEX
 # streams have been pruned by the Plugin.), and CUDF throws an exception for such case.

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -650,6 +650,30 @@ def test_read_orc_with_all_nested_fields_missing(
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.schema(read_schema).orc(map_data_path), conf=all_confs)
 
+    array_struct_data_path = spark_tmp_path + '/ORC_ARRAY_STRUCT_DATA'
+    with_cpu_session(
+        lambda spark: spark.sql("""
+            SELECT array(named_struct('first', 'Janet')) AS names
+            UNION ALL SELECT cast(null AS array<struct<first:string>>)
+            """).write.orc(array_struct_data_path))
+    array_struct_read_schema = StructType([StructField('names', ArrayType(StructType([
+        StructField('middle', StringType())])))])
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(array_struct_read_schema).orc(array_struct_data_path),
+        conf=all_confs)
+
+    map_struct_data_path = spark_tmp_path + '/ORC_MAP_STRUCT_DATA'
+    with_cpu_session(
+        lambda spark: spark.sql("""
+            SELECT map('primary', named_struct('first', 'Janet')) AS names
+            UNION ALL SELECT cast(null AS map<string,struct<first:string>>)
+            """).write.orc(map_struct_data_path))
+    map_struct_read_schema = StructType([StructField('names', MapType(
+        StringType(), StructType([StructField('middle', StringType())])))])
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(map_struct_read_schema).orc(map_struct_data_path),
+        conf=all_confs)
+
 
 # This is for the corner case of reading only a struct column that has no nulls.
 # Then there will be no streams in a stripe connecting to this column (Its ROW_INDEX

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1664,7 +1664,7 @@ private case class GpuOrcFileFilterHandler(
       }
 
       (checkTypeCompatibility(fileSchema, readSchema, isCaseAware, fileIncluded, isForcePos,
-        isOrcFloatTypesToStringEnable),
+        isOrcFloatTypesToStringEnable, isRoot = true),
         fileIncluded)
     }
 
@@ -1679,7 +1679,8 @@ private case class GpuOrcFileFilterHandler(
         isCaseAware: Boolean,
         fileIncluded: Array[Boolean],
         isForcePos: Boolean,
-        isOrcFloatTypesToStringEnable: Boolean): TypeDescription = {
+        isOrcFloatTypesToStringEnable: Boolean,
+        isRoot: Boolean): TypeDescription = {
       (fileType.getCategory, readType.getCategory) match {
         case (TypeDescription.Category.STRUCT, TypeDescription.Category.STRUCT) =>
           // Check for the top or nested struct types.
@@ -1708,12 +1709,17 @@ private case class GpuOrcFileFilterHandler(
             .zipWithIndex.foreach { case ((fileFieldName, fType), idx) =>
             getReadFieldType(fileFieldName, idx).foreach { case (rField, rType) =>
               val newChild = checkTypeCompatibility(fType, rType,
-                isCaseAware, fileIncluded, isForcePos, isOrcFloatTypesToStringEnable)
+                isCaseAware, fileIncluded, isForcePos, isOrcFloatTypesToStringEnable,
+                isRoot = false)
               prunedReadSchema.addField(rField, newChild)
             }
           }
           fileIncluded(fileType.getId) = true
-          if (prunedReadSchema.getChildren.isEmpty && !fileType.getChildren.isEmpty) {
+          // The ORC root struct is only a schema container, so retaining one of its children
+          // would turn a zero-column scan into a one-column scan. Nested structs need a child
+          // retained to carry their parent validity through schema evolution.
+          if (!isRoot && prunedReadSchema.getChildren.isEmpty &&
+              !fileType.getChildren.isEmpty) {
             retainCheapestColumn(fileType, fileIncluded)
           } else {
             prunedReadSchema
@@ -1723,16 +1729,16 @@ private case class GpuOrcFileFilterHandler(
         case (TypeDescription.Category.LIST, TypeDescription.Category.LIST) =>
           val newChild = checkTypeCompatibility(fileType.getChildren.get(0),
             readType.getChildren.get(0), isCaseAware, fileIncluded, isForcePos,
-            isOrcFloatTypesToStringEnable)
+            isOrcFloatTypesToStringEnable, isRoot = false)
           fileIncluded(fileType.getId) = true
           TypeDescription.createList(newChild)
         case (TypeDescription.Category.MAP, TypeDescription.Category.MAP) =>
           val newKey = checkTypeCompatibility(fileType.getChildren.get(0),
             readType.getChildren.get(0), isCaseAware, fileIncluded, isForcePos,
-            isOrcFloatTypesToStringEnable)
+            isOrcFloatTypesToStringEnable, isRoot = false)
           val newValue = checkTypeCompatibility(fileType.getChildren.get(1),
             readType.getChildren.get(1), isCaseAware, fileIncluded, isForcePos,
-            isOrcFloatTypesToStringEnable)
+            isOrcFloatTypesToStringEnable, isRoot = false)
           fileIncluded(fileType.getId) = true
           TypeDescription.createMap(newKey, newValue)
         case (ft, rt) if ft.isPrimitive && rt.isPrimitive =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1796,9 +1796,13 @@ private case class GpuOrcFileFilterHandler(
         t.getCategory match {
           case TypeDescription.Category.STRUCT =>
             val children = t.getChildren.asScala
-            val selectedIndex = children.indices.minBy(i => estimate(children(i)))
-            TypeDescription.createStruct().addField(
-              t.getFieldNames.get(selectedIndex), retain(children(selectedIndex)))
+            if (children.isEmpty) {
+              t.clone()
+            } else {
+              val selectedIndex = children.indices.minBy(i => estimate(children(i)))
+              TypeDescription.createStruct().addField(
+                t.getFieldNames.get(selectedIndex), retain(children(selectedIndex)))
+            }
           case TypeDescription.Category.LIST =>
             TypeDescription.createList(retain(t.getChildren.get(0)))
           case TypeDescription.Category.MAP =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1713,7 +1713,11 @@ private case class GpuOrcFileFilterHandler(
             }
           }
           fileIncluded(fileType.getId) = true
-          prunedReadSchema
+          if (prunedReadSchema.getChildren.isEmpty && !fileType.getChildren.isEmpty) {
+            retainCheapestColumn(fileType, fileIncluded)
+          } else {
+            prunedReadSchema
+          }
         // Go into children for LIST, MAP to filter out the missing names
         // for struct children.
         case (TypeDescription.Category.LIST, TypeDescription.Category.LIST) =>
@@ -1747,6 +1751,68 @@ private case class GpuOrcFileFilterHandler(
           throw new QueryExecutionException("Unsupported type pair of " +
             s"(file type, read type)=($f, $r)")
       }
+    }
+
+    /**
+     * Retain the cheapest physical path when every requested child of a struct is missing.
+     * The retained path carries the parent struct validity into schema evolution, where the
+     * requested children are added as null columns.
+     */
+    private def retainCheapestColumn(
+        fileType: TypeDescription,
+        fileIncluded: Array[Boolean]): TypeDescription = {
+      def primitiveCost(t: TypeDescription): Int = t.getCategory match {
+        case TypeDescription.Category.BOOLEAN => 1
+        case TypeDescription.Category.BYTE | TypeDescription.Category.SHORT |
+             TypeDescription.Category.INT | TypeDescription.Category.FLOAT |
+             TypeDescription.Category.DATE => 4
+        case TypeDescription.Category.LONG | TypeDescription.Category.DOUBLE |
+             TypeDescription.Category.TIMESTAMP => 8
+        case TypeDescription.Category.DECIMAL => 16
+        case _ => 32
+      }
+
+      def estimate(t: TypeDescription, repetitionLevel: Int = 0): (Int, Int) = {
+        t.getCategory match {
+          case TypeDescription.Category.STRUCT =>
+            val children = t.getChildren.asScala
+            if (children.isEmpty) {
+              (Int.MaxValue, Int.MaxValue)
+            } else {
+              children.map(estimate(_, repetitionLevel)).min
+            }
+          case TypeDescription.Category.LIST =>
+            estimate(t.getChildren.get(0), repetitionLevel + 1)
+          case TypeDescription.Category.MAP =>
+            val key = estimate(t.getChildren.get(0), repetitionLevel + 1)
+            val value = estimate(t.getChildren.get(1), repetitionLevel + 1)
+            (key._1.max(value._1), key._2 + value._2)
+          case _ => (repetitionLevel, primitiveCost(t))
+        }
+      }
+
+      def retain(t: TypeDescription): TypeDescription = {
+        fileIncluded(t.getId) = true
+        t.getCategory match {
+          case TypeDescription.Category.STRUCT =>
+            val children = t.getChildren.asScala
+            val selectedIndex = children.indices.minBy(i => estimate(children(i)))
+            TypeDescription.createStruct().addField(
+              t.getFieldNames.get(selectedIndex), retain(children(selectedIndex)))
+          case TypeDescription.Category.LIST =>
+            TypeDescription.createList(retain(t.getChildren.get(0)))
+          case TypeDescription.Category.MAP =>
+            TypeDescription.createMap(
+              retain(t.getChildren.get(0)), retain(t.getChildren.get(1)))
+          case _ =>
+            // Primitive types contain only their own ID. For an unsupported complex type such
+            // as UNION, retain the full subtree so the cloned schema and include mask agree.
+            (t.getId to t.getMaximumId).foreach(i => fileIncluded(i) = true)
+            t.clone()
+        }
+      }
+
+      retain(fileType)
     }
 
     /**

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -43,6 +43,10 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
   testSparkResultsAreEqual("Test ORC count chunked by bytes", fileSplitsOrc,
     new SparkConf().set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "100"))(frameCount)
 
+  testSparkResultsAreEqual("schema evolution with all top-level fields missing",
+    frameFromOrcWithSchema("schema-can-prune.orc", StructType(Seq(
+      StructField("missing", StringType))))) { frame => frame }
+
   testSparkResultsAreEqual("schema-can-prune dis-order read schema",
     frameFromOrcWithSchema("schema-can-prune.orc", StructType(Seq(
       StructField("c2_string", StringType),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -16,9 +16,12 @@
 
 package com.nvidia.spark.rapids
 
-import java.io.FileNotFoundException
+import java.io.{File, FileNotFoundException}
+import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.ql.exec.vector.{BytesColumnVector, StructColumnVector}
+import org.apache.orc.{OrcFile, TypeDescription}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.FileSourceScanExec
@@ -46,6 +49,33 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
   testSparkResultsAreEqual("schema evolution with all top-level fields missing",
     frameFromOrcWithSchema("schema-can-prune.orc", StructType(Seq(
       StructField("missing", StringType))))) { frame => frame }
+
+  private def writeNestedEmptyStructOrc(spark: SparkSession, base: File): Unit = {
+    assert(base.mkdirs())
+    val schema = TypeDescription.createStruct().addField("name",
+      TypeDescription.createStruct()
+        .addField("empty", TypeDescription.createStruct())
+        .addField("first", TypeDescription.createString()))
+    val writer = OrcFile.createWriter(new Path(base.getCanonicalPath, "part-00000.orc"),
+      OrcFile.writerOptions(spark.sparkContext.hadoopConfiguration).setSchema(schema))
+    try {
+      val batch = schema.createRowBatch()
+      batch.size = 2
+      val nameVector = batch.cols(0).asInstanceOf[StructColumnVector]
+      nameVector.noNulls = false
+      nameVector.isNull(1) = true
+      nameVector.fields(1).asInstanceOf[BytesColumnVector].setVal(0, "Janet".getBytes(UTF_8))
+      writer.addRowBatch(batch)
+    } finally {
+      writer.close()
+    }
+  }
+
+  testSparkReadResultsAreEqual("schema evolution through an empty physical struct",
+    file => spark => spark.read.schema(StructType(Seq(
+      StructField("name", StructType(Seq(StructField("missing", StringType)))))))
+      .orc(file.getCanonicalPath),
+    writeNestedEmptyStructOrc) { frame => frame }
 
   testSparkResultsAreEqual("schema-can-prune dis-order read schema",
     frameFromOrcWithSchema("schema-can-prune.orc", StructType(Seq(


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +36 lines** (`GpuOrcScan.scala`; fix-line intersection, shim 330)

Closes #15179

## Problem

When every requested child of an ORC struct is absent from the physical file schema, nested pruning produced a zero-child struct. The GPU ORC reader then failed instead of returning the same nullable result as Spark CPU:

- V1 GPU: `ai.rapids.cudf.CudfException: std::bad_alloc`
- V2 GPU: `ai.rapids.cudf.CudfException: vector::_M_default_append`
- CPU: `WrappedArray([null], [null])`

## Fix

Retain the cheapest physical path under the struct when all requested children are missing. This preserves the parent validity stream so schema evolution can add the requested fields as null columns. Struct, list, and map paths keep their required ORC children and the include mask remains aligned with the physical schema.

The new Python integration coverage exercises V1 and V2 across all ORC reader configurations with primitive, array, and map physical children, including both non-null and null parent structs.

## Validation

- `mvn package -DskipTests -pl dist -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm`
  - `BUILD SUCCESS`
- `SPARK_HOME=/home/allxu/Downloads/spark-3.3.0-bin-hadoop3 TEST_PARALLEL=1 integration_tests/run_pyspark_from_build.sh -k 'test_read_orc_with_all_nested_fields_missing'`
  - `30 passed, 39164 deselected, 17 warnings in 29.50s`
- Full 32-config spark-shell reproduction after the fix:
  - V1 GPU and CPU: `WrappedArray([null], [null])`, match true
  - V2 GPU and CPU: `WrappedArray([null], [null])`, match true
- `scripts/check-shim-coverage.sh`: passed

## Performance impact

The schema traversal runs only when all requested children of a struct are absent, outside the row-processing hot path. It selects the shallowest and narrowest valid physical path to limit additional I/O. Normal matched-schema reads are unchanged.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
