### PR TITLE
Fix DBR 17.3 build after SessionCatalog partition API change [databricks]

### DIFF
--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -352,7 +352,7 @@ def test_hive_text_round_trip_partitioned_case_insensitive(spark_tmp_path, data_
                     reason="Hive text reads are disabled on CDH, as per "
                            "https://github.com/NVIDIA/spark-rapids/pull/7628")
 @ignore_order(local=True)
-@allow_non_gpu("EqualTo", "IsNotNull", *non_utc_allow_for_test_basic_hive_text_read)
+@allow_non_gpu("EqualTo,IsNotNull,Literal", *non_utc_allow_for_test_basic_hive_text_read)
 def test_hive_text_partition_listing_shim_paths(spark_tmp_path, spark_tmp_table_factory):
     gen = StructGen([('my_field', int_gen)], nullable=False)
     data_path = spark_tmp_path + '/hive_text_table'

--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -346,6 +346,45 @@ def test_hive_text_round_trip_partitioned_case_insensitive(spark_tmp_path, data_
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: read_hive_text_table_partitions(spark, table_name, "DT='1'"),
         conf=hive_text_enabled_conf)
+
+
+@pytest.mark.skipif(is_spark_cdh(),
+                    reason="Hive text reads are disabled on CDH, as per "
+                           "https://github.com/NVIDIA/spark-rapids/pull/7628")
+@ignore_order(local=True)
+@allow_non_gpu("EqualTo", "IsNotNull", *non_utc_allow_for_test_basic_hive_text_read)
+def test_hive_text_partition_listing_shim_paths(spark_tmp_path, spark_tmp_table_factory):
+    gen = StructGen([('my_field', int_gen)], nullable=False)
+    data_path = spark_tmp_path + '/hive_text_table'
+    table_name = spark_tmp_table_factory.get()
+
+    with_cpu_session(lambda spark: create_hive_text_table_partitioned(
+        spark, gen, table_name, data_path))
+
+    def read_partitioned_table(spark):
+        def assert_gpu_hive_scan(df, description):
+            is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
+            if is_gpu:
+                plan = df._jdf.queryExecution().executedPlan()
+                explain_str = str(plan)
+                callback = spark._sc._jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+                assert callback.contains(plan, "GpuHiveTableScanExec"), \
+                    "%s did not use GpuHiveTableScanExec:\n%s" % (description, explain_str)
+
+        # The unfiltered query exercises SparkShimImpl.listPartitions.
+        unfiltered = spark.sql(
+            "SELECT 'unfiltered' AS query_name, my_field FROM %s" % table_name)
+        assert_gpu_hive_scan(unfiltered, "Unfiltered partitioned Hive text read")
+
+        # The filtered query exercises SparkShimImpl.listPartitionsByFilter.
+        filtered = spark.sql(
+            "SELECT 'filtered' AS query_name, my_field FROM %s WHERE dt = '1'" % table_name)
+        assert_gpu_hive_scan(filtered, "Filtered partitioned Hive text read")
+        return unfiltered.unionByName(filtered)
+
+    conf = copy_and_update(hive_text_enabled_conf,
+                           {"spark.sql.hive.metastorePartitionPruning": "true"})
+    assert_gpu_and_cpu_are_equal_collect(read_partitioned_table, conf=conf)
 
 @pytest.mark.skipif(is_spark_cdh(),
                     reason="Hive text reads are disabled on CDH, as per "

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -22,6 +22,8 @@ import org.apache.parquet.schema.MessageType
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SparkSession => SqlSparkSession}
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.trees.TreeNode
@@ -87,6 +89,18 @@ trait SparkShims {
    * in favor of filesWithAbsolutePaths or innerFiles.
    */
   def getPartitionFiles(partition: FilePartition): Seq[PartitionedFile]
+
+  def listPartitionsByFilter(
+      sparkSession: SqlSparkSession,
+      tableName: TableIdentifier,
+      predicates: Seq[Expression],
+      resolvedCatalogTable: Option[CatalogTable]): Seq[CatalogTablePartition]
+
+  def listPartitions(
+      sparkSession: SqlSparkSession,
+      tableName: TableIdentifier,
+      partialSpec: Option[TablePartitionSpec],
+      resolvedCatalogTable: Option[CatalogTable]): Seq[CatalogTablePartition]
 
   def shouldFailDivOverflow: Boolean
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,10 +158,17 @@ case class GpuHiveTableScanExec(requestedAttributes: Seq[Attribute],
         val normalizedFilters = partitionPruningPredicate.map(_.transform {
           case a: AttributeReference => originalAttributes(a)
         })
-        sparkSession.sessionState.catalog
-          .listPartitionsByFilter(hiveTableRelation.tableMeta.identifier, normalizedFilters)
+        SparkShimImpl.listPartitionsByFilter(
+          sparkSession,
+          hiveTableRelation.tableMeta.identifier,
+          normalizedFilters,
+          Some(hiveTableRelation.tableMeta))
       } else {
-        sparkSession.sessionState.catalog.listPartitions(hiveTableRelation.tableMeta.identifier)
+        SparkShimImpl.listPartitions(
+          sparkSession,
+          hiveTableRelation.tableMeta.identifier,
+          None,
+          Some(hiveTableRelation.tableMeta))
       }
     prunedPartitions.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInsertIntoHadoopFsRelationCommand.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInsertIntoHadoopFsRelationCommand.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids
 import java.io.IOException
 
 import com.nvidia.spark.rapids.{ColumnarFileFormat, GpuDataWritingCommand, RapidsConf}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -104,8 +105,11 @@ case class GpuInsertIntoHadoopFsRelationCommand(
     // When partitions are tracked by the catalog, compute all custom partition locations that
     // may be relevant to the insertion job.
     if (partitionsTrackedByCatalog) {
-      matchingPartitions = sparkSession.sessionState.catalog.listPartitions(
-        catalogTable.get.identifier, Some(staticPartitions))
+      matchingPartitions = SparkShimImpl.listPartitions(
+        sparkSession,
+        catalogTable.get.identifier,
+        Some(staticPartitions),
+        catalogTable)
       initialMatchingPartitions = matchingPartitions.map(_.spec)
       customPartitionLocations = getCustomPartitionLocations(
         fs, catalogTable.get, qualifiedOutputPath, matchingPartitions)

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark320PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark320PlusNonDBShims.scala
@@ -40,7 +40,7 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{BucketJoinTwoSidesPrefetch, FoldLocalAggregate, RapidsConf, SparkShims}
+import com.nvidia.spark.rapids.{BucketJoinTwoSidesPrefetch, FoldLocalAggregate, RapidsConf}
 import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -53,7 +53,7 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 /**
  * Shim methods that can be compiled with every supported 3.2.0+ except Databricks versions
  */
-trait Spark320PlusNonDBShims extends SparkShims with WindowInPandasShims {
+trait Spark320PlusNonDBShims extends SparkCatalogPartitionShims with WindowInPandasShims {
 
   override final def broadcastModeTransform(mode: BroadcastMode, rows: Array[InternalRow]): Any =
     mode.transform(rows)

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/SparkCatalogPartitionShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/SparkCatalogPartitionShims.scala
@@ -13,45 +13,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /*** spark-rapids-shim-json-lines
-{"spark": "400db173"}
+{"spark": "330"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "411"}
+{"spark": "412"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.SparkShims
 
 import org.apache.spark.sql.{SparkSession => SqlSparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.expressions.objects.Invoke
-import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
-import org.apache.spark.sql.rapids.shims.InvokeExprMeta
 
-trait Spark400PlusDBShims extends Spark341PlusDBShims {
-  override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
-    val shimExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
-      GpuOverrides.expr[Invoke](
-        "Calls the specified function on an object. This is a wrapper to other expressions, so " +
-          "can not know the details in advance. E.g.: between is replaced by " +
-          "And(GreaterThanOrEqual(ref, lower), LessThanOrEqual(ref, upper);  StructToJson is " +
-          "replaced by Invoke(Literal(StructsToJsonEvaluator), evaluate, string_type, arguments)",
-        InvokeCheck,
-        InvokeExprMeta)
-        .note("The supported types are not deterministic since it's a dynamic expression")
-    ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
-    super.getExprs ++ shimExprs
-  }
-
+trait SparkCatalogPartitionShims extends SparkShims {
   override def listPartitionsByFilter(
       sparkSession: SqlSparkSession,
       tableName: TableIdentifier,
       predicates: Seq[Expression],
       resolvedCatalogTable: Option[CatalogTable]): Seq[CatalogTablePartition] = {
-    sparkSession.sessionState.catalog.listPartitionsByFilter(
-      tableName, predicates, resolvedCatalogTable)
+    // DBR 17.3 needs this shared shim parameter; legacy SessionCatalog APIs do not.
+    val _ = resolvedCatalogTable
+    sparkSession.sessionState.catalog.listPartitionsByFilter(tableName, predicates)
   }
 
   override def listPartitions(
@@ -59,11 +70,8 @@ trait Spark400PlusDBShims extends Spark341PlusDBShims {
       tableName: TableIdentifier,
       partialSpec: Option[TablePartitionSpec],
       resolvedCatalogTable: Option[CatalogTable]): Seq[CatalogTablePartition] = {
-    sparkSession.sessionState.catalog.listPartitions(
-      tableName, partialSpec, resolvedCatalogTable = resolvedCatalogTable)
-  }
-
-  override def getPartitionFiles(partition: FilePartition): Seq[PartitionedFile] = {
-    partition.filesWithAbsolutePaths.toSeq
+    // DBR 17.3 needs this shared shim parameter; legacy SessionCatalog APIs do not.
+    val _ = resolvedCatalogTable
+    sparkSession.sessionState.catalog.listPartitions(tableName, partialSpec)
   }
 }

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import com.nvidia.spark.rapids._
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}
 
-object SparkShimImpl extends Spark330PlusDBShims {
+object SparkShimImpl extends Spark330PlusDBShims with SparkCatalogPartitionShims {
   // AnsiCast is removed from Spark3.4.0
   override def ansiCastRule: ExprRule[_ <: Expression] = null
 

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.datasources.V1WritesUtils.Empty2Null
 import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
 
-object SparkShimImpl extends Spark332PlusDBShims {
+object SparkShimImpl extends Spark332PlusDBShims with SparkCatalogPartitionShims {
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     val shimExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
       // Empty2Null is pulled out of FileFormatWriter by default since Spark 3.4.0,

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -19,4 +19,4 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-object SparkShimImpl extends Spark341PlusDBShims
+object SparkShimImpl extends Spark341PlusDBShims with SparkCatalogPartitionShims

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -19,4 +19,4 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-object SparkShimImpl extends Spark350db143Shims
+object SparkShimImpl extends Spark350db143Shims with SparkCatalogPartitionShims


### PR DESCRIPTION


### Description

This is backport from main branch - https://github.com/NVIDIA/cudf-spark/pull/15185   to release/26.06 branch since it breaks DBR-17.3 build.  DBR 17.3 recently changed the `SessionCatalog` partition-listing APIs to require an additional `resolvedCatalogTable: Option[CatalogTable]` parameter:

- `listPartitionsByFilter`
- `listPartitions`

This broke the DBR 17.3 build because shared plugin code was calling the older signatures directly.

This PR routes those calls through `SparkShimImpl` and handles the API difference at the shim layer without reflection. DBR 17.3 calls the new catalog signatures directly, while non-DB and pre-17.3 DB runtimes share a legacy catalog-partition shim that calls the older signatures.

### Changes

- Added abstract shim wrappers for `listPartitionsByFilter` and `listPartitions`.
- Added `SparkCatalogPartitionShims` for non-DB and pre-DBR-17.3 runtimes using the older catalog API.
- Added DBR 17.3 overrides that call the new `resolvedCatalogTable` signatures directly.
- Updated `GpuHiveTableScanExec` and `GpuInsertIntoHadoopFsRelationCommand` to use the shim wrappers.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
