### PR TITLE
Fix allow_non_gpu_conditional to gate allowances on its condition [databricks]

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -16,6 +16,7 @@
 markers =
     allow_non_gpu_databricks(any, [ops]): Allow the test to run anything not on the GPU in Databricks environment (ops can be SparkPlan or Expression class names)
     allow_non_gpu(any, [ops]): Allow the test to run anything not on the GPU (ops can be SparkPlan or Expression class names)
+    allow_non_gpu_conditional(condition, [ops], any): Apply allow_non_gpu allowances only when the Boolean condition is true (ops can be SparkPlan or Expression class names; each may be a comma-separated string; any=True allows anything when the condition is true)
     approximate_float(rel, abs): float calculation is approximate instead of exact
     ignore_order(local): Ignores the order of the result in asserts. If local is true the results are sorted in python instead of using spark.
     incompat: Enable incompat operators

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -260,6 +260,7 @@ else
 
     RUN_TESTS_COMMAND=(
         "$SCRIPTPATH"/runtests.py
+        -c "$LOCAL_ROOTDIR/pytest.ini"
         --rootdir "$LOCAL_ROOTDIR"
     )
     if [[ "${TESTS}" == "" ]]; then

--- a/integration_tests/src/main/python/allow_non_gpu_conditional_marker_test.py
+++ b/integration_tests/src/main/python/allow_non_gpu_conditional_marker_test.py
@@ -38,15 +38,9 @@ import conftest
 from conftest import get_non_gpu_allowed, is_allowing_any_non_gpu
 from marks import allow_non_gpu, allow_non_gpu_conditional
 
-allow_conditional = allow_non_gpu_conditional
-
 
 def allowed():
     return list(get_non_gpu_allowed())
-
-
-def allowing_any():
-    return is_allowing_any_non_gpu()
 
 
 # ---------------------------------------------------------------------------
@@ -55,27 +49,27 @@ def allowing_any():
 
 def test_baseline_no_marker():
     assert allowed() == [], f"no marker must allow nothing, got {allowed()}"
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
-@allow_conditional(True, "CondTrueOp")
+@allow_non_gpu_conditional(True, "CondTrueOp")
 def test_true_condition_applies_ops():
     assert "CondTrueOp" in allowed(), \
         f"true condition must apply its ops, got {allowed()}"
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
 @allow_non_gpu("BaseOp")
-@allow_conditional(True, "CondOp")
+@allow_non_gpu_conditional(True, "CondOp")
 def test_true_condition_merges_with_base():
     assert "BaseOp" in allowed() and "CondOp" in allowed(), \
         f"true condition must merge with the base allow list, got {allowed()}"
 
 
-@allow_conditional(True, "AnyWithOps", any=True)
+@allow_non_gpu_conditional(True, "AnyWithOps", any=True)
 def test_any_true_with_ops_precedence():
     # any=True takes precedence over an ops payload (mirrors allow_non_gpu).
-    assert allowing_any(), "any=True with a true condition must allow anything"
+    assert is_allowing_any_non_gpu(), "any=True with a true condition must allow anything"
     assert "AnyWithOps" not in allowed(), \
         f"ops payload must be superseded by any=True, got {allowed()}"
 
@@ -84,23 +78,23 @@ def test_any_true_with_ops_precedence():
 # False conditions must contribute no allowances
 # ---------------------------------------------------------------------------
 
-@allow_conditional(False, "LeakedOp")
+@allow_non_gpu_conditional(False, "LeakedOp")
 def test_false_condition_adds_nothing():
     assert "LeakedOp" not in allowed(), \
         f"LEAK: ops of a false-condition marker are applied, got {allowed()}"
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
 @allow_non_gpu("KeptOp")
-@allow_conditional(False, "LeakA,LeakB")
+@allow_non_gpu_conditional(False, "LeakA,LeakB")
 def test_false_condition_keeps_base_allowances_intact():
     assert allowed() == ["KeptOp"], \
         f"false condition must leave exactly the base allowances, got {allowed()}"
 
 
-@allow_conditional(False, "LeakedAnyOp", any=True)
+@allow_non_gpu_conditional(False, "LeakedAnyOp", any=True)
 def test_false_condition_with_any_true():
