### PR TITLE
Revert "[Coverage] Add YearMonthInterval multiply/divide IT parallel to DayTime" [skip ci]

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1404,28 +1404,6 @@ def test_day_time_interval_division_number_no_overflow2(data_gen):
         # avoid dividing by 0
         lambda spark: gen_df(spark, gen_list).selectExpr("_c1 / case when _c2 = 0 then cast(1 as {}) else _c2 end".format(to_cast_string(data_gen.data_type))))
 
-@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=-3, max_exp=5, special_cases=[0.0])], ids=idfn)
-def test_year_month_interval_multiply_number(data_gen):
-    # Cast result to BIGINT (months count) so the final schema is LongType.
-    # YearMonthIntervalType schema is not deserializable by PySpark 3.3.0
-    # client-side, and CAST(YM AS STRING) is not GPU-supported (would force
-    # the multiply onto CPU). CAST(YM AS BIGINT) is GPU-supported.
-    gen_list = [('_c2', data_gen)]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: gen_df(spark, gen_list).selectExpr(
-            "CAST(INTERVAL '0-3' YEAR TO MONTH * _c2 AS BIGINT)",
-            "CAST(INTERVAL '5-7' YEAR TO MONTH * _c2 AS BIGINT)",
-            "CAST(_c2 * INTERVAL '100-0' YEAR TO MONTH AS BIGINT)"))
-
-@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=0, max_exp=5, special_cases=[])], ids=idfn)
-def test_year_month_interval_division_number_no_overflow(data_gen):
-    # Cast result to BIGINT (same reason as test_year_month_interval_multiply_number).
-    gen_list = [('_c2', data_gen)]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: gen_df(spark, gen_list).selectExpr(
-            "CAST(INTERVAL '5-3' YEAR TO MONTH / _c2 AS BIGINT)",
-            "CAST(INTERVAL '100-0' YEAR TO MONTH / _c2 AS BIGINT)"))
-
 def _get_overflow_df_1col(spark, data_type, value, expr):
     return spark.createDataFrame(
         SparkContext.getOrCreate().parallelize([value]),


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (this revert removes the Python integration tests from #14938 and adds no test code).

Fixes #15248.

### Description

Reverts #14938.

#14938 added YearMonthInterval multiply/divide integration tests that require GPU execution. As recorded in #15248, the Databricks nightly matrix instead routes `MultiplyYMInterval` and `DivideYMInterval` through `GpuCpuBridgeExpression`, where those CPU expressions are disallowed, causing 13 integration-test failures across DBR 13.3, 14.3, and 17.3.

This revert removes those tests while #15248 tracks the unsupported execution path and its future coverage.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
