### PR TITLE
Add FilterExec to the allow_non_gpu list for test_delta_dv_cpu_bridge_filter_after_native_scan

### DIFF
--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -888,9 +888,6 @@ def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
         assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
 
 
-_delta_meta_allow_without_filter = [c for c in delta_meta_allow if c != "FilterExec"]
-
-
 def _test_delta_dv_filter_after_native_scan(spark_tmp_path, cpu_bridge_enabled):
     data_path = spark_tmp_path + "/DELTA_DATA"
     conf = {
@@ -963,6 +960,11 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
     _test_delta_dv_filter_after_native_scan(spark_tmp_path, cpu_bridge_enabled=False)
 
 
+# This covers the CPU bridge path: the filter expression runs on the CPU while
+# GpuFilterExec remains in the plan. FilterExec still has to be allowed because
+# Delta metadata queries run on the CPU by default, and their plans include
+# FilterExec. Even when a Delta metadata query runs on the GPU, its filter
+# expression is not bridge-compatible because it is nondeterministic.
 @allow_non_gpu("FilterExec", "In", "InSet", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -963,7 +963,7 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
     _test_delta_dv_filter_after_native_scan(spark_tmp_path, cpu_bridge_enabled=False)
 
 
-@allow_non_gpu("In", "InSet", "ColumnarToRowExec", *_delta_meta_allow_without_filter)
+@allow_non_gpu("FilterExec", "In", "InSet", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark/issues/15203

### Description

The test in question is failing because of a Delta metadata query running on CPU with a FilterExec, which is the default. Running metadata query on GPU will not fix it as the [UDF in the FilterExec is not deterministic](https://github.com/delta-io/delta/blob/v3.3.0/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala#L1063-L1067), which makes itself [non-bridge-compatible](https://github.com/NVIDIA/cudf-spark/blob/008859b04eb43c0524efe31997054b30b6f4ace0/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala#L1519). This PR adds the FilterExec to the allow_non_gpu list for the failing test. The test still asserts the existence of the GpuFilterExec and GpuCpuBridgeExpression in the user query plan.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
