### PR TITLE
[AutoSparkUT] Re-enable Iceberg delete fallback test [databricks]

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -315,7 +315,6 @@ def test_iceberg_delete_nested_types(spark_tmp_table_factory, delete_mode):
     pytest.param('copy-on-write', 'ReplaceDataExec', id='cow'),
     pytest.param('merge-on-read', 'WriteDeltaExec', id='mor')
 ])
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/13649")
 def test_iceberg_delete_fallback_iceberg_disabled(spark_tmp_table_factory, delete_mode, fallback_exec):
     """Test DELETE falls back when Iceberg is completely disabled (both modes)"""
     base_table_name = get_full_table_name(spark_tmp_table_factory)


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (focused Spark 3.5/Iceberg 1.6.1 run; raw +2 was the recurring MemoryCheckerImpl local-GPU-init artifact and was excluded)

Contributes to #13649

Summary

- Remove the stale function-level xfail from test_iceberg_delete_fallback_iceberg_disabled.
- Preserve both copy-on-write and merge-on-read fallback expectations and all test semantics.
- Recover the existing fallback test after the HostColumnarToGpu BinaryType fix merged in #14702; this PR does not claim new binary-specific IT coverage.

Validation

- Fresh Spark 3.5.0 / Iceberg 1.6.1 build: 11/11 reactor modules succeeded.
- Baseline with xfail bypassed: 2 passed, 5 warnings in 15.96s.
- Marker-free focused test: 2 passed, 5 warnings in 15.30s.
- Full iceberg_delete_test.py: 30 passed, 5 warnings in 313.56s.
- Event logs contain HostColumnarToGpu and the expected ReplaceDataExec and WriteDeltaExec fallback paths.
- Independent focused review found no actionable findings.
- Spark 4 was not run because no local Spark 4 distribution is available.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required