### PR TITLE
Chunk large native libraries for parallel extraction

### DIFF
--- a/dist/build/chunk-native-libraries.py
+++ b/dist/build/chunk-native-libraries.py
@@ -79,7 +79,6 @@ def split_library(root_dir, library_path, chunk_size):
         raise RuntimeError("Chunk output already exists for %s" % relative_library)
     ensure_directory(temporary_chunk_dir)
 
-    crc = CRC32()
     source = FileInputStream(library_path)
     buffer = zeros(COPY_BUFFER_SIZE, "b")
     deflated_entries = []
@@ -102,7 +101,6 @@ def split_library(root_dir, library_path, chunk_size):
                         raise RuntimeError("Unexpected end of native library %s" % relative_library)
                     if count:
                         chunk_output.write(buffer, 0, count)
-                        crc.update(buffer, 0, count)
                         chunk_crc.update(buffer, 0, count)
                         chunk_bytes += count
                         total_bytes += count
@@ -131,10 +129,9 @@ def split_library(root_dir, library_path, chunk_size):
     manifest = (
         "format.version=1\n"
         "library.size=%d\n"
-        "library.crc32=%08x\n"
         "chunk.size=%d\n"
         "chunk.count=%d\n"
-        % (library_size, crc.getValue(), chunk_size, chunk_count))
+        % (library_size, chunk_size, chunk_count))
     manifest += "".join(
         "chunk.%05d.crc32=%08x\n" % (index, value)
         for index, value in enumerate(chunk_crc32))

