### PR TITLE
[SkipRecovery] Re-enable CSV null parsing test [databricks]

### DIFF
--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -255,8 +255,18 @@ def test_basic_csv_read(std_input_path, name, schema, options, read_func, v1_ena
         'spark.sql.sources.useV1SourceList': v1_enabled_list,
         'spark.sql.ansi.enabled': ansi_enabled
     })
-    assert_gpu_and_cpu_are_equal_collect(read_func(std_input_path + '/' + name, schema, spark_tmp_table_factory, options),
-            conf=updated_conf)
+    read = read_func(std_input_path + '/' + name, schema, spark_tmp_table_factory, options)
+    if name == 'trucks-null.csv' and 'nullValue' not in options:
+        if v1_enabled_list == 'csv':
+            gpu_scan = 'GpuFileSourceScanExec'
+        elif read_func is read_csv_sql:
+            gpu_scan = 'GpuFileSourceScanExec'
+        else:
+            gpu_scan = 'GpuBatchScanExec'
+        assert_cpu_and_gpu_are_equal_collect_with_capture(
+            read, exist_classes=gpu_scan, conf=updated_conf)
+    else:
+        assert_gpu_and_cpu_are_equal_collect(read, conf=updated_conf)
 
 @pytest.mark.parametrize('name,schema,options', [
     pytest.param('small_float_values.csv', _float_schema, {'header': 'true'}),

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -214,7 +214,7 @@ def read_csv_sql(data_path, schema, spark_tmp_table_factory, options = {}):
     ('trucks-more-comments.csv', _trucks_schema,  {'header': 'true', 'comment': '#'}),
     pytest.param('trucks-missing-quotes.csv', _trucks_schema, {'header': 'true'}, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/130')),
     pytest.param('trucks-null.csv', _trucks_schema, {'header': 'true', 'nullValue': 'null'}, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/2068')),
-    pytest.param('trucks-null.csv', _trucks_schema, {'header': 'true'}, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/1986')),
+    ('trucks-null.csv', _trucks_schema, {'header': 'true'}),
     pytest.param('simple_int_values.csv', _byte_schema, {'header': 'true'}),
     pytest.param('simple_int_values.csv', _short_schema, {'header': 'true'}),
     pytest.param('simple_int_values.csv', _int_schema, {'header': 'true'}),


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350, vs nightly b9; excluded recurring MemoryCheckerImpl +2 GPU-init artifact)

## Summary

- Remove the stale xfail linked to #1986 from the `trucks-null.csv` CSV-read parameter.
- Keep the same test data, schema, options, and 8-way DataFrame/SQL × V1/V2 × ANSI matrix.
- Require the recovered parameter to contain the expected concrete GPU CSV scan class, so the existing non-UTC fallback allowances cannot hide a CPU scan.
- Preserve the adjacent #2068 xfail and all other CSV exemptions.

The product fix was merged in #4790 and is present on current main. The previously masked matrix now passes with GPU CSV scan execution.

Contributes to #1986

## Testing

- Build: `mvn package -DskipTests -pl dist,integration_tests -am -Dbuildver=350 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm`
  - `BUILD SUCCESS`; 11/11 reactor modules succeeded.
- Final strict focused matrix, `TZ=UTC`: `8 passed, 408 deselected` across DataFrame/SQL, V1/V2, and ANSI on/off.
- Final strict focused matrix, `TZ=Asia/Shanghai`: `8 passed, 408 deselected` across the same matrix.
- Full `csv_test.py` after adding the parameter-scoped capture assertion: `838 passed, 160 skipped, 44 xfailed, 84 xpassed` (1126 collected; exit code 0).
- JaCoCo focused rerun: `8 passed, 408 deselected`; raw sql-plugin delta `+2`, solely the recurring `MemoryCheckerImpl` GPU-init artifact, for a reported net `+0`.
- NT local review: no must-fix or should-fix findings; its concrete-class identifier suggestion was adopted and revalidated in both time zones.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
