### PR TITLE
[SkipRecovery] Re-enable Spark 3.5 Hive simple UDF test [databricks]

### DIFF
--- a/integration_tests/src/main/python/row-based_udf_test.py
+++ b/integration_tests/src/main/python/row-based_udf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from asserts import assert_gpu_and_cpu_are_equal_sql
-from data_gen import *
-from spark_session import with_spark_session, is_spark_350_or_later
 from conftest import skip_unless_precommit_tests
+from data_gen import *
+from spark_session import with_spark_session
 
 def drop_udf(spark, udfname):
     spark.sql("DROP TEMPORARY FUNCTION IF EXISTS {}".format(udfname))
@@ -31,8 +29,6 @@ def load_hive_udf(spark, udfname, udfclass):
     # if UDF failed to load, throws AnalysisException, check if the udf class is in the class path
     spark.sql("CREATE TEMPORARY FUNCTION {} AS '{}'".format(udfname, udfclass))
 
-@pytest.mark.xfail(condition=is_spark_350_or_later(),
-                   reason='https://github.com/NVIDIA/spark-rapids/issues/9064')
 def test_hive_empty_simple_udf():
 
     with_spark_session(skip_if_no_hive)

--- a/integration_tests/src/main/python/row-based_udf_test.py
+++ b/integration_tests/src/main/python/row-based_udf_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from asserts import assert_gpu_and_cpu_are_equal_sql
 from conftest import skip_unless_precommit_tests
 from data_gen import *
-from spark_session import with_spark_session
+from spark_session import is_spark_400_or_later, with_spark_session
 
 def drop_udf(spark, udfname):
     spark.sql("DROP TEMPORARY FUNCTION IF EXISTS {}".format(udfname))
@@ -29,6 +31,8 @@ def load_hive_udf(spark, udfname, udfclass):
     # if UDF failed to load, throws AnalysisException, check if the udf class is in the class path
     spark.sql("CREATE TEMPORARY FUNCTION {} AS '{}'".format(udfname, udfclass))
 
+@pytest.mark.xfail(condition=is_spark_400_or_later(),
+                   reason='https://github.com/NVIDIA/cudf-spark/issues/15268')
 def test_hive_empty_simple_udf():
 
     with_spark_session(skip_if_no_hive)


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350 vs nightly 5a3faf4c/b9; the raw +2 was only the excluded MemoryCheckerImpl local GPU initialization artifact)

## Summary

- Re-enable `test_hive_empty_simple_udf` on Spark 3.5 after the support fix in #9099.
- Keep the test xfailed only on Spark 4+, linked to #15268, after Blossom and a local Spark 4.0.1 GPU/CPU reproduction confirmed the distinct `LlapSigner$Signable` classpath failure.
- Keep the test body and its CPU/GPU parity assertion unchanged.

Contributes to #9064 and #15268.

## Validation

- Spark 3.5.0 exact node: `1 passed, 39573 deselected, 16 warnings in 11.45s`.
- Spark 4.0.1 / Scala 2.13 exact node: `1 xfailed, 39574 deselected, 145 warnings in 9.04s`; the xfail matched `NoClassDefFoundError: org/apache/hadoop/hive/llap/security/LlapSigner$Signable`.
- Spark 4.0.1 / Scala 2.13 integration-test build: all 11 reactor modules succeeded; `BUILD SUCCESS`.
- Standalone Spark 4.0.1 reproduction confirmed RAPIDS enabled, plugins loaded, GPU operators present, GPU failure, and successful CPU results in the same session; filed #15268 with the evidence.
- Static checks: `git diff --check` and Python `py_compile` passed.
- JaCoCo exact Spark 3.5 test at the matching nightly anchor previously reported a net increment of `+0` after excluding the recurring `MemoryCheckerImpl +2` initialization artifact.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