--- a/dist/build/chunk-native-libraries.py
+++ b/dist/build/chunk-native-libraries.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+
+from java.io import FileInputStream, FileOutputStream
+from java.util.zip import CRC32
+from jarray import zeros
+
+
+COPY_BUFFER_SIZE = 1024 * 1024
+MANIFEST_SUFFIX = ".chunks.properties"
+CHUNK_DIRECTORY_SUFFIX = ".chunks"
+NATIVE_SUFFIXES = (".so", ".dylib", ".dll")
+EMPTY_INCLUDE_PATTERN = "__no_native_chunks__"
+
+
+def ensure_directory(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+
+def remove_path(path):
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    elif os.path.exists(path):
+        os.remove(path)
+
+
+def native_libraries(root_dir, minimum_size):
+    candidates = []
+    for arch in sorted(os.listdir(root_dir)):
+        arch_dir = os.path.join(root_dir, arch)
+        if not os.path.isdir(arch_dir):
+            continue
+        for operating_system in sorted(os.listdir(arch_dir)):
+            os_dir = os.path.join(arch_dir, operating_system)
+            if not os.path.isdir(os_dir):
+                continue
+            for name in sorted(os.listdir(os_dir)):
+                path = os.path.join(os_dir, name)
+                if (os.path.isfile(path) and name.endswith(NATIVE_SUFFIXES)
+                        and os.path.getsize(path) >= minimum_size):
+                    candidates.append(path)
+    return candidates
+
+
+def split_library(root_dir, library_path, chunk_size):
+    relative_library = os.path.relpath(library_path, root_dir).replace(os.sep, "/")
+    source_stat = os.stat(library_path)
+    library_size = source_stat.st_size
+    chunk_dir = library_path + CHUNK_DIRECTORY_SUFFIX
+    temporary_chunk_dir = chunk_dir + ".tmp"
+    manifest_path = library_path + MANIFEST_SUFFIX
+    temporary_manifest = manifest_path + ".tmp"
+
+    remove_path(temporary_chunk_dir)
+    remove_path(temporary_manifest)
+    if os.path.exists(chunk_dir) or os.path.exists(manifest_path):
+        raise RuntimeError("Chunk output already exists for %s" % relative_library)
+    ensure_directory(temporary_chunk_dir)
+
+    crc = CRC32()
+    source = FileInputStream(library_path)
+    buffer = zeros(COPY_BUFFER_SIZE, "b")
+    deflated_entries = []
+    chunk_crc32 = []
+    chunk_count = 0
+    total_bytes = 0
+    try:
+        while total_bytes < library_size:
+            chunk_name = "%05d" % chunk_count
+            chunk_path = os.path.join(temporary_chunk_dir, chunk_name)
+            chunk_output = FileOutputStream(chunk_path)
+            chunk_crc = CRC32()
+            chunk_bytes = 0
+            expected = min(chunk_size, library_size - total_bytes)
+            try:
+                while chunk_bytes < expected:
+                    requested = int(min(COPY_BUFFER_SIZE, expected - chunk_bytes))
+                    count = source.read(buffer, 0, requested)
+                    if count < 0:
+                        raise RuntimeError("Unexpected end of native library %s" % relative_library)
+                    if count:
+                        chunk_output.write(buffer, 0, count)
+                        crc.update(buffer, 0, count)
+                        chunk_crc.update(buffer, 0, count)
+                        chunk_bytes += count
+                        total_bytes += count
+            finally:
+                chunk_output.close()
+
+            os.utime(chunk_path, (source_stat.st_atime, source_stat.st_mtime))
+            final_relative = (
+                relative_library + CHUNK_DIRECTORY_SUFFIX + "/" + chunk_name)
+            deflated_entries.append(final_relative)
+            chunk_crc32.append(chunk_crc.getValue())
+            chunk_count += 1
+    except:
+        remove_path(temporary_chunk_dir)
+        remove_path(temporary_manifest)
+        raise
+    finally:
+        source.close()
+
+    if total_bytes != library_size:
+        remove_path(temporary_chunk_dir)
+        raise RuntimeError(
+            "Native library changed while chunking %s: expected %d bytes, read %d"
+            % (relative_library, library_size, total_bytes))
+
+    manifest = (
+        "format.version=1\n"
+        "library.size=%d\n"
+        "library.crc32=%08x\n"
+        "chunk.size=%d\n"
+        "chunk.count=%d\n"
+        % (library_size, crc.getValue(), chunk_size, chunk_count))
+    manifest += "".join(
+        "chunk.%05d.crc32=%08x\n" % (index, value)
+        for index, value in enumerate(chunk_crc32))
+    manifest_output = open(temporary_manifest, "w")
+    try:
+        manifest_output.write(manifest)
+    finally:
+        manifest_output.close()
+    os.utime(temporary_manifest, (source_stat.st_atime, source_stat.st_mtime))
+
+    os.rename(temporary_chunk_dir, chunk_dir)
+    os.rename(temporary_manifest, manifest_path)
+    os.remove(library_path)
+    return relative_library, deflated_entries
+
+
+def write_lines(path, values):
+    output = open(path, "w")
+    try:
+        if not values:
+            output.write(EMPTY_INCLUDE_PATTERN)
+            output.write("\n")
+        for value in sorted(values):
+            output.write(value)
+            output.write("\n")
+    finally:
+        output.close()
+
+
+root_dir = attributes.get("root_dir")
+metadata_dir = attributes.get("metadata_dir")
+minimum_size = long(attributes.get("minimum_size"))
+chunk_size = long(attributes.get("chunk_size"))
+
+if minimum_size <= 0 or chunk_size <= 0:
+    raise RuntimeError("Native chunk sizes must be positive")
+
+ensure_directory(metadata_dir)
+deflated_entries = []
+manifests = []
+for library_path in native_libraries(root_dir, minimum_size):
+    relative_library, library_deflated = split_library(
+        root_dir, library_path, chunk_size)
+    deflated_entries.extend(library_deflated)
+    manifests.append(relative_library + MANIFEST_SUFFIX)
+    self.log(
+        "Chunked %s into %d DEFLATED entries"
+        % (relative_library, len(library_deflated)))
+
+write_lines(os.path.join(metadata_dir, "deflated-chunks.list"), deflated_entries)
+write_lines(os.path.join(metadata_dir, "chunk-manifests.list"), manifests)
+if manifests:
+    marker = open(os.path.join(metadata_dir, "enabled"), "w")
+    marker.close()

--- a/dist/build/chunk-native-libraries.py
+++ b/dist/build/chunk-native-libraries.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import shutil
 
 from java.io import FileInputStream, FileOutputStream
@@ -25,6 +26,22 @@ MANIFEST_SUFFIX = ".chunks.properties"
 CHUNK_DIRECTORY_SUFFIX = ".chunks"
 NATIVE_SUFFIXES = (".so", ".dylib", ".dll")
 EMPTY_INCLUDE_PATTERN = "__no_native_chunks__"
+BYTE_SIZE_RE = re.compile(r"^\s*(\d+)\s*([KMGT]?)B?\s*$", re.IGNORECASE)
+BYTE_SIZE_MULTIPLIERS = {
+    "": 1,
+    "K": 1024,
+    "M": 1024 ** 2,
+    "G": 1024 ** 3,
+    "T": 1024 ** 4,
+}
+
+
+def parse_byte_size(value):
+    match = BYTE_SIZE_RE.match(str(value))
+    if not match:
+        raise ValueError("Invalid byte size: %r" % value)
+    amount, suffix = match.groups()
+    return long(amount) * BYTE_SIZE_MULTIPLIERS[suffix.upper()]
 
 
 def ensure_directory(path):
@@ -165,8 +182,8 @@ def write_lines(path, values):
 
 root_dir = attributes.get("root_dir")
 metadata_dir = attributes.get("metadata_dir")
-minimum_size = long(attributes.get("minimum_size"))
-chunk_size = long(attributes.get("chunk_size"))
+minimum_size = parse_byte_size(attributes.get("minimum_size"))
+chunk_size = parse_byte_size(attributes.get("chunk_size"))
 
 if minimum_size <= 0 or chunk_size <= 0:
     raise RuntimeError("Native chunk sizes must be positive")

--- a/dist/build/chunk-native-libraries.py
+++ b/dist/build/chunk-native-libraries.py
@@ -39,6 +39,13 @@ def remove_path(path):
         os.remove(path)
 
 
+def remove_path_ignoring_errors(path):
+    try:
+        remove_path(path)
+    except:
+        pass
+
+
 def native_libraries(root_dir, minimum_size):
     candidates = []
     for arch in sorted(os.listdir(root_dir)):
@@ -109,8 +116,8 @@ def split_library(root_dir, library_path, chunk_size):
             chunk_crc32.append(chunk_crc.getValue())
             chunk_count += 1
     except:
-        remove_path(temporary_chunk_dir)
-        remove_path(temporary_manifest)
+        remove_path_ignoring_errors(temporary_chunk_dir)
+        remove_path_ignoring_errors(temporary_manifest)
         raise
     finally:
         source.close()
@@ -138,6 +145,8 @@ def split_library(root_dir, library_path, chunk_size):
         manifest_output.close()
     os.utime(temporary_manifest, (source_stat.st_atime, source_stat.st_mtime))
 
+    # Any failure here aborts the Maven execution before JAR creation. The initialize-phase
+    # cleanup removes partial parallel-world output before the next invocation.
     os.rename(temporary_chunk_dir, chunk_dir)
     os.rename(temporary_manifest, manifest_path)
     os.remove(library_path)

--- a/dist/build/verify-native-library-chunks.py
+++ b/dist/build/verify-native-library-chunks.py
@@ -75,6 +75,12 @@ try:
         library_crc = long(require_property(properties, "library.crc32", manifest_name), 16)
         chunk_size = long(require_property(properties, "chunk.size", manifest_name))
         chunk_count = int(require_property(properties, "chunk.count", manifest_name))
+        if library_size <= 0:
+            raise RuntimeError("Invalid library.size in %s" % manifest_name)
+        if chunk_size <= 0:
+            raise RuntimeError("Invalid chunk.size in %s" % manifest_name)
+        if chunk_count <= 0:
+            raise RuntimeError("Invalid chunk.count in %s" % manifest_name)
         expected_count = 1 + ((library_size - 1) // chunk_size)
         if chunk_count != expected_count:
             raise RuntimeError("Invalid chunk count in %s" % manifest_name)

--- a/dist/build/verify-native-library-chunks.py
+++ b/dist/build/verify-native-library-chunks.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from java.util import Properties
+from java.util.zip import CRC32, ZipEntry, ZipFile
+from jarray import zeros
+
+
+COPY_BUFFER_SIZE = 1024 * 1024
+MANIFEST_SUFFIX = ".chunks.properties"
+EMPTY_INCLUDE_PATTERN = "__no_native_chunks__"
+
+
+def read_lines(path):
+    source = open(path, "r")
+    try:
+        return set(
+            line.strip() for line in source
+            if line.strip() and line.strip() != EMPTY_INCLUDE_PATTERN)
+    finally:
+        source.close()
+
+
+def require_property(properties, key, manifest_name):
+    value = properties.getProperty(key)
+    if value is None or not value.strip():
+        raise RuntimeError("Missing %s in %s" % (key, manifest_name))
+    return value.strip()
+
+
+jar_path = attributes.get("jar_path")
+metadata_dir = attributes.get("metadata_dir")
+deflated_entries = read_lines(os.path.join(metadata_dir, "deflated-chunks.list"))
+manifest_entries = read_lines(os.path.join(metadata_dir, "chunk-manifests.list"))
+expected_chunks = deflated_entries
+verified_chunks = set()
+
+archive = ZipFile(jar_path)
+buffer = zeros(COPY_BUFFER_SIZE, "b")
+try:
+    for entry_name in sorted(deflated_entries):
+        entry = archive.getEntry(entry_name)
+        if entry is None:
+            raise RuntimeError("Missing DEFLATED native chunk %s" % entry_name)
+        if entry.getMethod() != ZipEntry.DEFLATED:
+            raise RuntimeError("Native chunk %s is not DEFLATED" % entry_name)
+
+    for manifest_name in sorted(manifest_entries):
+        manifest_entry = archive.getEntry(manifest_name)
+        if manifest_entry is None:
+            raise RuntimeError("Missing native chunk manifest %s" % manifest_name)
+        properties = Properties()
+        manifest_input = archive.getInputStream(manifest_entry)
+        try:
+            properties.load(manifest_input)
+        finally:
+            manifest_input.close()
+
+        if require_property(properties, "format.version", manifest_name) != "1":
+            raise RuntimeError("Unsupported chunk manifest version in %s" % manifest_name)
+        library_size = long(require_property(properties, "library.size", manifest_name))
+        library_crc = long(require_property(properties, "library.crc32", manifest_name), 16)
+        chunk_size = long(require_property(properties, "chunk.size", manifest_name))
+        chunk_count = int(require_property(properties, "chunk.count", manifest_name))
+        expected_count = 1 + ((library_size - 1) // chunk_size)
+        if chunk_count != expected_count:
+            raise RuntimeError("Invalid chunk count in %s" % manifest_name)
+
+        library_name = manifest_name[:-len(MANIFEST_SUFFIX)]
+        if archive.getEntry(library_name) is not None:
+            raise RuntimeError(
+                "Conventional native resource still exists beside %s" % manifest_name)
+
+        crc = CRC32()
+        total_size = 0
+        for index in range(chunk_count):
+            chunk_name = "%s.chunks/%05d" % (library_name, index)
+            chunk_crc_key = "chunk.%05d.crc32" % index
+            expected_chunk_crc = long(
+                require_property(properties, chunk_crc_key, manifest_name), 16)
+            chunk_entry = archive.getEntry(chunk_name)
+            if chunk_entry is None:
+                raise RuntimeError("Missing native chunk %s" % chunk_name)
+            expected_size = (
+                chunk_size if index < chunk_count - 1
+                else library_size - chunk_size * index)
+            if chunk_entry.getSize() != expected_size:
+                raise RuntimeError(
+                    "Native chunk %s has size %d, expected %d"
+                    % (chunk_name, chunk_entry.getSize(), expected_size))
+            chunk_input = archive.getInputStream(chunk_entry)
+            chunk_bytes = 0
+            chunk_crc = CRC32()
+            try:
+                while True:
+                    count = chunk_input.read(buffer)
+                    if count < 0:
+                        break
+                    if count:
+                        crc.update(buffer, 0, count)
+                        chunk_crc.update(buffer, 0, count)
+                        chunk_bytes += count
+            finally:
+                chunk_input.close()
+            if chunk_bytes != expected_size:
+                raise RuntimeError(
+                    "Native chunk %s read %d bytes, expected %d"
+                    % (chunk_name, chunk_bytes, expected_size))
+            if chunk_crc.getValue() != expected_chunk_crc:
+                raise RuntimeError("Native chunk CRC mismatch for %s" % chunk_name)
+            total_size += chunk_bytes
+            verified_chunks.add(chunk_name)
+
+        if total_size != library_size or crc.getValue() != library_crc:
+            raise RuntimeError("Reconstructed native library mismatch for %s" % library_name)
+finally:
+    archive.close()
+
+if verified_chunks != expected_chunks:
+    raise RuntimeError(
+        "Native chunk lists do not match manifests: expected=%d verified=%d"
+        % (len(expected_chunks), len(verified_chunks)))
+self.log(
+    "Verified %d chunked native libraries and %d chunks"
+    % (len(manifest_entries), len(verified_chunks)))

--- a/dist/build/verify-native-library-chunks.py
+++ b/dist/build/verify-native-library-chunks.py
@@ -72,7 +72,6 @@ try:
         if require_property(properties, "format.version", manifest_name) != "1":
             raise RuntimeError("Unsupported chunk manifest version in %s" % manifest_name)
         library_size = long(require_property(properties, "library.size", manifest_name))
-        library_crc = long(require_property(properties, "library.crc32", manifest_name), 16)
         chunk_size = long(require_property(properties, "chunk.size", manifest_name))
         chunk_count = int(require_property(properties, "chunk.count", manifest_name))
         if library_size <= 0:
@@ -90,7 +89,6 @@ try:
             raise RuntimeError(
                 "Conventional native resource still exists beside %s" % manifest_name)
 
-        crc = CRC32()
         total_size = 0
         for index in range(chunk_count):
             chunk_name = "%s.chunks/%05d" % (library_name, index)
@@ -116,7 +114,6 @@ try:
                     if count < 0:
                         break
                     if count:
-                        crc.update(buffer, 0, count)
                         chunk_crc.update(buffer, 0, count)
                         chunk_bytes += count
             finally:
@@ -130,8 +127,9 @@ try:
             total_size += chunk_bytes
             verified_chunks.add(chunk_name)
 
-        if total_size != library_size or crc.getValue() != library_crc:
-            raise RuntimeError("Reconstructed native library mismatch for %s" % library_name)
+        if total_size != library_size:
+            raise RuntimeError(
+                "Reconstructed native library size mismatch for %s" % library_name)
 finally:
     archive.close()
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -50,8 +50,8 @@
         <rapids.jni.unpack.skip>false</rapids.jni.unpack.skip>
         <rapids.source.jar.phase>none</rapids.source.jar.phase>
         <dist.native.chunking.enabled>true</dist.native.chunking.enabled>
-        <dist.native.chunking.minimum.size>268435456</dist.native.chunking.minimum.size>
-        <dist.native.chunking.chunk.size>33554432</dist.native.chunking.chunk.size>
+        <dist.native.chunking.minimum.size>256M</dist.native.chunking.minimum.size>
+        <dist.native.chunking.chunk.size>32M</dist.native.chunking.chunk.size>
         <dist.native.chunking.metadata.dir>${project.build.directory}/native-chunks</dist.native.chunking.metadata.dir>
     </properties>
     <profiles>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -49,6 +49,10 @@
         <rapids.default.jar.phase>none</rapids.default.jar.phase>
         <rapids.jni.unpack.skip>false</rapids.jni.unpack.skip>
         <rapids.source.jar.phase>none</rapids.source.jar.phase>
+        <dist.native.chunking.enabled>true</dist.native.chunking.enabled>
+        <dist.native.chunking.minimum.size>268435456</dist.native.chunking.minimum.size>
+        <dist.native.chunking.chunk.size>33554432</dist.native.chunking.chunk.size>
+        <dist.native.chunking.metadata.dir>${project.build.directory}/native-chunks</dist.native.chunking.metadata.dir>
     </properties>
     <profiles>
         <profile>
@@ -263,6 +267,7 @@
                                     <fileset dir="${project.build.directory}" includes="*.jar"/>
                                 </delete>
                                 <delete dir="${project.build.directory}/deps" includeemptydirs="true"/>
+                                <delete dir="${dist.native.chunking.metadata.dir}" includeemptydirs="true"/>
                                 <mkdir dir="${project.build.directory}/deps"/>
                             </target>
                         </configuration>
@@ -305,6 +310,59 @@
                                     <else>
                                         <fail>Re-execute build with the default `-Drapids.jni.unpack.skip=false`</fail>
                                     </else>
+                                </ac:if>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>chunk-native-libraries</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"/>
+                                <scriptdef name="chunkNativeLibraries" language="jython"
+                                           src="${spark.rapids.source.basedir}/${rapids.module}/build/chunk-native-libraries.py">
+                                    <attribute name="root_dir"/>
+                                    <attribute name="metadata_dir"/>
+                                    <attribute name="minimum_size"/>
+                                    <attribute name="chunk_size"/>
+                                </scriptdef>
+                                <ac:if xmlns:ac="antlib:net.sf.antcontrib">
+                                    <and>
+                                        <istrue value="${dist.native.chunking.enabled}"/>
+                                        <istrue value="${dist.jar.compress}"/>
+                                    </and>
+                                    <then>
+                                        <chunkNativeLibraries
+                                            root_dir="${project.build.directory}/parallel-world"
+                                            metadata_dir="${dist.native.chunking.metadata.dir}"
+                                            minimum_size="${dist.native.chunking.minimum.size}"
+                                            chunk_size="${dist.native.chunking.chunk.size}"/>
+                                    </then>
+                                </ac:if>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify-native-library-chunks</id>
+                        <phase>verify</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"/>
+                                <scriptdef name="verifyNativeLibraryChunks" language="jython"
+                                           src="${spark.rapids.source.basedir}/${rapids.module}/build/verify-native-library-chunks.py">
+                                    <attribute name="jar_path"/>
+                                    <attribute name="metadata_dir"/>
+                                </scriptdef>
+                                <ac:if xmlns:ac="antlib:net.sf.antcontrib">
+                                    <available file="${dist.native.chunking.metadata.dir}/enabled"/>
+                                    <then>
+                                        <verifyNativeLibraryChunks
+                                            jar_path="${dist.jar.name}"
+                                            metadata_dir="${dist.native.chunking.metadata.dir}"/>
+                                    </then>
                                 </ac:if>
                             </target>
                         </configuration>

--- a/scala2.13/dist/pom.xml
+++ b/scala2.13/dist/pom.xml
@@ -50,8 +50,8 @@
         <rapids.jni.unpack.skip>false</rapids.jni.unpack.skip>
         <rapids.source.jar.phase>none</rapids.source.jar.phase>
         <dist.native.chunking.enabled>true</dist.native.chunking.enabled>
-        <dist.native.chunking.minimum.size>268435456</dist.native.chunking.minimum.size>
-        <dist.native.chunking.chunk.size>33554432</dist.native.chunking.chunk.size>
+        <dist.native.chunking.minimum.size>256M</dist.native.chunking.minimum.size>
+        <dist.native.chunking.chunk.size>32M</dist.native.chunking.chunk.size>
         <dist.native.chunking.metadata.dir>${project.build.directory}/native-chunks</dist.native.chunking.metadata.dir>
     </properties>
     <profiles>

--- a/scala2.13/dist/pom.xml
+++ b/scala2.13/dist/pom.xml
@@ -49,6 +49,10 @@
         <rapids.default.jar.phase>none</rapids.default.jar.phase>
         <rapids.jni.unpack.skip>false</rapids.jni.unpack.skip>
         <rapids.source.jar.phase>none</rapids.source.jar.phase>
+        <dist.native.chunking.enabled>true</dist.native.chunking.enabled>
+        <dist.native.chunking.minimum.size>268435456</dist.native.chunking.minimum.size>
+        <dist.native.chunking.chunk.size>33554432</dist.native.chunking.chunk.size>
+        <dist.native.chunking.metadata.dir>${project.build.directory}/native-chunks</dist.native.chunking.metadata.dir>
     </properties>
     <profiles>
         <profile>
@@ -263,6 +267,7 @@
                                     <fileset dir="${project.build.directory}" includes="*.jar"/>
                                 </delete>
                                 <delete dir="${project.build.directory}/deps" includeemptydirs="true"/>
+                                <delete dir="${dist.native.chunking.metadata.dir}" includeemptydirs="true"/>
                                 <mkdir dir="${project.build.directory}/deps"/>
                             </target>
                         </configuration>
@@ -305,6 +310,59 @@
                                     <else>
                                         <fail>Re-execute build with the default `-Drapids.jni.unpack.skip=false`</fail>
                                     </else>
+                                </ac:if>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>chunk-native-libraries</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"/>
+                                <scriptdef name="chunkNativeLibraries" language="jython"
+                                           src="${spark.rapids.source.basedir}/${rapids.module}/build/chunk-native-libraries.py">
+                                    <attribute name="root_dir"/>
+                                    <attribute name="metadata_dir"/>
+                                    <attribute name="minimum_size"/>
+                                    <attribute name="chunk_size"/>
+                                </scriptdef>
+                                <ac:if xmlns:ac="antlib:net.sf.antcontrib">
+                                    <and>
+                                        <istrue value="${dist.native.chunking.enabled}"/>
+                                        <istrue value="${dist.jar.compress}"/>
+                                    </and>
+                                    <then>
+                                        <chunkNativeLibraries
+                                            root_dir="${project.build.directory}/parallel-world"
+                                            metadata_dir="${dist.native.chunking.metadata.dir}"
+                                            minimum_size="${dist.native.chunking.minimum.size}"
+                                            chunk_size="${dist.native.chunking.chunk.size}"/>
+                                    </then>
+                                </ac:if>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify-native-library-chunks</id>
+                        <phase>verify</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"/>
+                                <scriptdef name="verifyNativeLibraryChunks" language="jython"
+                                           src="${spark.rapids.source.basedir}/${rapids.module}/build/verify-native-library-chunks.py">
+                                    <attribute name="jar_path"/>
+                                    <attribute name="metadata_dir"/>
+                                </scriptdef>
+                                <ac:if xmlns:ac="antlib:net.sf.antcontrib">
+                                    <available file="${dist.native.chunking.metadata.dir}/enabled"/>
+                                    <then>
+                                        <verifyNativeLibraryChunks
+                                            jar_path="${dist.jar.name}"
+                                            metadata_dir="${dist.native.chunking.metadata.dir}"/>
+                                    </then>
                                 </ac:if>
                             </target>
                         </configuration>


### PR DESCRIPTION
### Description

Depends on rapidsai/cudf#23409, which teaches `NativeDepsLoader` to consume the generated format.

Related issue: [#15145](https://github.com/NVIDIA/cudf-spark/issues/15145). This PR addresses its native JAR extraction bottleneck; background preloading and concurrent memory-pool initialization remain separate work.

Large CUDA native libraries are expensive to inflate through one sequential JAR stream. CUDA 13 also uses zstd-compressed fatbins, so additional whole-library DEFLATE compression is less valuable while startup latency remains significant.

This change makes chunking a cudf-spark distribution packaging concern:

- native libraries at least 256 MiB are split into 32 MiB resources during `process-resources`
- a versioned manifest records the library size, chunk geometry, and per-chunk CRC32 values
- the existing `create-parallel-worlds-jar` execution picks up the generated resources and DEFLATEs them in its normal archive pass
- the conventional resource is retained for smaller libraries and when JAR compression is disabled
- a `verify`-phase task checks entry methods, resource presence, sizes, and reconstructed checksums

There is no new user-facing configuration. The POM properties are internal build controls so chunking remains limited to the cudf-spark distribution JAR.

### Performance

#### Native extraction

Measured the exact pre-change and PR paths on the same host with JDK 17 and the same 1,504,051,352-byte CUDA12 `libcudf.so`. Each case ran six extractions in one JVM; the first invocation was treated as warm-up and the remaining five were used for the median.

| Path | First invocation | Post-warm-up range | Median |
| --- | ---: | ---: | ---: |
| Pre-change conventional DEFLATED resource, 16 KiB sequential copy | 6.411 s | 6.370-6.426 s | 6.371 s |
| 45 DEFLATED chunks, 12-worker positional extraction | 1.164 s | 1.078-1.124 s | 1.113 s |

The post-warm-up median improves by **5.72x**, reducing extraction latency by **82.5%**. The first measured invocation improves by 5.51x. Both paths produced exactly 1,504,051,352 bytes.

#### JAR creation

Isolated the existing `create-parallel-worlds-jar` Maven execution using two resource trees on the same ext4 filesystem. All non-native files were hard-linked between the trees; only the native representation differed. Every invocation forced a new archive:

```bash
/usr/bin/time mvn jar:jar@create-parallel-worlds-jar -pl dist \
  -DskipTests -Dmaven.jar.forceCreation=true
```

Each case had one warm-up followed by five measured runs. Times below are direct-goal wall time, including identical Maven/JVM startup overhead.

| Input representation | Measured range | Median | Output JAR size |
| --- | ---: | ---: | ---: |
| One conventional DEFLATED `libcudf.so` entry | 54.87-55.14 s | 55.07 s | 952,504,790 bytes |
| 45 DEFLATED chunks plus manifest | 5.40-5.66 s | 5.47 s | 952,587,551 bytes |

Chunking makes focused JAR creation **10.07x faster**, reducing wall time by **90.1%**. The chunked archive is only 82,761 bytes larger, a **0.0087%** increase. Plexus Archiver can compress independent chunk entries concurrently instead of processing one 1.5 GB entry on a single worker.

### Validation

- `./build/make-scala-version-build-files.sh 2.13`
- `mvn package -pl dist -DskipTests`
- `mvn antrun:run@verify-native-library-chunks -pl dist -DskipTests -Dspark.rapids.source.basedir=$PWD`
- verifier reconstructed one native library from 45 DEFLATED chunks with matching checksums
- exact cross-repository extraction benchmark described above
- focused forced-rebuild JAR benchmark described above

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