-    assert not allowing_any(), "any=True must be gated by the condition"
+    assert not is_allowing_any_non_gpu(), "any=True must be gated by the condition"
     assert "LeakedAnyOp" not in allowed(), \
         f"LEAK: ops of a false-condition any=True marker applied, got {allowed()}"
 
@@ -109,19 +103,19 @@ def test_false_condition_with_any_true():
 # Condition-only and any-only invocation forms must set up cleanly
 # ---------------------------------------------------------------------------
 
-@allow_conditional(True)
+@allow_non_gpu_conditional(True)
 def test_condition_only_true_warns_not_errors():
     # A condition-only marker allows nothing (plus a warning), like a bare
     # @allow_non_gpu. Pre-fix, setup died with IndexError on args[1].
     assert allowed() == [], f"condition-only marker must allow nothing, got {allowed()}"
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
-@allow_conditional(True, any=True)
+@allow_non_gpu_conditional(True, any=True)
 def test_any_true_without_ops():
     # The documented (condition, any=True) form. Pre-fix, setup died with
     # IndexError on args[1] before kwargs were even inspected.
-    assert allowing_any(), "(True, any=True) must allow anything on the CPU"
+    assert is_allowing_any_non_gpu(), "(True, any=True) must allow anything on the CPU"
     assert allowed() == []
 
 
@@ -129,7 +123,7 @@ def test_any_true_without_ops():
 # Varargs, stacked markers, and payload trimming
 # ---------------------------------------------------------------------------
 
-@allow_conditional(True, "MultiA", "MultiB")
+@allow_non_gpu_conditional(True, "MultiA", "MultiB")
 def test_multiple_ops_varargs():
     # Varargs ops are accepted like allow_non_gpu. Pre-fix, args[2:] were
     # silently ignored.
@@ -137,8 +131,8 @@ def test_multiple_ops_varargs():
         f"all ops args must be honored, got {allowed()}"
 
 
-@allow_conditional(True, "StackTop")
-@allow_conditional(True, "StackBottom")
+@allow_non_gpu_conditional(True, "StackTop")
+@allow_non_gpu_conditional(True, "StackBottom")
 def test_stacked_markers_union():
     # Every stacked marker contributes (each gated by its own condition).
     # Pre-fix, get_closest_marker silently dropped all but one.
@@ -146,7 +140,7 @@ def test_stacked_markers_union():
         f"stacked markers must union their allowances, got {allowed()}"
 
 
-@allow_conditional(True, "SpaceA, SpaceB")
+@allow_non_gpu_conditional(True, "SpaceA, SpaceB")
 def test_embedded_space_trimmed():
     # Entries are trimmed on split so Python-side consumers of
     # get_non_gpu_allowed() never see ' SpaceB'. (The Scala side already
@@ -206,13 +200,13 @@ def test_non_bool_condition_alone_raises_typeerror_not_indexerror():
 def test_nonbool_any_string_rejected():
     with pytest.raises(TypeError, match="'any' parameter"):
         _setup(_FakeMark((True, "OpA"), {"any": "false"}))
-    assert not allowing_any(), "truthy string any= must not disable test mode"
+    assert not is_allowing_any_non_gpu(), "truthy string any= must not disable test mode"
 
 
 def test_nonbool_any_int_rejected():
     with pytest.raises(TypeError, match="'any' parameter"):
         _setup(_FakeMark((True, "OpA"), {"any": 1}))
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
 # ---------------------------------------------------------------------------
@@ -239,11 +233,11 @@ def test_zero_argument_marker_rejected():
         _setup(_FakeMark(()))
 
 
-@allow_conditional(True, "ExplicitAnyFalseOp", any=False)
+@allow_non_gpu_conditional(True, "ExplicitAnyFalseOp", any=False)
 def test_explicit_any_false_with_ops():
     # any=False is the documented default spelled out: ops apply normally.
     assert "ExplicitAnyFalseOp" in allowed(), f"got {allowed()}"
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +263,7 @@ def test_active_empty_payload_warns():
     with pytest.warns(UserWarning, match="empty ops payload"):
         _setup(_FakeMark((True, "")))
     assert allowed() == []
-    assert not allowing_any()
+    assert not is_allowing_any_non_gpu()
 
 
 def test_whitespace_payload_warns():

