### PR TITLE
Normalize blossom-ci allowlist [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -61,7 +61,6 @@ jobs:
         github.actor == 'patilkishorv' ||
         github.actor == 'pmattione-nvidia' ||
         github.actor == 'pxLi' ||
-        github.actor == 'razajafri' ||
         github.actor == 'res-life' ||
         github.actor == 'revans2' ||
         github.actor == 'rishic3' ||

--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -38,47 +38,47 @@ jobs:
       github.event.comment.body == 'build' &&
       (
         github.actor == 'abellina' ||
+        github.actor == 'amahussein' ||
         github.actor == 'anfeng' ||
+        github.actor == 'binmahone' ||
+        github.actor == 'cindyyuanjiang' ||
         github.actor == 'firestarman' ||
         github.actor == 'GaryShen2008' ||
-        github.actor == 'kuhushukla' ||
-        github.actor == 'mythrocks' ||
-        github.actor == 'nartal1' ||
-        github.actor == 'NvTimLiu' ||
-        github.actor == 'razajafri' ||
-        github.actor == 'revans2' ||
-        github.actor == 'sameerz' ||
-        github.actor == 'tgravescs' ||
-        github.actor == 'wbo4958' ||
-        github.actor == 'wjxiz1992' ||
-        github.actor == 'sperlingxx' ||
-        github.actor == 'hyperbolic2346' ||
         github.actor == 'gerashegalov' ||
-        github.actor == 'ttnghia' ||
-        github.actor == 'nvliyuan' ||
-        github.actor == 'res-life' ||
         github.actor == 'HaoYang670' ||
-        github.actor == 'NVnavkumar' ||
-        github.actor == 'amahussein' ||
-        github.actor == 'mattahrens' ||
-        github.actor == 'YanxuanLiu' ||
-        github.actor == 'cindyyuanjiang' ||
-        github.actor == 'thirtiseven' ||
-        github.actor == 'winningsix' ||
-        github.actor == 'viadea' ||
-        github.actor == 'yinqingh' ||
-        github.actor == 'parthosa' ||
-        github.actor == 'liurenjie1024' ||
-        github.actor == 'binmahone' ||
-        github.actor == 'zpuller' ||
-        github.actor == 'pxLi' ||
-        github.actor == 'SurajAralihalli' ||
+        github.actor == 'hyperbolic2346' ||
         github.actor == 'jihoonson' ||
         github.actor == 'knoguchi22' ||
+        github.actor == 'kuhushukla' ||
+        github.actor == 'liurenjie1024' ||
+        github.actor == 'mattahrens' ||
+        github.actor == 'mythrocks' ||
+        github.actor == 'nartal1' ||
+        github.actor == 'nvliyuan' ||
+        github.actor == 'NVnavkumar' ||
+        github.actor == 'NvTimLiu' ||
+        github.actor == 'parthosa' ||
         github.actor == 'patilkishorv' ||
         github.actor == 'pmattione-nvidia' ||
+        github.actor == 'pxLi' ||
+        github.actor == 'razajafri' ||
+        github.actor == 'res-life' ||
+        github.actor == 'revans2' ||
         github.actor == 'rishic3' ||
+        github.actor == 'sameerz' ||
         github.actor == 'sdrp713' ||
+        github.actor == 'sperlingxx' ||
+        github.actor == 'SurajAralihalli' ||
+        github.actor == 'tgravescs' ||
+        github.actor == 'thirtiseven' ||
+        github.actor == 'ttnghia' ||
+        github.actor == 'viadea' ||
+        github.actor == 'wbo4958' ||
+        github.actor == 'winningsix' ||
+        github.actor == 'wjxiz1992' ||
+        github.actor == 'YanxuanLiu' ||
+        github.actor == 'yinqingh' ||
+        github.actor == 'zpuller' ||
         false
       )
     steps:

--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -34,6 +34,7 @@ jobs:
 
     # This job only runs for pull request comments
     if: |
+      github.event.issue.pull_request &&
       github.event.comment.body == 'build' &&
       (
         github.actor == 'abellina' ||
@@ -70,14 +71,15 @@ jobs:
         github.actor == 'liurenjie1024' ||
         github.actor == 'binmahone' ||
         github.actor == 'zpuller' ||
-        github.actor == 'pxLi'  ||
+        github.actor == 'pxLi' ||
         github.actor == 'SurajAralihalli' ||
         github.actor == 'jihoonson' ||
         github.actor == 'knoguchi22' ||
         github.actor == 'patilkishorv' ||
         github.actor == 'pmattione-nvidia' ||
         github.actor == 'rishic3' ||
-        github.actor == 'sdrp713'
+        github.actor == 'sdrp713' ||
+        false
       )
     steps:
       - name: Check if comment is issued by authorized person


### PR DESCRIPTION
### Description

Add a PR-only constraint so the CI is not triggered on pure issues, and sort/standardize the allowlist entries. Also remove one stale user from the allowlist.

See also NVIDIA/cudf-spark-jni#4839.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
