### PR TITLE
[AutoSparkUT] Recover JSON timestamp fallback tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1606,7 +1606,7 @@ def test_spark_from_json_timestamp_format_option_zoneid(zone_id):
         'spark.rapids.sql.expression.cpuBridge.enabled': 'false'})
     assert_gpu_fallback_collect(
         lambda spark : spark.createDataFrame(data, 'json STRING').select(f.col('json'), f.from_json(f.col('json'), schema, {'timestampFormat': "yyyy-MM-dd'T'HH:mm:ss",'timeZone': zone_id})),
-        'JsonToStructs',
+        'ProjectExec',
         conf=conf)
 
 @pytest.mark.parametrize('zone_id', [

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -963,13 +963,14 @@ def test_from_json_struct_timestamp_fallback_legacy(timestamp_gen, timestamp_for
     "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
     "dd/MM/yyyy'T'HH:mm:ss[.SSS][XXX]",
 ])
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10535')
 def test_from_json_struct_timestamp_fallback_non_default_format(timestamp_gen, timestamp_format):
     json_string_gen = StringGen(r'{ "a": ' + timestamp_gen + ' }') \
         .with_special_case('{ "a": null }') \
         .with_special_case('null')
     options = { 'timestampFormat': timestamp_format } if timestamp_format else { }
-    conf = copy_and_update(_enable_all_types_conf, {'spark.sql.legacy.timeParserPolicy': 'CORRECTED'})
+    conf = copy_and_update(_enable_all_types_conf, {
+        'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
+        'spark.rapids.sql.expression.cpuBridge.enabled': 'false'})
     assert_gpu_fallback_collect(
         lambda spark : unary_op_df(spark, json_string_gen) \
             .select(f.col('a'), f.from_json('a', 'struct<a:timestamp>', options)),
@@ -1596,16 +1597,17 @@ def test_spark_from_json_timestamp_default_format():
     "Asia/Urumqi",
     "Asia/Hong_Kong",
     "Europe/Brussels"], ids=idfn)
-@allow_non_gpu('JsonToStructs')
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10535')
+@allow_non_gpu('ProjectExec')
 # This is expected to fallback to the CPU because the timestampFormat is not supported, but really is, so we shold be better about this.
 def test_spark_from_json_timestamp_format_option_zoneid(zone_id):
     schema = StructType([StructField("t", TimestampType())])
     data = [[r'''{"t": "2016-01-01T00:00:00"}''']]
+    conf = copy_and_update(_enable_all_types_conf, {
+        'spark.rapids.sql.expression.cpuBridge.enabled': 'false'})
     assert_gpu_fallback_collect(
         lambda spark : spark.createDataFrame(data, 'json STRING').select(f.col('json'), f.from_json(f.col('json'), schema, {'timestampFormat': "yyyy-MM-dd'T'HH:mm:ss",'timeZone': zone_id})),
         'JsonToStructs',
-        conf =_enable_all_types_conf)
+        conf=conf)
 
 @pytest.mark.parametrize('zone_id', [
     "UTC",


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350 b22 nightly baseline; the raw +2 was solely the excluded `MemoryCheckerImpl` GPU-initialization artifact)

Contributes to #10535.

## Summary

- Recover `test_from_json_struct_timestamp_fallback_non_default_format` (2 parameters).
- Recover `test_spark_from_json_timestamp_format_option_zoneid` (8 parameters).
- Disable the expression CPU bridge only in these fallback tests so they continue to verify whole-`ProjectExec` CPU fallback.
- Update the zone-id test allowlist to match its actual fallback node.

This is a partial recovery. Four issue-linked exemptions remain because unmasked GPU-vs-CPU probes still reproduce real corrected timestamp parsing divergence (GPU returns null where CPU returns parsed timestamps).

## Validation

- Spark 3.5 / shim 350 build: `BUILD SUCCESS` (11/11 modules, 05:44 min).
- Focused recovery: `10 passed, 7881 deselected, 7 warnings in 9.19s`.
- Full `json_test.py`: `7224 passed, 30 skipped, 165 xfailed, 472 xpassed, 5043 warnings in 573.42s`.
- Nightly-matched JaCoCo run: `10 passed, 7877 deselected, 5 warnings in 9.11s`; net sql-plugin contribution `+0 lines` after excluding the recurring `MemoryCheckerImpl +2` artifact.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
