### PR TITLE
Disable protobuf tests on Databricks [databricks]

### DIFF
--- a/jenkins/databricks/common_vars.sh
+++ b/jenkins/databricks/common_vars.sh
@@ -108,6 +108,9 @@ fi
 
 export TEST_TYPE=${TEST_TYPE:-"nightly"}
 
+# Databricks Maven coordinates do not publish a spark-protobuf artifact.
+export INCLUDE_SPARK_PROTOBUF_JAR=false
+
 if [[ -n "$LOCAL_JAR_PATH" ]]; then
     export LOCAL_JAR_PATH=$LOCAL_JAR_PATH
 fi

--- a/scala2.13/shim-deps/pom.xml
+++ b/scala2.13/shim-deps/pom.xml
@@ -251,6 +251,9 @@
                     <name>databricks</name>
                 </property>
             </activation>
+            <properties>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>com.nvidia</groupId>

--- a/shim-deps/pom.xml
+++ b/shim-deps/pom.xml
@@ -251,6 +251,9 @@
                     <name>databricks</name>
                 </property>
             </activation>
+            <properties>
+                <spark.protobuf.skipCopy>true</spark.protobuf.skipCopy>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>com.nvidia</groupId>


### PR DESCRIPTION
Follow-up to #14885.

### Description

#14885 added protobuf integration tests and copied the external `spark-protobuf` module for supported OSS Spark builds. These tests are not currently supported on Databricks.

Databricks builds use vendor Spark versions such as `3.4.1-databricks`, for which the corresponding `spark-protobuf` artifact is not published to Maven Central. This could block the package phase before the tests start. A matching stale jar could also cause the test runner to enable the unsupported tests unexpectedly.

This change disables protobuf integration tests on Databricks end to end:

- Sets `spark.protobuf.skipCopy=true` in the `dbdeps` profile so Databricks builds do not resolve or copy `spark-protobuf`.
- Sets `INCLUDE_SPARK_PROTOBUF_JAR=false` in the shared Databricks test environment.
- Ensures a matching stale jar is excluded from the test classpath.
- Keeps the existing `spark-protobuf` copy and tests enabled for supported OSS Spark profiles.
- Regenerates the Scala 2.13 Maven configuration.

Validation:

- Verified the `341db` `copy-spark-protobuf` execution is skipped and succeeds.
- Verified the Scala 2.13 `400db173` execution is skipped and succeeds.
- Verified OSS Spark 3.4.1 still copies `spark-protobuf_2.12:3.4.1`.
- Verified `protobuf_test.py` reports two skipped tests without an import or Spark startup error when protobuf is disabled, even when a matching jar is present.
- Ran `./build/make-scala-version-build-files.sh 2.13`.
- Ran `bash -n` and `shellcheck -S error` for the Databricks test scripts.
- Ran `git diff --check`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
