### PR TITLE
Fix test_bloom_filter_join_cpu_probe failures on Dataproc

### DIFF
--- a/integration_tests/src/main/python/cpu_bridge_test.py
+++ b/integration_tests/src/main/python/cpu_bridge_test.py
@@ -17,9 +17,9 @@ import pytest
 from pyspark.sql.functions import col
 import pyspark.sql.functions as f
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_fallback_collect, assert_cpu_and_gpu_are_equal_sql_with_capture
-from marks import allow_non_gpu
+from conftest import is_dataproc_runtime, is_dataproc_serverless_runtime
 from data_gen import *
-from marks import ignore_order
+from marks import allow_non_gpu, ignore_order
 from spark_session import is_databricks_runtime, is_spark_341_or_later, with_cpu_session
 
 
@@ -196,6 +196,13 @@ bloom_filter_confs = {
     "spark.sql.optimizer.runtime.bloomFilter.enabled": True
 }
 
+# Dataproc uses Cast instead of XxHash64 for runtime bloom filter probe keys.
+dataproc_bloom_filter_probe_allow = (
+    ("Cast",)
+    if is_dataproc_runtime() or is_dataproc_serverless_runtime()
+    else ()
+)
+
 def check_bloom_filter_join(confs, is_multi_column):
     def do_join(spark):
         if is_multi_column:
@@ -211,8 +218,10 @@ def check_bloom_filter_join(confs, is_multi_column):
     all_confs = copy_and_update(bloom_filter_confs, partial_conf)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=all_confs)
 
-@allow_non_gpu("ShuffleExchangeExec", "BloomFilterMightContain", "ScalarSubquery", 
-"XxHash64", "GetStructField", "Remainder", "And")
+@allow_non_gpu(
+    "ShuffleExchangeExec", "BloomFilterMightContain", "ScalarSubquery",
+    "XxHash64", "GetStructField", "Remainder", "And",
+    *dataproc_bloom_filter_probe_allow)
 @ignore_order(local=True)
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=["SINGLE_COLUMN", "MULTI_COLUMN"])
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -19,9 +19,10 @@ from pyspark.sql.types import *
 from asserts import (assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal,
                      assert_gpu_fallback_collect, assert_cpu_and_gpu_are_equal_collect_with_capture,
                      assert_cpu_and_gpu_are_equal_sql_with_capture, assert_gpu_and_cpu_are_equal_sql)
-from conftest import is_emr_runtime
+from conftest import is_dataproc_runtime, is_dataproc_serverless_runtime, is_emr_runtime
 from data_gen import *
-from marks import ignore_order, allow_non_gpu, incompat, validate_execs_in_gpu_plan, disable_ansi_mode
+from marks import (allow_non_gpu, disable_ansi_mode, ignore_order, incompat,
+                   validate_execs_in_gpu_plan)
 from spark_session import with_cpu_session, is_databricks_runtime, is_spark_400_or_later, is_spark_411_or_later
 from src.main.python.spark_session import with_gpu_session
 
@@ -1355,6 +1356,13 @@ bloom_filter_confs = {
     "spark.sql.optimizer.runtime.bloomFilter.enabled": "true"
 }
 
+# Dataproc uses Cast instead of XxHash64 for runtime bloom filter probe keys.
+dataproc_bloom_filter_probe_allow = (
+    ("Cast",)
+    if is_dataproc_runtime() or is_dataproc_serverless_runtime()
+    else ()
+)
+
 def check_bloom_filter_join(confs, expected_classes, is_multi_column):
     def do_join(spark):
         if is_multi_column:
@@ -1378,8 +1386,10 @@ def test_bloom_filter_join(batch_size, is_multi_column):
                             expected_classes="GpuBloomFilterMightContain,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)
 
-@allow_non_gpu("ShuffleExchangeExec", "And", "BloomFilterMightContain", "GetStructField", 
-  "ScalarSubquery", "XxHash64", "Remainder")
+@allow_non_gpu(
+    "ShuffleExchangeExec", "And", "BloomFilterMightContain", "GetStructField",
+    "ScalarSubquery", "XxHash64", "Remainder",
+    *dataproc_bloom_filter_probe_allow)
 @ignore_order(local=True)
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #15202.

### Description

Dataproc's Spark (2.1 images and Serverless 2.2) plans runtime bloom filter probes as might_contain(bf, cast(key as bigint)) instead of the OSS might_contain(bf, xxhash64(key)), so the CPU bridge keeps a Cast on the CPU side. The expression-level allow_non_gpu lists for test_bloom_filter_join_cpu_probe encode the OSS shape and do not include Cast, so the test-mode bridge validator rejects the plan on Dataproc.

Add Cast to the allow lists only when running on Dataproc or Dataproc Serverless, using a runtime-gated tuple expanded into the existing allow_non_gpu marker. All other runtimes keep the stricter assertion unchanged. No shared test infrastructure is modified.

allow_non_gpu_conditional was deliberately not used: its conftest handling applies the ops regardless of the condition. That repair is tracked separately. see issue #15213 

No need to append the databricks postfix because the change only affect Dataproc runtime.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
   - `cpu_bridge_test.py::test_bloom_filter_join_cpu_probe[SINGLE_COLUMN]`
   - `cpu_bridge_test.py::test_bloom_filter_join_cpu_probe[MULTI_COLUMN]`
   - `join_test.py::test_bloom_filter_join_cpu_probe[False]`
   - `join_test.py::test_bloom_filter_join_cpu_probe[True]`
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
