### PR TITLE
[BUG] Enable YearMonthInterval arithmetic on Databricks [databricks]

### DIFF
--- a/docs/additional-functionality/advanced_configs.md
+++ b/docs/additional-functionality/advanced_configs.md
@@ -265,7 +265,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.DenseRank"></a>spark.rapids.sql.expression.DenseRank|`dense_rank`|Window function that returns the dense rank value within the aggregation window|true|None|
 <a name="sql.expression.Divide"></a>spark.rapids.sql.expression.Divide|`/`|Division|true|None|
 <a name="sql.expression.DivideDTInterval"></a>spark.rapids.sql.expression.DivideDTInterval| |Day-time interval * operator|true|None|
-<a name="sql.expression.DivideYMInterval"></a>spark.rapids.sql.expression.DivideYMInterval| |Year-month interval * operator|true|None|
+<a name="sql.expression.DivideYMInterval"></a>spark.rapids.sql.expression.DivideYMInterval| |Year-month interval / number|true|None|
 <a name="sql.expression.DynamicPruningExpression"></a>spark.rapids.sql.expression.DynamicPruningExpression| |Dynamic pruning expression marker|true|None|
 <a name="sql.expression.ElementAt"></a>spark.rapids.sql.expression.ElementAt|`element_at`|Returns element of array at given(1-based) index in value if column is array. Returns value for the given key in value if column is map.|true|None|
 <a name="sql.expression.EndsWith"></a>spark.rapids.sql.expression.EndsWith| |Ends with|true|None|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -7200,7 +7200,7 @@ are limited.
 <tr>
 <td rowSpan="3">DivideYMInterval</td>
 <td rowSpan="3"> </td>
-<td rowSpan="3">Year-month interval * operator</td>
+<td rowSpan="3">Year-month interval / number</td>
 <td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1404,6 +1404,28 @@ def test_day_time_interval_division_number_no_overflow2(data_gen):
         # avoid dividing by 0
         lambda spark: gen_df(spark, gen_list).selectExpr("_c1 / case when _c2 = 0 then cast(1 as {}) else _c2 end".format(to_cast_string(data_gen.data_type))))
 
+@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=-3, max_exp=5, special_cases=[0.0])], ids=idfn)
+def test_year_month_interval_multiply_number(data_gen):
+    # Cast result to BIGINT (months count) so the final schema is LongType.
+    # YearMonthIntervalType schema is not deserializable by PySpark 3.3.0
+    # client-side, and CAST(YM AS STRING) is not GPU-supported (would force
+    # the multiply onto CPU). CAST(YM AS BIGINT) is GPU-supported.
+    gen_list = [('_c2', data_gen)]
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, gen_list).selectExpr(
+            "CAST(INTERVAL '0-3' YEAR TO MONTH * _c2 AS BIGINT)",
+            "CAST(INTERVAL '5-7' YEAR TO MONTH * _c2 AS BIGINT)",
+            "CAST(_c2 * INTERVAL '100-0' YEAR TO MONTH AS BIGINT)"))
+
+@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens_for_fallback + [DoubleGen(min_exp=0, max_exp=5, special_cases=[])], ids=idfn)
+def test_year_month_interval_division_number_no_overflow(data_gen):
+    # Cast result to BIGINT (same reason as test_year_month_interval_multiply_number).
+    gen_list = [('_c2', data_gen)]
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, gen_list).selectExpr(
+            "CAST(INTERVAL '5-3' YEAR TO MONTH / _c2 AS BIGINT)",
+            "CAST(INTERVAL '100-0' YEAR TO MONTH / _c2 AS BIGINT)"))
+
 def _get_overflow_df_1col(spark, data_type, value, expr):
     return spark.createDataFrame(
         SparkContext.getOrCreate().parallelize([value]),

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala
@@ -51,7 +51,6 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.{FileFormat, FilePartition, FileScanRDD, PartitionedFile}
-import org.apache.spark.sql.rapids.shims.{GpuDivideYMInterval, GpuMultiplyYMInterval}
 import org.apache.spark.sql.types.StructType
 
 trait Spark330PlusShims extends Spark321PlusShims with Spark320PlusNonDBShims {
@@ -69,33 +68,9 @@ trait Spark330PlusShims extends Spark321PlusShims with Spark320PlusNonDBShims {
   }
 
   // GPU support ANSI interval types from 330
-  override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
-    val map: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
-      GpuOverrides.expr[MultiplyYMInterval](
-        "Year-month interval * number",
-        ExprChecks.binaryProject(
-          TypeSig.YEARMONTH,
-          TypeSig.YEARMONTH,
-          ("lhs", TypeSig.YEARMONTH, TypeSig.YEARMONTH),
-          ("rhs", TypeSig.gpuNumeric - TypeSig.DECIMAL_128, TypeSig.gpuNumeric)),
-        (a, conf, p, r) => new BinaryExprMeta[MultiplyYMInterval](a, conf, p, r) {
-          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-            GpuMultiplyYMInterval(lhs, rhs)
-        }),
-      GpuOverrides.expr[DivideYMInterval](
-        "Year-month interval * operator",
-        ExprChecks.binaryProject(
-          TypeSig.YEARMONTH,
-          TypeSig.YEARMONTH,
-          ("lhs", TypeSig.YEARMONTH, TypeSig.YEARMONTH),
-          ("rhs", TypeSig.gpuNumeric - TypeSig.DECIMAL_128, TypeSig.gpuNumeric)),
-        (a, conf, p, r) => new BinaryExprMeta[DivideYMInterval](a, conf, p, r) {
-          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-            GpuDivideYMInterval(lhs, rhs)
-        })
-    ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
-    super.getExprs ++ map ++ DayTimeIntervalShims.exprs ++ RoundingShims.exprs
-  }
+  override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] =
+    super.getExprs ++ YearMonthIntervalShims.exprs ++ DayTimeIntervalShims.exprs ++
+      RoundingShims.exprs
 
   // GPU support ANSI interval types from 330
   override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/YearMonthIntervalShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/YearMonthIntervalShims.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "400"}
