### PR TITLE
Support quantified \D and \W in regex patterns

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -921,6 +921,30 @@ def test_regexp_replace_word():
         ),
         conf=_regexp_conf)
 
+def test_regexp_quantified_digit_word():
+    # https://github.com/NVIDIA/cudf-spark/issues/15306
+    gen = mk_str_gen('[a-d]{1,3}[0-9]{1,3}[ _!]{0,2}[a-d]{0,3}') \
+        .with_special_case('䤫畍킱곂⬡❽ࢅ獰᳌蛫青') \
+        .with_special_case('a\n2\r\n3')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, gen).selectExpr(
+            'rlike(a, "\\\\d+")',
+            'rlike(a, "\\\\w+")',
+            'rlike(a, "\\\\D+")',
+            'rlike(a, "\\\\W+")',
+            'rlike(a, "[a-d]+\\\\D+[0-9]+")',
+            'rlike(a, "\\\\D{2,3}")',
+            'rlike(a, "\\\\W{2,3}")',
+            'regexp_extract(a, "(\\\\d+)", 1)',
+            'regexp_extract(a, "(\\\\D+)", 1)',
+            'regexp_extract(a, "([a-d]+)(\\\\D+)([a-d]+)", 2)',
+            'regexp_extract(a, "(\\\\W+)", 1)',
+            'regexp_replace(a, "(\\\\w+)", "#")',
+            'regexp_replace(a, "(\\\\D+)", "#")',
+            'regexp_replace(a, "(\\\\W+)", "@")',
+        ),
+        conf=_regexp_conf)
+
 def test_predefined_character_classes():
     gen = mk_str_gen('[a-zA-Z]{0,2}[\r\n!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~]{0,2}[0-9]{0,2}')
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -811,7 +811,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
   private def getUnsupportedRepetitionBaseOption(e: RegexAST): Option[RegexAST] = {
     e match {
       case RegexEscaped(ch) => ch match {
-        case 'd' | 'w' | 's' | 'S' | 'h' | 'H' | 'v' | 'V' => None
+        case 'd' | 'D' | 'w' | 'W' | 's' | 'S' | 'h' | 'H' | 'v' | 'V' => None
         case _ => Some(e)
       }
       case RegexChar(a) if "$^".contains(a) =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -472,6 +472,19 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }
 
+  test("quantified \\D and \\W") {
+    // see https://github.com/NVIDIA/cudf-spark/issues/15306
+    val inputs = Seq("", "abc", "123", "a1b2", "___", "a_b 1", "!!!", "ab12cd",
+        "a\rb", "1\r2", "1\n2", "1\r\n2", " \t\r\n")
+    val findPatterns = Seq(raw"\D+", raw"\W+", raw"\D*", raw"\W*", raw"\D{2,3}", raw"\W{2,3}",
+        raw"(\D+)", raw"(\W+)")
+    // \D* and \W* omitted from replace: empty-match semantics differ (see issue 4884)
+    val replacePatterns =
+        Seq(raw"\D+", raw"\W+", raw"\D{2,3}", raw"\W{2,3}", raw"(\D+)", raw"(\W+)")
+    assertCpuGpuMatchesRegexpFind(findPatterns, inputs)
+    assertCpuGpuMatchesRegexpReplace(replacePatterns, inputs)
+  }
+
   test("dot matches CR on GPU but not on CPU") {
     // see https://github.com/rapidsai/cudf/issues/9619
     val pattern = "1."


### PR DESCRIPTION
Fixes #15306.

### Description

`regexp_extract` (and `rlike` / `regexp_replace`) fell back to the CPU whenever the pattern contained a quantified `\D` or `\W` — e.g. `regexp_extract(col, '(\\D+)', 1)` — because the pattern failed to transpile with "Preceding token cannot be quantified".

The set of predefined character classes allowed as a repetition base in `CudfRegexTranspiler` was missing `\D` and `\W`, even though it contained the lowercase `\d` and `\w` (and other negation classes like `\H`). Since `\D` and `\W` otherwise transpile into valid patterns, they are fine as a repetition base. Quantified forms (`\D+`, `\W*`, `\D{2,3}`, `(\D+)`, …) now transpile and run on the GPU. Results are unchanged (identical to the CPU); only the execution location changes (GPU instead of CPU fallback).

Added a unit test for quantified `\D` and `\W` that transpiles and compares cuDF vs Java for both find and replace.
Also added an integration test that exercises `rlike`, `regexp_extract`, and `regexp_replace` for quantified `\D`/`\W`, plus previously-missing coverage for quantified `\d`/`\w`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required