### PR TITLE
Fix named struct dataType null field names [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -27,9 +27,9 @@ import com.nvidia.spark.rapids.shims.ShimExpression
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FUNC_ALIAS
 import org.apache.spark.sql.catalyst.expressions.{EmptyRow, Expression, NamedExpression}
-import org.apache.spark.sql.rapids.shims.CreateNamedStructShims
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.shims.CreateNamedStructShims
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, Metadata, NullType, StringType, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -27,6 +27,7 @@ import com.nvidia.spark.rapids.shims.ShimExpression
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FUNC_ALIAS
 import org.apache.spark.sql.catalyst.expressions.{EmptyRow, Expression, NamedExpression}
+import org.apache.spark.sql.rapids.shims.CreateNamedStructShims
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, Metadata, NullType, StringType, StructField, StructType}
@@ -205,7 +206,7 @@ case class GpuCreateNamedStruct(children: Seq[Expression]) extends GpuExpression
           case ne: NamedExpression => ne.metadata
           case _ => Metadata.empty
         }
-        StructField(name.toString, expr.dataType, expr.nullable, metadata)
+        StructField(CreateNamedStructShims.fieldName(name), expr.dataType, expr.nullable, metadata)
     }
     StructType(fields)
   }

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/CreateNamedStructShims.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/CreateNamedStructShims.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "400"}
+{"spark": "400db173"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "411"}
+{"spark": "412"}
+spark-rapids-shim-json-lines ***/
+
+package org.apache.spark.sql.rapids.shims
+
+object CreateNamedStructShims {
+  def fieldName(name: Any): String = name.toString
+}

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/CreateNamedStructShims.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/CreateNamedStructShims.scala
@@ -15,8 +15,10 @@
  */
 /*** spark-rapids-shim-json-lines
 {"spark": "330"}
+{"spark": "330db"}
 {"spark": "331"}
 {"spark": "332"}
+{"spark": "332db"}
 {"spark": "333"}
 {"spark": "334"}
 {"spark": "340"}

--- a/sql-plugin/src/main/spark404/scala/org/apache/spark/sql/rapids/shims/CreateNamedStructShims.scala
+++ b/sql-plugin/src/main/spark404/scala/org/apache/spark/sql/rapids/shims/CreateNamedStructShims.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "404"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+
+package org.apache.spark.sql.rapids.shims
+
+object CreateNamedStructShims {
+  def fieldName(name: Any): String = if (name == null) null else name.toString
+}

--- a/sql-plugin/src/test/spark330/scala/org/apache/spark/sql/rapids/GpuCreateNamedStructSuite.scala
+++ b/sql-plugin/src/test/spark330/scala/org/apache/spark/sql/rapids/GpuCreateNamedStructSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "400"}
+{"spark": "400db173"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "411"}
+{"spark": "412"}
+spark-rapids-shim-json-lines ***/
+
+package org.apache.spark.sql.rapids
+
+import com.nvidia.spark.rapids.{FQSuiteName, GpuLiteral}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.types.{IntegerType, StringType}
+
+class GpuCreateNamedStructSuite extends AnyFunSuite with FQSuiteName {
+  test("dataType follows legacy Spark behavior for a null field name") {
+    val struct = GpuCreateNamedStruct(Seq(
+      GpuLiteral.create(null, StringType),
+      GpuLiteral.create(1, IntegerType)))
+
+    intercept[NullPointerException] {
+      struct.dataType
+    }
+    assert(struct.checkInputDataTypes().isFailure)
+  }
+}

--- a/sql-plugin/src/test/spark330/scala/org/apache/spark/sql/rapids/GpuCreateNamedStructSuite.scala
+++ b/sql-plugin/src/test/spark330/scala/org/apache/spark/sql/rapids/GpuCreateNamedStructSuite.scala
@@ -15,8 +15,10 @@
  */
 /*** spark-rapids-shim-json-lines
 {"spark": "330"}
+{"spark": "330db"}
 {"spark": "331"}
 {"spark": "332"}
+{"spark": "332db"}
 {"spark": "333"}
 {"spark": "334"}
 {"spark": "340"}

--- a/sql-plugin/src/test/spark404/scala/org/apache/spark/sql/rapids/GpuCreateNamedStructSuite.scala
+++ b/sql-plugin/src/test/spark404/scala/org/apache/spark/sql/rapids/GpuCreateNamedStructSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "404"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+
+package org.apache.spark.sql.rapids
+
+import com.nvidia.spark.rapids.{FQSuiteName, GpuLiteral}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.types.{IntegerType, StringType}
+
+class GpuCreateNamedStructSuite extends AnyFunSuite with FQSuiteName {
+  test("dataType is null-safe for a null field name") {
+    val struct = GpuCreateNamedStruct(Seq(
+      GpuLiteral.create(null, StringType),
+      GpuLiteral.create(1, IntegerType)))
+    val dataType = struct.dataType
+
+    assert(dataType.length === 1)
+    assert(dataType.head.name === null)
+    assert(dataType.head.dataType === IntegerType)
+    assert(dataType.head.nullable === false)
+    assert(struct.checkInputDataTypes().isFailure)
+  }
+}


### PR DESCRIPTION
Fixes #15316.

### Description

- Fix `GpuCreateNamedStruct.dataType` to match Spark behavior for null field names, so Spark versions with SPARK-57736 no longer hit an NPE before type checking rejects the invalid input.
- Add `CreateNamedStructShims` so legacy Spark shims keep the old `name.toString` behavior, while Spark 4.0.4, 4.1.3, and 4.2.0 use Spark's null-safe field-name behavior.
- Add shim-specific Scala tests for both legacy and fixed behavior, covering null field names in `GpuCreateNamedStruct.dataType` and the expected input type-check failure.
- Validated with focused Scala tests: `mvn -s /home/liangcail/.m2/settings_art.xml -f scala2.13/pom.xml -pl sql-plugin -Dbuildver=358 -Dcuda.version=cuda13 -DwildcardSuites=org.apache.spark.sql.rapids.GpuCreateNamedStructSuite test`, plus the same command for `buildver=403`, `404`, `412`, `413`, and `420`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