--- a/integration_tests/src/main/python/allow_non_gpu_conditional_marker_test.py
+++ b/integration_tests/src/main/python/allow_non_gpu_conditional_marker_test.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Contract and hardening tests for the allow_non_gpu_conditional pytest marker.
+#
+# Every test asserts the marker's documented contract:
+#   @allow_non_gpu_conditional(condition, *ops, any=False)
+#   - condition must be a literal bool; anything else (including a missing
+#     condition) raises TypeError on BOTH branches
+#   - a false condition contributes nothing (state-equivalent to no marker)
+#   - ops are one or more positional strings, each optionally comma-separated;
+#     entries are trimmed, empties dropped, duplicates removed
+#   - any=True (condition true) allows anything and takes precedence over ops;
+#     'any' must be a real bool and is the only accepted keyword
+#
+# The tests are Spark-job-free: marker processing happens in the real
+# conftest.pytest_runtest_setup (driven either by real pytest markers or by a
+# direct call with a minimal fake item), and no test body issues Spark work.
+# Module-scope marker coverage lives in allow_non_gpu_conditional_scope_test.py
+# so the pytestmark there cannot taint the unmarked baselines here.
+
+import warnings
+
+import pytest
+
+import conftest
+from conftest import get_non_gpu_allowed, is_allowing_any_non_gpu
+from marks import allow_non_gpu, allow_non_gpu_conditional
+
+allow_conditional = allow_non_gpu_conditional
+
+
+def allowed():
+    return list(get_non_gpu_allowed())
+
+
+def allowing_any():
+    return is_allowing_any_non_gpu()
+
+
+# ---------------------------------------------------------------------------
+# Baseline behavior
+# ---------------------------------------------------------------------------
+
+def test_baseline_no_marker():
+    assert allowed() == [], f"no marker must allow nothing, got {allowed()}"
+    assert not allowing_any()
+
+
+@allow_conditional(True, "CondTrueOp")
+def test_true_condition_applies_ops():
+    assert "CondTrueOp" in allowed(), \
+        f"true condition must apply its ops, got {allowed()}"
+    assert not allowing_any()
+
+
+@allow_non_gpu("BaseOp")
+@allow_conditional(True, "CondOp")
+def test_true_condition_merges_with_base():
+    assert "BaseOp" in allowed() and "CondOp" in allowed(), \
+        f"true condition must merge with the base allow list, got {allowed()}"
+
+
+@allow_conditional(True, "AnyWithOps", any=True)
+def test_any_true_with_ops_precedence():
+    # any=True takes precedence over an ops payload (mirrors allow_non_gpu).
+    assert allowing_any(), "any=True with a true condition must allow anything"
+    assert "AnyWithOps" not in allowed(), \
+        f"ops payload must be superseded by any=True, got {allowed()}"
+
+
+# ---------------------------------------------------------------------------
+# False conditions must contribute no allowances
+# ---------------------------------------------------------------------------
+
+@allow_conditional(False, "LeakedOp")
+def test_false_condition_adds_nothing():
+    assert "LeakedOp" not in allowed(), \
+        f"LEAK: ops of a false-condition marker are applied, got {allowed()}"
+    assert not allowing_any()
+
+
+@allow_non_gpu("KeptOp")
+@allow_conditional(False, "LeakA,LeakB")
+def test_false_condition_keeps_base_allowances_intact():
+    assert allowed() == ["KeptOp"], \
+        f"false condition must leave exactly the base allowances, got {allowed()}"
+
+
+@allow_conditional(False, "LeakedAnyOp", any=True)
+def test_false_condition_with_any_true():
+    assert not allowing_any(), "any=True must be gated by the condition"
+    assert "LeakedAnyOp" not in allowed(), \
+        f"LEAK: ops of a false-condition any=True marker applied, got {allowed()}"
+
+
+# ---------------------------------------------------------------------------
+# Condition-only and any-only invocation forms must set up cleanly
+# ---------------------------------------------------------------------------
+
+@allow_conditional(True)
+def test_condition_only_true_warns_not_errors():
+    # A condition-only marker allows nothing (plus a warning), like a bare
+    # @allow_non_gpu. Pre-fix, setup died with IndexError on args[1].
+    assert allowed() == [], f"condition-only marker must allow nothing, got {allowed()}"
+    assert not allowing_any()
+
+
+@allow_conditional(True, any=True)
+def test_any_true_without_ops():
+    # The documented (condition, any=True) form. Pre-fix, setup died with
+    # IndexError on args[1] before kwargs were even inspected.
+    assert allowing_any(), "(True, any=True) must allow anything on the CPU"
+    assert allowed() == []
+
+
+# ---------------------------------------------------------------------------
+# Varargs, stacked markers, and payload trimming
+# ---------------------------------------------------------------------------
+
+@allow_conditional(True, "MultiA", "MultiB")
+def test_multiple_ops_varargs():
+    # Varargs ops are accepted like allow_non_gpu. Pre-fix, args[2:] were
+    # silently ignored.
+    assert "MultiA" in allowed() and "MultiB" in allowed(), \
+        f"all ops args must be honored, got {allowed()}"
+
+
+@allow_conditional(True, "StackTop")
+@allow_conditional(True, "StackBottom")
+def test_stacked_markers_union():
+    # Every stacked marker contributes (each gated by its own condition).
+    # Pre-fix, get_closest_marker silently dropped all but one.
+    assert "StackTop" in allowed() and "StackBottom" in allowed(), \
+        f"stacked markers must union their allowances, got {allowed()}"
+
+
+@allow_conditional(True, "SpaceA, SpaceB")
+def test_embedded_space_trimmed():
+    # Entries are trimmed on split so Python-side consumers of
+    # get_non_gpu_allowed() never see ' SpaceB'. (The Scala side already
+    # trims via ConfHelper.stringToSeq.)
+    assert "SpaceB" in allowed() and " SpaceB" not in allowed(), \
+        f"payload entries must be trimmed, got {allowed()}"
+
+
+# ---------------------------------------------------------------------------
+# Raising/warning forms, exercised by direct call with a minimal fake item
+# ---------------------------------------------------------------------------
+
+class _FakeMark:
+    def __init__(self, args, kwargs=None):
+        self.args = args
+        self.kwargs = kwargs or {}
+
+
+class _FakeItem:
+    """Minimal stand-in carrying only allow_non_gpu_conditional marks."""
+
+    def __init__(self, *marks):
+        self._marks = list(marks)
+
+    def get_closest_marker(self, name):
+        if name == "allow_non_gpu_conditional" and self._marks:
+            return self._marks[0]
+        return None
+
+    def iter_markers(self, name):
+        if name == "allow_non_gpu_conditional":
+            return list(self._marks)
+        return []
+
+
+def _setup(*marks):
+    conftest.pytest_runtest_setup(_FakeItem(*marks))
+
+
+def test_non_bool_condition_with_ops_raises_typeerror():
+    with pytest.raises(TypeError, match="must be a Boolean"):
+        _setup(_FakeMark(("premerge", "OpY")))
+
+
+def test_non_bool_condition_alone_raises_typeerror_not_indexerror():
+    # The boolean type check fires for every malformed invocation. Pre-fix, a
+    # condition-only non-bool marker died with IndexError on args[1] before
+    # the TypeError check was reached.
+    with pytest.raises(TypeError, match="must be a Boolean"):
+        _setup(_FakeMark(("premerge",)))
+
+
+# ---------------------------------------------------------------------------
+# any= must be a real bool: a truthy non-bool must never disable test mode
+# ---------------------------------------------------------------------------
+
+def test_nonbool_any_string_rejected():
+    with pytest.raises(TypeError, match="'any' parameter"):
+        _setup(_FakeMark((True, "OpA"), {"any": "false"}))
+    assert not allowing_any(), "truthy string any= must not disable test mode"
+
+
+def test_nonbool_any_int_rejected():
+    with pytest.raises(TypeError, match="'any' parameter"):
+        _setup(_FakeMark((True, "OpA"), {"any": 1}))
+    assert not allowing_any()
+
+
+# ---------------------------------------------------------------------------
+# Unknown / typo kwargs must be rejected, not silently ignored
+# ---------------------------------------------------------------------------
+
+def test_unknown_kwarg_rejected():
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        _setup(_FakeMark((True, "OpA"), {"reason": "some reason"}))
+
+
+def test_typo_kwarg_rejected():
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        _setup(_FakeMark((True,), {"anny": True}))
+
+
+# ---------------------------------------------------------------------------
+# Argument-shape regressions
+# ---------------------------------------------------------------------------
+
+def test_zero_argument_marker_rejected():
+    # Bare @allow_non_gpu_conditional(): no condition at all.
+    with pytest.raises(TypeError, match="requires a Boolean condition"):
+        _setup(_FakeMark(()))
+
+
+@allow_conditional(True, "ExplicitAnyFalseOp", any=False)
+def test_explicit_any_false_with_ops():
+    # any=False is the documented default spelled out: ops apply normally.
+    assert "ExplicitAnyFalseOp" in allowed(), f"got {allowed()}"
+    assert not allowing_any()
+
+
+# ---------------------------------------------------------------------------
+# Ops must be strings; validation fires on both condition branches
+# ---------------------------------------------------------------------------
+
+def test_nonstring_op_rejected():
+    with pytest.raises(TypeError, match="must be strings"):
+        _setup(_FakeMark((True, 123)))
+
+
+def test_malformed_rejected_even_when_condition_false():
+    with pytest.raises(TypeError, match="must be strings"):
+        _setup(_FakeMark((False, 123)))
+    assert allowed() == [], "false-branch malformed marker must not mutate state"
+
+
+# ---------------------------------------------------------------------------
+# Empty / whitespace payloads warn instead of silently allowing nothing
+# ---------------------------------------------------------------------------
+
+def test_active_empty_payload_warns():
+    with pytest.warns(UserWarning, match="empty ops payload"):
+        _setup(_FakeMark((True, "")))
+    assert allowed() == []
+    assert not allowing_any()
+
+
+def test_whitespace_payload_warns():
+    with pytest.warns(UserWarning, match="empty ops payload"):
+        _setup(_FakeMark((True, "  ,  ")))
+    assert allowed() == []
+
+
+# ---------------------------------------------------------------------------
+# Condition-only forms: true warns, false is silent (exactly like no marker)
+# ---------------------------------------------------------------------------
+
+def test_true_condition_only_warns():
+    with pytest.warns(UserWarning, match="without anything allowed"):
+        _setup(_FakeMark((True,)))
+    assert allowed() == []
+
+
+def test_false_condition_only_is_silent():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _setup(_FakeMark((False,)))
+    ours = [w for w in caught if "allow_non_gpu_conditional" in str(w.message)]
+    assert not ours, f"false condition-only must be silent, got {ours}"
+    assert allowed() == []
+
+
+# ---------------------------------------------------------------------------
+# Duplicate ops across stacked markers deduplicate ("union" semantics)
+# ---------------------------------------------------------------------------
+
+def test_duplicate_ops_deduplicated():
+    _setup(_FakeMark((True, "DupOp,DupOp")), _FakeMark((True, "DupOp")))
+    assert allowed() == ["DupOp"], \
+        f"union semantics require dedup, got {allowed()}"

