### PR TITLE
Handle collect_set signed zeros by Scala version [databricks]

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -23,7 +23,7 @@ from pyspark.sql.window import Window
 import pyspark.sql.functions as f
 from spark_session import is_before_spark_320, is_databricks113_or_later, \
     is_databricks133_or_later, is_spark_350_or_later, spark_version, with_cpu_session, \
-    is_spark_340_or_later, is_spark_420_or_later
+    is_scala212, is_spark_340_or_later, is_spark_420_or_later
 import warnings
 
 # mark this test as ci_1 for mvn verify sanity check in pre-merge CI
@@ -2330,6 +2330,14 @@ def test_join_sum_window_of_window_no_ansi(data_gen):
 
 # Generates some repeated values to test the deduplication of GpuCollectSet.
 # And GpuCollectSet does not yet support struct type.
+_collect_set_float_special_cases = None
+if is_scala212():
+    # Scala 2.12 CPU window collect_set can retain both signed zeros, while the GPU and
+    # Scala 2.13 treat them as the same value. Exclude -0.0 from the Scala 2.12 test data.
+    _collect_set_float_special_cases = [
+        FLOAT_MIN, FLOAT_MAX, 0.0, 1.0, -1.0,
+        float('inf'), float('-inf'), float('nan'), NEG_FLOAT_NAN_MAX_VALUE]
+
 _gen_data_for_collect_set = [
     ('a', RepeatSeqGen(LongGen(), length=20)),
     ('b', UniqueLongGen()),
@@ -2341,7 +2349,8 @@ _gen_data_for_collect_set = [
     ('c_timestamp', RepeatSeqGen(TimestampGen(), length=15)),
     ('c_byte', RepeatSeqGen(ByteGen(), length=15)),
     ('c_string', RepeatSeqGen(StringGen(), length=15)),
-    ('c_float', RepeatSeqGen(FloatGen(), length=15)),
+    ('c_float', RepeatSeqGen(
+        FloatGen(special_cases=_collect_set_float_special_cases), length=15)),
     ('c_double', RepeatSeqGen(DoubleGen(), length=15)),
     ('c_decimal_32', RepeatSeqGen(DecimalGen(precision=8, scale=3), length=15)),
     ('c_decimal_64', RepeatSeqGen(decimal_gen_64bit, length=15)),

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2330,14 +2330,6 @@ def test_join_sum_window_of_window_no_ansi(data_gen):
 
 # Generates some repeated values to test the deduplication of GpuCollectSet.
 # And GpuCollectSet does not yet support struct type.
-_collect_set_float_special_cases = None
-if is_scala212():
-    # Scala 2.12 CPU window collect_set can retain both signed zeros, while the GPU and
-    # Scala 2.13 treat them as the same value. Exclude -0.0 from the Scala 2.12 test data.
-    _collect_set_float_special_cases = [
-        FLOAT_MIN, FLOAT_MAX, 0.0, 1.0, -1.0,
-        float('inf'), float('-inf'), float('nan'), NEG_FLOAT_NAN_MAX_VALUE]
-
 _gen_data_for_collect_set = [
     ('a', RepeatSeqGen(LongGen(), length=20)),
     ('b', UniqueLongGen()),
@@ -2349,8 +2341,7 @@ _gen_data_for_collect_set = [
     ('c_timestamp', RepeatSeqGen(TimestampGen(), length=15)),
     ('c_byte', RepeatSeqGen(ByteGen(), length=15)),
     ('c_string', RepeatSeqGen(StringGen(), length=15)),
-    ('c_float', RepeatSeqGen(
-        FloatGen(special_cases=_collect_set_float_special_cases), length=15)),
+    ('c_float', RepeatSeqGen(FloatGen(), length=15)),
     ('c_double', RepeatSeqGen(DoubleGen(), length=15)),
     ('c_decimal_32', RepeatSeqGen(DecimalGen(precision=8, scale=3), length=15)),
     ('c_decimal_64', RepeatSeqGen(decimal_gen_64bit, length=15)),
@@ -2386,8 +2377,20 @@ _gen_data_for_collect_set_nested = [
 @ignore_order(local=True)
 @allow_non_gpu(*non_utc_allow)
 def test_window_aggs_for_rows_collect_set():
+    data_gen = _gen_data_for_collect_set
+    if is_scala212():
+        # Scala 2.12 CPU window collect_set can retain both signed zeros, while the GPU and
+        # Scala 2.13 treat them as the same value. Exclude -0.0 from this Scala 2.12 test.
+        float_special_cases = [
+            FLOAT_MIN, FLOAT_MAX, 0.0, 1.0, -1.0,
+            float('inf'), float('-inf'), float('nan'), NEG_FLOAT_NAN_MAX_VALUE]
+        data_gen = [
+            (name, RepeatSeqGen(FloatGen(special_cases=float_special_cases), length=15))
+            if name == 'c_float' else (name, gen)
+            for name, gen in data_gen]
+
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: gen_df(spark, _gen_data_for_collect_set),
+        lambda spark: gen_df(spark, data_gen),
         "window_collect_table",
         '''
         select a, b,

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2384,9 +2384,14 @@ def test_window_aggs_for_rows_collect_set():
         float_special_cases = [
             FLOAT_MIN, FLOAT_MAX, 0.0, 1.0, -1.0,
             float('inf'), float('-inf'), float('nan'), NEG_FLOAT_NAN_MAX_VALUE]
+        double_special_cases = [
+            DOUBLE_MIN, DOUBLE_MAX, 0.0, 1.0, -1.0,
+            float('inf'), float('-inf'), float('nan'), NEG_DOUBLE_NAN_MAX_VALUE]
+        collect_set_fp_gens = {
+            'c_float': RepeatSeqGen(FloatGen(special_cases=float_special_cases), length=15),
+            'c_double': RepeatSeqGen(DoubleGen(special_cases=double_special_cases), length=15)}
         data_gen = [
-            (name, RepeatSeqGen(FloatGen(special_cases=float_special_cases), length=15))
-            if name == 'c_float' else (name, gen)
+            (name, collect_set_fp_gens[name]) if name in collect_set_fp_gens else (name, gen)
             for name, gen in data_gen]
 
     assert_gpu_and_cpu_are_equal_sql(


### PR DESCRIPTION
Fixes #12199.

### Description

Spark CPU window `collect_set` behavior for `0.0` and `-0.0` depends on the Scala binary version. Spark builds using Scala 2.12 can retain both signed zeros in some window frames, while Scala 2.13 builds and the GPU implementation deduplicate them.

This change excludes `-0.0` from the float special cases only within `test_window_aggs_for_rows_collect_set` when it runs against Scala 2.12. The shared collect-set generator is unchanged, so other tests retain their existing coverage. Scala 2.13 continues to exercise both signed-zero values. No runtime behavior changes.

Testing:

- `python3 -m py_compile integration_tests/src/main/python/window_function_test.py`
- Spark 3.5.9 / Scala 2.12 CPU A/B validation with `DATAGEN_SEED=1740159968`: the original generator produced 71 signed-zero duplicate window frames out of 2,048 rows; the PR-localized generator produced 0
- Spark 3.5.6 / Scala 2.12 GPU integration test with `DATAGEN_SEED=1740159968` and `TZ=America/Punta_Arenas`: 1 passed
- Spark 4.0.1 / Scala 2.13 package build: success
- Spark 4.0.1 / Scala 2.13 GPU integration test with the same seed and time zone: 1 passed
- Other window collect-set candidates using the shared generator on Spark 3.5.6 / Scala 2.12: 3 passed
- Representative hash groupby/reduction collect-set suites on Spark 3.5.6 / Scala 2.12: 42 passed

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
