### PR TITLE
[cudf-udf]: fix conda dependency resolution and CUDA header discovery [skip test]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -564,7 +564,7 @@ if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
   CUDF_VER=$(echo "${PROJECT_VER}" | cut -d '.' -f 1,2)
   CUDA_VER_FOR_CUDF=${CUDA_VER_FOR_CUDF:-'12.9'}
 
-  conda create -y -n ${CUDF_UDF_ENV} -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
+  conda create -y -n ${CUDF_UDF_ENV} -c rapidsai-nightly -c conda-forge -c nvidia -c defaults \
     python=${CUDF_UDF_PYTHON_VER} pip cudf=${CUDF_VER} cuda-version=${CUDA_VER_FOR_CUDF}
 
   # Activate the cudf_udf env and reset PYTHONPATH to use the new env's site-packages
@@ -585,6 +585,7 @@ if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
     PYSP_TEST_spark_rapids_memory_gpu_minAllocFraction=0 \
     PYSP_TEST_spark_rapids_python_memory_gpu_allocFraction=0.1 \
     PYSP_TEST_spark_rapids_python_concurrentPythonWorkers=2 \
+    PYSP_TEST_spark_executorEnv_CONDA_PREFIX=${CONDA_PREFIX} \
     PYSP_TEST_spark_executorEnv_PYTHONPATH=${RAPIDS_PLUGIN_JAR} \
     ./run_pyspark_from_build.sh -m cudf_udf --cudf_udf
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark/issues/15247. 

Verified this fix in internal pipeline

### Description

Fix the cuDF UDF test environment after the CuPy 14 upgrade introduced newer cuda-pathfinder requirements. This allows Conda dependency resolution to complete and ensures Spark executors can discover the CUDA headers installed in the cuDF Conda environment.

#### Changes
Prioritize conda-forge ahead of the nvidia channel so the CuPy 14 dependency graph can resolve a compatible cuda-pathfinder.
Propagate CONDA_PREFIX through spark.executorEnv.CONDA_PREFIX so CuPy 14 can locate Conda-installed CUDA headers in Python workers.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