--- a/integration_tests/src/main/python/allow_non_gpu_conditional_scope_test.py
+++ b/integration_tests/src/main/python/allow_non_gpu_conditional_scope_test.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Scope tests for the allow_non_gpu_conditional pytest marker:
+# iter_markers accumulates function, parameter, class, and module marks; every
+# effective marker in scope contributes (each gated by its own condition), with
+# entries deduplicated. Pre-fix, get_closest_marker kept only the closest mark
+# and outer scopes were silently dropped.
+#
+# This module is separate from allow_non_gpu_conditional_marker_test.py because
+# the module-level pytestmark below applies to every test in this file and must
+# not taint the unmarked baseline tests there. The tests are Spark-job-free.
+
+import pytest
+
+from conftest import get_non_gpu_allowed
+from marks import allow_non_gpu_conditional
+
+allow_conditional = allow_non_gpu_conditional
+
+# Module-scope marker: applies to every test in this file.
+pytestmark = allow_conditional(True, "ModuleScopeOp")
+
+
+def allowed():
+    return list(get_non_gpu_allowed())
+
+
+def test_module_scope_applies():
+    assert "ModuleScopeOp" in allowed(), f"got {allowed()}"
+
+
+@allow_conditional(True, "FuncScopeOp")
+def test_module_plus_function_scope():
+    a = allowed()
+    assert "FuncScopeOp" in a and "ModuleScopeOp" in a, \
+        f"module + function markers must both contribute, got {a}"
+
+
+class TestClassScope:
+    pytestmark = allow_conditional(True, "ClassScopeOp")
+
+    def test_module_plus_class_scope(self):
+        a = allowed()
+        assert "ClassScopeOp" in a and "ModuleScopeOp" in a, \
+            f"module + class markers must both contribute, got {a}"
+
+    @allow_conditional(True, "FuncScopeOp2")
+    def test_module_class_function_scope(self):
+        a = allowed()
+        assert {"ModuleScopeOp", "ClassScopeOp", "FuncScopeOp2"} <= set(a), \
+            f"all scopes must contribute, got {a}"
+
+
+@pytest.mark.parametrize("x", [
+    pytest.param(1, marks=allow_conditional(True, "ParamScopeOp")),
+    pytest.param(2),
+])
+def test_param_scope(x):
+    a = allowed()
+    if x == 1:
+        assert "ParamScopeOp" in a and "ModuleScopeOp" in a, f"got {a}"
+    else:
+        assert "ParamScopeOp" not in a and "ModuleScopeOp" in a, f"got {a}"
+
+
+@allow_conditional(True, "ModuleScopeOp")
+def test_dedup_across_scopes():
+    a = allowed()
+    assert a.count("ModuleScopeOp") == 1, \
+        f"an op contributed by two scopes must appear once, got {a}"