+{"spark": "400db173"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "411"}
+{"spark": "412"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.rapids.shims.{GpuDivideYMInterval, GpuMultiplyYMInterval}
+
+object YearMonthIntervalShims {
+  def exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
+    GpuOverrides.expr[MultiplyYMInterval](
+      "Year-month interval * number",
+      ExprChecks.binaryProject(
+        TypeSig.YEARMONTH,
+        TypeSig.YEARMONTH,
+        ("lhs", TypeSig.YEARMONTH, TypeSig.YEARMONTH),
+        ("rhs", TypeSig.gpuNumeric - TypeSig.DECIMAL_128, TypeSig.gpuNumeric)),
+      (a, conf, p, r) => new BinaryExprMeta[MultiplyYMInterval](a, conf, p, r) {
+        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+          GpuMultiplyYMInterval(lhs, rhs)
+      }),
+    GpuOverrides.expr[DivideYMInterval](
+      "Year-month interval / number",
+      ExprChecks.binaryProject(
+        TypeSig.YEARMONTH,
+        TypeSig.YEARMONTH,
+        ("lhs", TypeSig.YEARMONTH, TypeSig.YEARMONTH),
+        ("rhs", TypeSig.gpuNumeric - TypeSig.DECIMAL_128, TypeSig.gpuNumeric)),
+      (a, conf, p, r) => new BinaryExprMeta[DivideYMInterval](a, conf, p, r) {
+        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+          GpuDivideYMInterval(lhs, rhs)
+      })
+  ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r))
+    .toMap[Class[_ <: Expression], ExprRule[_ <: Expression]]
+}

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -52,7 +52,8 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims {
         }),
       GpuElementAtMeta.elementAtRule(true)
     ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
-    super.getExprs ++ shimExprs ++ DayTimeIntervalShims.exprs ++ RoundingShims.exprs
+    super.getExprs ++ shimExprs ++ YearMonthIntervalShims.exprs ++
+      DayTimeIntervalShims.exprs ++ RoundingShims.exprs
   }
 
   override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +25 lines** (23 in `YearMonthIntervalShims` and 2 in `Spark330PlusShims`; shim-330 fix-line intersection).

Closes #15248.

## Description

Restore the YearMonthInterval multiply/divide integration coverage from #14938 and make the corresponding GPU rules available to Databricks shims.

The rules for `MultiplyYMInterval` and `DivideYMInterval` were previously registered only by `Spark330PlusShims`, which belongs to the non-Databricks shim hierarchy. Databricks uses `Spark330PlusDBShims`, so those expressions were never registered there and strict integration tests rejected their `GpuCpuBridgeExpression` fallback.

This change moves the two rules into a shared `YearMonthIntervalShims` map and merges it from both the Apache and Databricks Spark 3.3+ shim traits. It also restores the strict GPU-vs-CPU Python integration tests without a Databricks skip or CPU allowlist.

## Validation

- Shim coverage: `check-shim-coverage.sh` passed for all 30 Apache/Databricks shims listed by the two traits.
- Style/license: `mvn verify -DskipTests -pl sql-plugin -am -Dbuildver=330` — `BUILD SUCCESS`; Scalastyle processed 1,682 files with 0 errors/0 warnings, RAT reported 0 unapproved files.
- Compile-only matrix: buildver 330, 340, and Scala 2.13 buildver 400 — `BUILD SUCCESS` for each.
- Scala: `IntervalMultiplySuite,IntervalDivisionSuite` — `Tests: succeeded 219, failed 0, canceled 0, ignored 0, pending 0`.
- Apache Spark 3.5 Python IT: `arithmetic_ops_test.py -k year_month_interval` — `10 passed, 1485 deselected`.
- DBR 13.3 / Spark 3.4.1 / buildver 341db: full reactor `BUILD SUCCESS` (08:45); focused IT `10 passed, 1485 deselected` (JUnit: tests=10, failures=0, errors=0, skipped=0).
- DBR 14.3 / Spark 3.5.0 / buildver 350db143: full reactor `BUILD SUCCESS` (08:35); focused IT `10 passed, 1485 deselected` (JUnit: tests=10, failures=0, errors=0, skipped=0).
- DBR 17.3 / Spark 4.0.0 / buildver 400db173: full Scala 2.13 reactor `BUILD SUCCESS` (24:12); focused IT `10 passed, 1485 deselected` (JUnit: tests=10, failures=0, errors=0, skipped=0).

JaCoCo was measured from a clean run of the two affected Scala suites. The repository helper does not currently recognize shim-routed `src/main/spark*/scala` paths, so the diff paths were normalized to `src/main/scala` before applying the same `fixline_intersect.py` algorithm: `FIXLINE_COVERED=25 (of 87 added production lines)`.

## Performance impact

Cold path only: this constructs two expression-rule entries during shim rule discovery. The execution kernels and per-row arithmetic paths are unchanged, so no runtime benchmark is required.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
