### PR TITLE
Fix Iceberg REST compression defaults

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -563,13 +563,17 @@ partition type to keep memory usage manageable.
 
 #### Iceberg REST catalog write compression
 
-Some REST catalog deployments can apply a catalog-side default Parquet compression codec that
-is not supported by the RAPIDS GPU writer. The REST catalog CI sets table defaults for data
-and delete files to use `zstd`, which is supported by the GPU writer:
+Older Iceberg REST clients, including 1.6.x, do not apply client-side
+`spark.sql.catalog.*.table-default.*` settings when creating REST tables. The resulting tables
+can use a default Parquet compression codec that is not supported by the RAPIDS GPU writer.
+REST catalog tests therefore add explicit table properties for data and delete files to use
+`zstd`, which is supported by the GPU writer:
 
-```shell
-"PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_parquet_compression-codec=zstd"
-"PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_delete_parquet_compression-codec=zstd"
+```sql
+TBLPROPERTIES (
+  'write.parquet.compression-codec' = 'zstd',
+  'write.delete.parquet.compression-codec' = 'zstd'
+)
 ```
 
 ### Run Apache iceberg s3tables tests

--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -23,7 +23,7 @@ from pyspark.sql.types import FloatType, DoubleType, BinaryType
 
 import pytest
 
-from conftest import spark_jvm
+from conftest import is_iceberg_rest_catalog, spark_jvm
 from data_gen import *
 from spark_session import is_iceberg_supported_spark, with_cpu_session
 
@@ -297,9 +297,18 @@ def schema_to_ddl(spark, schema):
 
 
 # Base table properties applied to every Iceberg test table.
-# Disables the fanout writer to prevent OOM in CI.  S3TablesCatalog does not
+# Disables the fanout writer to prevent OOM in CI. S3TablesCatalog does not
 # honor catalog-level table-default properties, so this must be set per table.
 _BASE_TBLPROPS = {'write.spark.fanout.enabled': False}
+
+# Older Iceberg REST clients, including 1.6.x, do not apply catalog table-default
+# properties when creating a table. Apply supported codecs directly to REST test
+# tables so writes do not fall back to gzip and then to CPU.
+if is_iceberg_rest_catalog():
+    _BASE_TBLPROPS.update({
+        'write.parquet.compression-codec': 'zstd',
+        'write.delete.parquet.compression-codec': 'zstd',
+    })
 
 
 def _to_tblprops_str(props: dict) -> dict:

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -350,8 +350,6 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
           # filecache.enabled is a startup-only config, so it must be set here via
           # PYSP_TEST_ env var rather than as a session-level Spark config, because
           # FileCacheManager is initialized at executor startup time.
-          # Some REST catalog defaults resolve Iceberg Parquet writes to gzip, which
-          # is not supported by the GPU writer, so use a supported default codec.
           env \
             HOST_NAME=$PROJECT_REPO_HOST \
             EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
@@ -370,8 +368,6 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
             "PYSP_TEST_spark_sql_catalog_spark__catalog_oauth2-server-uri=${ICEBERG_REST_OAUTH2_SERVER_URI:-http://localhost:8080/realms/iceberg/protocol/openid-connect/token}" \
             PYSP_TEST_spark_sql_catalog_spark__catalog_scope="${ICEBERG_REST_SCOPE:-lakekeeper}" \
             PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="${ICEBERG_REST_WAREHOUSE:-demo}" \
-            "PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_parquet_compression-codec=zstd" \
-            "PYSP_TEST_spark_sql_catalog_spark__catalog_table-default_write_delete_parquet_compression-codec=zstd" \
             ./run_pyspark_from_build.sh -m iceberg --iceberg
     elif [[ "$test_type" == "s3tables" ]]; then
       echo "!!! Running iceberg tests with s3tables"


### PR DESCRIPTION
Fixes #15274.

### Description

Iceberg REST catalog write tests can resolve the Parquet compression codec to `gzip`, which is not supported by the GPU writer. The previous catalog-level fix is effective with Iceberg 1.9.x and 1.10.x, but Iceberg 1.6.x does not apply `table-default.*` properties when creating REST tables.

This change sets `write.parquet.compression-codec=zstd` and `write.delete.parquet.compression-codec=zstd` directly on every REST test table. It also removes the version-dependent catalog defaults from `jenkins/spark-tests.sh` and documents the compatibility behavior.

Validation:

- `test_insert_into_aqe[unpartitioned]` passed.
- `test_delete_aqe[unpartitioned]` passed with copy-on-write and merge-on-read.
- `python -m py_compile integration_tests/src/main/python/iceberg/__init__.py` passed.
- `bash -n jenkins/spark-tests.sh` passed.
- Scala 2.13 build validation is pending and will be completed before the PR is marked ready for review.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`test_insert_into_aqe[unpartitioned]` and `test_delete_aqe[unpartitioned]`)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
