### PR TITLE
[AutoSparkUT] Re-enable escaped json_tuple test

### DIFF
--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -1027,7 +1027,7 @@ def test_get_json_object_child_formats(std_input_path, input_file):
     "int_struct_formatted_problematic_rows.json",
     "int_mixed_array_struct_formatted.json",
     "bad_whitespace.json",
-    pytest.param("escaped_strings.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11386')),
+    "escaped_strings.json",
     pytest.param("nested_escaped_strings.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11387')),
     pytest.param("repeated_columns.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11361')),
     "mixed_objects.json",


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350 vs nightly b9; the raw +2 was only the recurring MemoryCheckerImpl local-GPU-init artifact)

## Summary

- Re-enable the escaped_strings.json parameter in test_json_tuple_formats after the #11386 fix.
- Keep the independent nested_escaped_strings.json (#11387) and repeated_columns.json (#11361) xfails unchanged.
- Preserve the existing test logic and CPU/GPU parity assertions.

Contributes to #11386

## Validation

- mvn package -DskipTests -pl dist,integration_tests -am -Dbuildver=350 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm: BUILD SUCCESS; 11/11 reactor modules succeeded.
- Focused marker-free Spark 3.5 test: 1 passed, 5 warnings in 3.94s.
- Full json_matrix_test.py: 955 passed, 76 xfailed, 4 xpassed, 47 warnings in 147.13s.
- The focused event log contains GpuProject, GpuGenerate, and GpuColumnarToRow.
- git diff --check and Python bytecode compilation passed.
- A Spark 4 runtime gate was not run locally because no Spark 4 distribution was available.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