--- a/integration_tests/src/main/python/allow_non_gpu_conditional_scope_test.py
+++ b/integration_tests/src/main/python/allow_non_gpu_conditional_scope_test.py
@@ -27,10 +27,8 @@ import pytest
 from conftest import get_non_gpu_allowed
 from marks import allow_non_gpu_conditional
 
-allow_conditional = allow_non_gpu_conditional
-
 # Module-scope marker: applies to every test in this file.
-pytestmark = allow_conditional(True, "ModuleScopeOp")
+pytestmark = allow_non_gpu_conditional(True, "ModuleScopeOp")
 
 
 def allowed():
@@ -41,7 +39,7 @@ def test_module_scope_applies():
     assert "ModuleScopeOp" in allowed(), f"got {allowed()}"
 
 
-@allow_conditional(True, "FuncScopeOp")
+@allow_non_gpu_conditional(True, "FuncScopeOp")
 def test_module_plus_function_scope():
     a = allowed()
     assert "FuncScopeOp" in a and "ModuleScopeOp" in a, \
@@ -49,14 +47,14 @@ def test_module_plus_function_scope():
 
 
 class TestClassScope:
-    pytestmark = allow_conditional(True, "ClassScopeOp")
+    pytestmark = allow_non_gpu_conditional(True, "ClassScopeOp")
 
     def test_module_plus_class_scope(self):
         a = allowed()
         assert "ClassScopeOp" in a and "ModuleScopeOp" in a, \
             f"module + class markers must both contribute, got {a}"
 
