### PR TITLE
Allow collate bridge fallback in Spark 4.x tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/string_type_test.py
+++ b/integration_tests/src/main/python/string_type_test.py
@@ -34,7 +34,7 @@ _non_utf8_binary_collations = ["UNICODE", "UTF8_LCASE", "UNICODE_CI"]
 
 # test Collate, currently does not have GPU version for Collate
 @pytest.mark.skipif(is_before_spark_400(), reason="Spark versions before 400 do not support collate")
-@allow_non_gpu("ProjectExec")
+@allow_non_gpu("ProjectExec", "Collate", "ResolvedCollation")
 def test_collate_expr_fallback():
     data_gen = [("c1", string_gen)]
     assert_gpu_fallback_collect(


### PR DESCRIPTION
Fixes #15205.

### Description

- Allow the existing collate fallback test to accept `Collate` and `ResolvedCollation` inside `GpuCpuBridge`, because Spark 4.1.x can keep `ProjectExec` on GPU while bridging the unsupported collate expression to CPU.
- Validated with `SPARK_HOME=/work/tools/spark-4.0.3-bin-hadoop3 TZ=UTC SPARK_RAPIDS_TEST_INJECT_OOM=0 bash integration_tests/run_pyspark_from_build.sh /bigdata/work/projects/on_github/cudf-spark/integration_tests/src/main/python/string_type_test.py -k test_collate_expr_fallback`.
- Validated with `SPARK_HOME=/work/tools/spark-4.1.1-bin-hadoop3 TZ=UTC SPARK_RAPIDS_TEST_INJECT_OOM=0 PYSP_TEST_spark_rapids_sql_explain=ALL PLUGIN_JAR=<local Spark 4.1.1 module jars> bash integration_tests/run_pyspark_from_build.sh /bigdata/work/projects/on_github/cudf-spark/integration_tests/src/main/python/string_type_test.py -k test_collate_expr_fallback`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required