### PR TITLE
[BUG] Preserve unmatched regexp_extract_all captures

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -37,6 +37,7 @@ import com.nvidia.spark.rapids.jni.RegexRewriteUtils
 import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimExpression, SparkShimImpl}
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.errors.ConvUtils
 import org.apache.spark.sql.rapids.catalyst.expressions._
 import org.apache.spark.sql.types._
@@ -1753,58 +1754,44 @@ case class GpuRegExpExtractAll(
           EnumSet.of(RegexFlag.EXT_NEWLINE), CaptureGroups.NON_CAPTURE)
         str.getBase.extractAllRecord(prog, 0)
       case _ =>
-        // Extract matches corresponding to idx. cuDF's extract_all_record does not support
-        // group idx, so we must manually extract the relevant matches. Example:
-        // Given the pattern (\d+)-(\d+) and idx=1
-        //
-        // |      Input      |      Java       |               cuDF             |
-        // |-----------------|-----------------|--------------------------------|
-        // | '1-2, 3-4, 5-6' | ['1', '3', '5'] | ['1', '2', '3', '4', '5', '6'] |
-        //
-        // Since idx=1 and the pattern has 2 capture groups, we take the 1st element and every
-        // 2nd element afterwards from the cuDF list
-
         val rowCount = str.getRowCount
         val prog = new RegexProgram(cudfRegexPattern, EnumSet.of(RegexFlag.EXT_NEWLINE))
 
-        val extractedWithNulls = withResource(
-          // Now the index is always 1 because we have transpiled all the capture groups to the
-          // single group that we care about, so we just have to handle the idx = 1 case here
-          str.getBase.extractAllRecord(prog, 1)) { allExtracted =>
-            withResource(allExtracted.countElements) { listSizes =>
-              withResource(listSizes.max) { maxSize =>
-                val maxSizeInt = maxSize.getInt
-                val stringCols = Range(0, maxSizeInt, 1).safeMap {
-                  i =>
-                    allExtracted.extractListElement(i)
-                }
-                withResource(stringCols) { _ =>
-                  ColumnVector.makeList(rowCount, DType.STRING, stringCols: _*)
+        // The transpiler leaves only the requested group as a capture group, so cuDF already
+        // returns one list element per regex match. Align the remaining result semantics with
+        // Spark: an unmatched capture is an empty string, no matches is an empty list, and a
+        // null input is a null list.
+        withResource(str.getBase.extractAllRecord(prog, 1)) { extracted =>
+          val noMatchesAsEmptyLists = withResource(GpuScalar.from(
+            new GenericArrayData(Array.empty[Any]), dataType)) { emptyStringList =>
+            // cuDF returns a zero-row list column when the entire input has no matches.
+            // Restore the input row count before applying Spark's null-input semantics.
+            if (extracted.getRowCount == 0) {
+              ColumnVector.fromScalar(emptyStringList, rowCount.toInt)
+            } else {
+              val capturesWithEmptyStrings = withResource(extracted.getChildColumnView(0)) {
+                captures =>
+                  withResource(Scalar.fromString("")) { emptyString =>
+                    withResource(captures.replaceNulls(emptyString)) { normalizedCaptures =>
+                      withResource(extracted.replaceListChild(normalizedCaptures)) {
+                        _.copyToColumnVector()
+                      }
+                    }
+                  }
+              }
+              withResource(capturesWithEmptyStrings) { normalized =>
+                withResource(normalized.isNull) { noMatchesOrNullInput =>
+                  noMatchesOrNullInput.ifElse(emptyStringList, normalized)
                 }
               }
             }
           }
-        // Filter out null values in the lists
-        val extractedStrings = withResource(extractedWithNulls) { _ =>
-          val booleanMask = withResource(extractedWithNulls.getListOffsetsView) { offsetsCol =>
-            withResource(extractedWithNulls.getChildColumnView(0)) { stringCol =>
-              withResource(stringCol.isNotNull) { isNotNull =>
-                isNotNull.makeListFromOffsets(rowCount, offsetsCol)
-              }
-            }
-          }
-          withResource(booleanMask) {
-            extractedWithNulls.applyBooleanMask
-          }
-        }
-
-        // If input is null, output should also be null
-        withResource(extractedStrings) { s =>
-          withResource(GpuScalar.from(null, DataTypes.createArrayType(DataTypes.StringType))) {
-            nullStringList =>
+          withResource(noMatchesAsEmptyLists) { normalized =>
+            withResource(GpuScalar.from(null, dataType)) { nullStringList =>
               withResource(str.getBase.isNull) { isInputNull =>
-                isInputNull.ifElse(nullStringList, s)
+                isInputNull.ifElse(nullStringList, normalized)
               }
+            }
           }
         }
     }


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +17 lines** (17 of 30 added production lines covered by `test_regexp_extract_all_idx_positive`, shim 401)

Contributes to #15281.

## Root cause

[rapidsai/cudf#23123](https://github.com/rapidsai/cudf/pull/23123) corrected `extract_all_record` so a capture group that does not participate in a match returns null instead of an empty string. `GpuRegExpExtractAll` subsequently removed null list children with a boolean mask. For alternations such as `(a)|(b)`, that deleted the requested but unmatched capture entirely, producing `[]` where Spark returns `[""]`.

The interval failures reported by the same issue are handled separately by #15280.

## Fix

- Keep cuDF's variable-length list result instead of transposing it through a rectangular list of columns.
- Replace null capture children with empty strings to implement Spark's unmatched-capture semantics.
- Normalize no-match rows to empty lists and restore null input rows to null lists.
- Explicitly restore the input row count when cuDF returns a zero-row list column for an all-no-match batch.

This treats cuDF's null capture as an explicit library boundary and preserves the three distinct Spark results: unmatched capture `[""]`, no match `[]`, and null input `null`.

## Validation

- Baseline Spark 4.0.1 reproduction: `3 failed, 39627 deselected` for `test_regexp_extract_all_idx_positive` at 4, 40, and 400 slices.
- Fixed Spark 4.0.1 regression: `3 passed, 39627 deselected` in 67.86s.
- Forced OOM injection: `3 passed, 39627 deselected` in 68.23s.
- Scala 2.13 / Spark 4.0.1 full distribution build: `BUILD SUCCESS` (10 reactor modules).
- Scala 2.12 / Spark 3.3.0 sql-plugin build: `BUILD SUCCESS`.
- JaCoCo fix-line intersection: 17 of 30 added production lines covered by `test_regexp_extract_all_idx_positive`.

## Performance impact

A local Spark 4.0.1 GPU microbenchmark processed 5,000,000 alternating-capture rows for five measured iterations after warm-up. Median runtime improved from 0.538s on `main` to 0.464s with this change (about 13.7%). The new path removes the maximum-list-width scan, per-position extraction, list reconstruction, and boolean-mask filtering; it uses child null replacement plus list-level null normalization instead.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`regexp_test.py::test_regexp_extract_all_idx_positive`, including 4, 40, and 400 slices.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