-    @allow_conditional(True, "FuncScopeOp2")
+    @allow_non_gpu_conditional(True, "FuncScopeOp2")
     def test_module_class_function_scope(self):
         a = allowed()
         assert {"ModuleScopeOp", "ClassScopeOp", "FuncScopeOp2"} <= set(a), \
@@ -64,7 +62,7 @@ class TestClassScope:
 
 
 @pytest.mark.parametrize("x", [
-    pytest.param(1, marks=allow_conditional(True, "ParamScopeOp")),
+    pytest.param(1, marks=allow_non_gpu_conditional(True, "ParamScopeOp")),
     pytest.param(2),
 ])
 def test_param_scope(x):
@@ -75,7 +73,7 @@ def test_param_scope(x):
         assert "ParamScopeOp" not in a and "ModuleScopeOp" in a, f"got {a}"
 
 
-@allow_conditional(True, "ModuleScopeOp")
+@allow_non_gpu_conditional(True, "ModuleScopeOp")
 def test_dedup_across_scopes():
     a = allowed()
     assert a.count("ModuleScopeOp") == 1, \

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -265,7 +265,6 @@ def pytest_runtest_setup(item):
     _allow_any_non_gpu_conditional = False
     non_gpu_databricks = item.get_closest_marker('allow_non_gpu_databricks')
     non_gpu = item.get_closest_marker('allow_non_gpu')
-    non_gpu_conditional = item.get_closest_marker('allow_non_gpu_conditional')
     _per_test_ansi_mode_enabled = None if item.get_closest_marker('disable_ansi_mode') is None \
       else not item.get_closest_marker('disable_ansi_mode')
 
