### PR TITLE
Fix regexp_replace no-op when '+' is the only metacharacter [databricks]

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -309,6 +309,7 @@ def test_re_replace_repetition():
                 'REGEXP_REPLACE(a, "A{0,}", "PROD")',
                 'REGEXP_REPLACE(a, "T?E?", "PROD")',
                 'REGEXP_REPLACE(a, "A*", "PROD")',
+                'REGEXP_REPLACE(a, "A+", "PROD")',
                 'REGEXP_REPLACE(a, "A{0,5}", "PROD")',
                 'REGEXP_REPLACE(a, "(A*)", "PROD")',
                 'REGEXP_REPLACE(a, "(((A*)))", "PROD")',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -469,7 +469,7 @@ object GpuOverrides extends Logging {
   private[this] lazy val regexList: Seq[String] = Seq("\\", "\u0000", "\\x", "\t", "\n", "\r",
     "\f", "\\a", "\\e", "\\cx", "[", "]", "^", "&", ".", "*", "\\d", "\\D", "\\h", "\\H", "\\s",
     "\\S", "\\v", "\\V", "\\w", "\\w", "\\p", "$", "\\b", "\\B", "\\A", "\\G", "\\Z", "\\z", "\\R",
-    "?", "|", "(", ")", "{", "}", "\\k", "\\Q", "\\E", ":", "!", "<=", ">")
+    "?", "+", "|", "(", ")", "{", "}", "\\k", "\\Q", "\\E", ":", "!", "<=", ">")
   val regexMetaChars = ".$^[]\\|?*+(){}"
   /**
    * Provides a way to log an info message about how long an operation took in milliseconds.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -324,6 +324,18 @@ class RegExpUtilsSuite extends AnyFunSuite {
     assert(conv2 == open + "1}3",
       s"expected user `$$13` to back off to `$${1}3`, got `$conv2`")
   }
+
+  test("isSupportedStringReplacePattern classifies regex patterns correctly") {
+    val cases = Seq(
+      "A" -> true,
+      "A*" -> false,
+      "(A)" -> false,
+      "A+" -> false)
+
+    cases.foreach { case (pattern, expected) =>
+      assert(GpuOverrides.isSupportedStringReplacePattern(pattern) == expected)
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
Fixes #15288.

### Description

On the GPU, `regexp_replace` silently returned the input unchanged for patterns whose only regex metacharacter is `'+'` (e.g. `'a+'`, `'a+b'`, `'ba+'`), while Spark CPU replaced the matches. This was only an issue for `regexp_replace`, and only with `'+'`, which is why it went unnoticed — other functions like `rlike`/`regexp_extract`/`split` were all correct, as was `regexp_replace` with grouped and character-class equivalents (`'(a)+'`, `'[a]+'`, `'aa*'`, `'a{1,}'`, etc).

This adds the missing `"+"` to the list of regex special characters. Once classified properly by the plugin, cuDF's regex engine handles these patterns correctly.

Added unit tests for the classifier, and the missing cases to the `regexp_replace` integration test.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
