### PR TITLE
Xfail CSV control-character test on EMR 7.13+

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -106,7 +106,7 @@ def is_emr_version_or_later(major, minor):
 
     version = os.environ.get('EMR_VERSION')
     if version is None:
-        raise RuntimeError('EMR_VERSION must be set for the EMR runtime')
+        return False
 
     # The EMR test runner supplies <major>.<minor> or <major>.<minor>.<patch>.
     version_parts = version.split('.')

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -104,14 +104,17 @@ def is_emr_version_or_later(major, minor):
     if not is_emr_runtime():
         return False
 
-    version_parts = os.environ.get('EMR_VERSION', '').split('.')
-    if len(version_parts) < 2:
-        return False
+    version = os.environ.get('EMR_VERSION')
+    if version is None:
+        raise RuntimeError('EMR_VERSION must be set for the EMR runtime')
 
-    try:
-        emr_version = (int(version_parts[0]), int(version_parts[1]))
-    except ValueError:
-        return False
+    # The EMR test runner supplies <major>.<minor> or <major>.<minor>.<patch>.
+    version_parts = version.split('.')
+    if len(version_parts) not in (2, 3) or not all(part.isdigit() for part in version_parts):
+        raise ValueError(
+            f'EMR_VERSION must use <major>.<minor>[.<patch>] format, got {version!r}')
+
+    emr_version = (int(version_parts[0]), int(version_parts[1]))
 
     return emr_version >= (major, minor)
 

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -100,6 +100,21 @@ def is_databricks_runtime():
 def is_emr_runtime():
     return runtime_env() == "emr"
 
+def is_emr_version_or_later(major, minor):
+    if not is_emr_runtime():
+        return False
+
+    version_parts = os.environ.get('EMR_VERSION', '').split('.')
+    if len(version_parts) < 2:
+        return False
+
+    try:
+        emr_version = (int(version_parts[0]), int(version_parts[1]))
+    except ValueError:
+        return False
+
+    return emr_version >= (major, minor)
+
 def is_dataproc_runtime():
     return runtime_env() == "dataproc"
 

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 from asserts import *
-from conftest import get_non_gpu_allowed, is_emr_version_or_later, is_not_utc, is_gbk_supported
+from conftest import get_non_gpu_allowed, is_emr_runtime, is_emr_version_or_later, is_not_utc, is_gbk_supported
 from datetime import datetime, timezone
 from data_gen import *
 from marks import *
@@ -721,7 +721,7 @@ def test_csv_read_gbk_encoded_data(std_input_path):
 
 @pytest.mark.parametrize('v1_enabled_list', ["", "csv"])
 @pytest.mark.xfail(
-    condition=is_emr_version_or_later(7, 13),
+    condition=is_emr_runtime() and is_emr_version_or_later(7, 13),
     reason='EMR 7.13+ CPU CSV behavior differs from OSS Spark; '
            'see https://github.com/NVIDIA/cudf-spark/issues/15254')
 def test_csv_read_blank_lines_with_control_chars(std_input_path, v1_enabled_list):

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -723,7 +723,8 @@ def test_csv_read_gbk_encoded_data(std_input_path):
 @pytest.mark.xfail(
     condition=is_emr_runtime() and is_emr_version_or_later(7, 13),
     reason='EMR 7.13+ CPU CSV behavior differs from OSS Spark; '
-           'see https://github.com/NVIDIA/cudf-spark/issues/15254')
+           'see https://github.com/NVIDIA/cudf-spark/issues/15254',
+    strict=True)
 def test_csv_read_blank_lines_with_control_chars(std_input_path, v1_enabled_list):
     """Verify that lines consisting only of control characters (<= 0x20) are filtered out,
     matching Spark CPU behavior (CSVExprUtils.filterCommentAndEmpty uses String.trim)."""

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 from asserts import *
-from conftest import get_non_gpu_allowed, is_not_utc, is_gbk_supported
+from conftest import get_non_gpu_allowed, is_emr_version_or_later, is_not_utc, is_gbk_supported
 from datetime import datetime, timezone
 from data_gen import *
 from marks import *
@@ -720,6 +720,10 @@ def test_csv_read_gbk_encoded_data(std_input_path):
         conf={"spark.sql.legacy.javaCharsets": legacy_charset})
 
 @pytest.mark.parametrize('v1_enabled_list', ["", "csv"])
+@pytest.mark.xfail(
+    condition=is_emr_version_or_later(7, 13),
+    reason='EMR 7.13+ CPU CSV behavior differs from OSS Spark; '
+           'see https://github.com/NVIDIA/cudf-spark/issues/15254')
 def test_csv_read_blank_lines_with_control_chars(std_input_path, v1_enabled_list):
     """Verify that lines consisting only of control characters (<= 0x20) are filtered out,
     matching Spark CPU behavior (CSVExprUtils.filterCommentAndEmpty uses String.trim)."""

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 from asserts import *
-from conftest import get_non_gpu_allowed, is_emr_runtime, is_emr_version_or_later, is_not_utc, is_gbk_supported
+from conftest import get_non_gpu_allowed, is_emr_version_or_later, is_not_utc, is_gbk_supported
 from datetime import datetime, timezone
 from data_gen import *
 from marks import *
@@ -721,7 +721,7 @@ def test_csv_read_gbk_encoded_data(std_input_path):
 
 @pytest.mark.parametrize('v1_enabled_list', ["", "csv"])
 @pytest.mark.xfail(
-    condition=is_emr_runtime() and is_emr_version_or_later(7, 13),
+    condition=is_emr_version_or_later(7, 13),
     reason='EMR 7.13+ CPU CSV behavior differs from OSS Spark; '
            'see https://github.com/NVIDIA/cudf-spark/issues/15254',
     strict=True)


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15254.

### Description

EMR 7.13 and later return control-character-only CSV rows on CPU, unlike OSS Spark and earlier EMR releases. The GPU reader continues to follow OSS Spark behavior, so `test_csv_read_blank_lines_with_control_chars` reports a CPU/GPU mismatch on those releases.

Add a reusable EMR release comparison helper based on the test runner's `EMR_VERSION`, and mark this test expected to fail on EMR 7.13 and later. This keeps EMR 7.9 and 7.12 as normal passing coverage and avoids encoding runtime-private implementation details in the public plugin.

Validation:

- EMR 7.12: `test_csv_read_blank_lines_with_control_chars` — 2 passed.
- EMR 7.13: `test_csv_read_blank_lines_with_control_chars` — 2 xfailed with issue #15254 in the reason.
- Python version-boundary checks for 7.12, 7.13, 7.13.0, 8.0, and non-EMR runtime.
- `git diff --check`
- `python3 -m py_compile integration_tests/src/main/python/conftest.py integration_tests/src/main/python/csv_test.py`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