@@ -292,21 +291,42 @@ def pytest_runtest_setup(item):
         _allow_any_non_gpu = False
         _non_gpu_allowed = []
 
-    if non_gpu_conditional:
+    for non_gpu_conditional in item.iter_markers('allow_non_gpu_conditional'):
+        # Validate the marker deterministically on BOTH condition branches so a
+        # malformed marker fails everywhere, not only where its condition is true.
+        unknown_kwargs = set(non_gpu_conditional.kwargs) - {'any'}
+        if unknown_kwargs:
+            raise TypeError(
+                "allow_non_gpu_conditional got unexpected keyword argument(s) "
+                f"{sorted(unknown_kwargs)}; only 'any' is supported.")
+        allow_any = non_gpu_conditional.kwargs.get('any', False)
+        if not isinstance(allow_any, bool):
+            raise TypeError(
+                "The 'any' parameter of 'allow_non_gpu_conditional' must be a Boolean.")
+        if not non_gpu_conditional.args:
+            raise TypeError(
+                "The 'allow_non_gpu_conditional' marker requires a Boolean condition "
+                "as its first argument.")
         condition = non_gpu_conditional.args[0]
-        _non_gpu_allowed_conditional = non_gpu_conditional.args[1]
         if not isinstance(condition, bool):
-            raise TypeError("The first parameter of 'allow_non_gpu_conditional' must be a Boolean.")
+            raise TypeError(
+                "The first parameter of 'allow_non_gpu_conditional' must be a Boolean.")
+        op_args = non_gpu_conditional.args[1:]
+        if not all(isinstance(arg, str) for arg in op_args):
+            raise TypeError("allow_non_gpu_conditional op names must be strings.")
+        ops = [op.strip() for arg in op_args for op in arg.split(',')]
+        ops = [op for op in ops if op]
+        if op_args and not ops:
+            warnings.warn('allow_non_gpu_conditional marker with an empty ops payload')
         if condition:
-            if non_gpu_conditional.kwargs and non_gpu_conditional.kwargs['any']:
+            if allow_any:
                 _allow_any_non_gpu_conditional = True
-                _non_gpu_allowed_conditional = []
-            elif _non_gpu_allowed_conditional:
-                _allow_any_non_gpu_conditional = False
-            else:
+            elif ops:
+                for op in ops:
+                    if op not in _non_gpu_allowed_conditional:
+                        _non_gpu_allowed_conditional.append(op)
+            elif not op_args:
                 warnings.warn('allow_non_gpu_conditional marker without anything allowed')
-                _allow_any_non_gpu_conditional = False
-                _non_gpu_allowed_conditional = []
 
 
     _allow_any_non_gpu = _allow_any_non_gpu | _allow_any_non_gpu_databricks | _allow_any_non_gpu_conditional
@@ -315,7 +335,7 @@ def pytest_runtest_setup(item):
     elif _non_gpu_allowed_databricks:
         _non_gpu_allowed = _non_gpu_allowed_databricks
     if _non_gpu_allowed_conditional:
-        _non_gpu_allowed = list(_non_gpu_allowed) + _non_gpu_allowed_conditional.split(",")
+        _non_gpu_allowed = list(_non_gpu_allowed) + _non_gpu_allowed_conditional
 
     global _validate_execs_in_gpu_plan
     validate_execs = item.get_closest_marker('validate_execs_in_gpu_plan')


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #15213

### Description

Fix allow_non_gpu_conditional to gate allowances on its condition

The allow_non_gpu_conditional marker applied its allowances on every runtime regardless of the condition, silently weakening fallback assertions wherever the condition was false.

Gate the allowances on the condition and validate marker arguments deterministically on both branches. Register the marker in pytest.ini and pass -c to pytest so Scala 2.13 runs load the config. Add marker contract and scope tests. Test-only change; no product code affected.


### Deferred and followups

- [ ] https://github.com/NVIDIA/cudf-spark/issues/15239
- [ ] https://github.com/NVIDIA/cudf-spark/issues/15238
- [ ] https://github.com/NVIDIA/cudf-spark/issues/15237

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [x] Covered by existing tests
   - test_pmod_*,
   - test_try_*_fallback_to_cpu,
   - test_array_aggregate_*_fallback,
   - the five Delta functions, and 
   - `string_type_test.py::test_constraint_char_preserve_disabled_fallback`.
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
