### PR TITLE
Fix changelog filtering for bot co-author trailers [skip ci]

### DIFF
--- a/scripts/generate-changelog
+++ b/scripts/generate-changelog
@@ -225,11 +225,10 @@ def get_commits(releases: set):
         else:
             from_branch = f"origin/release/{from_rel}"
 
-        # Get all the commit hashes, excluding those commits whose title contains '[bot]'
+        # Get all commit hashes. Automated PRs are filtered using the actual PR title later.
         git_log_args = [
             "git", "--no-pager", "log",
-            f"{from_branch}..{to_branch}", "--pretty=format:%h",
-            "--grep=[bot]", "-F", "--invert-grep"
+            f"{from_branch}..{to_branch}", "--pretty=format:%h"
         ]
 
         # Use check=True to raise exception if git fails, making errors explicit


### PR DESCRIPTION
The changelog generator previously used git log --grep to exclude commits containing [bot]. Git searches the entire commit message, so human-authored PRs were incorrectly omitted when a bot appeared only in a Co-authored-by trailer.

Collect all release-range commits and defer automated-PR filtering until the associated GitHub PR is resolved. The existing PR-title check continues to exclude PRs whose actual title contains [bot], while preserving human PRs with bot co-authors.

Fixes #15244

- The fix moves the [bot] decision to the correct data source: the PR title https://github.com/NvTimLiu/spark-rapids/blob/599eb2b1c446dfae20de1b819ab1beb651fcc64e/scripts/generate-changelog#L280.

  Before:

  Git commit message
  ├── Subject: Human-authored change (#13921)
  └── Trailer: Co-authored-by: greptile-apps[bot]
                           ↓
  git log --grep searches the entire message
                           ↓
  Commit incorrectly excluded

  After:

  1. get_commits() collects every commit SHA.
  2. get_pr_via_commits() retrieves the associated PR.
  3. process_changelog() checks the actual PR title:

  if '[bot]' in item['title']:
      continue

  Therefore:

  - Human PR title + bot co-author trailer → included.
  - Automated PR whose actual title contains [bot] → still excluded.

  The only tradeoff is a few additional GitHub API lookups for bot commits,
  but the filtering behavior remains correct.


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
