### PR TITLE
Prefetch Iceberg Parquet footers with a suffix read

### DIFF
--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/IcebergShimUtils.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/IcebergShimUtils.java
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.GpuMetric;
 import com.nvidia.spark.rapids.NoopMetric$;
 import com.nvidia.spark.rapids.RapidsConf;
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile;
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileScanTask;
@@ -93,6 +94,7 @@ public interface IcebergShimUtils {
      */
     default ParquetFileReader openParquetReader(
             IcebergInputFile inputFile,
+            RapidsInputFile footerFile,
             Path filePath,
             ParquetReadOptions options,
             scala.collection.immutable.Map<String, GpuMetric> metrics) throws IOException {

--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/ShimUtils.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/ShimUtils.java
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.GpuMetric;
 import com.nvidia.spark.rapids.RapidsConf;
 import com.nvidia.spark.rapids.ShimLoader;
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile;
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.ContentFile;
@@ -69,10 +70,11 @@ public class ShimUtils {
 
     public static ParquetFileReader openParquetReader(
             IcebergInputFile inputFile,
+            RapidsInputFile footerFile,
             Path filePath,
             ParquetReadOptions options,
             scala.collection.immutable.Map<String, GpuMetric> metrics) throws IOException {
-        return IMPL.openParquetReader(inputFile, filePath, options, metrics);
+        return IMPL.openParquetReader(inputFile, footerFile, filePath, options, metrics);
     }
 
     public static GpuSparkScan newCopyOnWriteScan(

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -135,4 +135,15 @@ public final class IcebergS3InputFile implements RapidsInputFile {
     }
     IcebergS3RangeCopier.copyTailToHMB(icebergS3Client, output, s3Uri, length, /*dstOffset*/ 0L);
   }
+
+  /**
+   * Copies a suffix range using this input file's resolved Iceberg S3 client.
+   *
+   * @return the number of bytes copied
+   */
+  public long copyTailToHMB(long length, HostMemoryBuffer output, long outputOffset)
+      throws IOException {
+    return IcebergS3RangeCopier.copyTailToHMB(
+        icebergS3Client, output, s3Uri, length, outputOffset);
+  }
 }

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
@@ -24,7 +24,9 @@ import scala.collection.JavaConverters._
 
 import com.nvidia.spark.rapids.{CombineConf, DateTimeRebaseCorrected, GpuMetric, ThreadPoolConfBuilder}
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.fileio.iceberg.IcebergFileIO
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile
 import com.nvidia.spark.rapids.iceberg.parquet.converter.FromIcebergShaded._
 import com.nvidia.spark.rapids.parquet.{GpuParquetUtils, ParquetFileInfoWithBlockMeta}
 import com.nvidia.spark.rapids.shims.PartitionedFileUtilsShim
@@ -52,10 +54,13 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 case class IcebergPartitionedFile(
     file: IcebergInputFile,
     split: Option[(Long, Long)] = None,
-    filter: Option[Expression] = None) {
+    filter: Option[Expression] = None,
+    fileIO: IcebergFileIO = null) {
 
   lazy val urlEncodedPath: String = new Path(file.getDelegate.location()).toUri.toString
   lazy val path: Path = new Path(new URI(urlEncodedPath))
+  private lazy val footerInputFile: RapidsInputFile =
+    Option(fileIO).map(_.newInputFile(urlEncodedPath)).getOrElse(file)
 
   def parquetReadOptions: ParquetReadOptions = {
     GpuIcebergParquetReader.buildReaderOptions(file.getDelegate, split)
@@ -63,7 +68,7 @@ case class IcebergPartitionedFile(
 
   def newReader(metrics: Map[String, GpuMetric] = Map.empty): ParquetFileReader = {
     try {
-      GpuParquetIO.openReader(file, path, parquetReadOptions, metrics)
+      GpuParquetIO.openReader(file, footerInputFile, path, parquetReadOptions, metrics)
     } catch {
       case e: IOException =>
         throw new UncheckedIOException(s"Failed to newInputFile Parquet file: " +

--- a/iceberg/common/src/main/scala/org/apache/iceberg/parquet/GpuParquetIO.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/parquet/GpuParquetIO.scala
@@ -17,6 +17,7 @@
 package org.apache.iceberg.parquet
 
 import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import com.nvidia.spark.rapids.iceberg.ShimUtils
 import org.apache.hadoop.fs.Path
@@ -38,9 +39,10 @@ object GpuParquetIO {
    */
   def openReader(
       inputFile: IcebergInputFile,
+      footerFile: RapidsInputFile,
       filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
-    ShimUtils.openParquetReader(inputFile, filePath, options, metrics)
+    ShimUtils.openParquetReader(inputFile, footerFile, filePath, options, metrics)
   }
 }

--- a/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuIcebergPartitionReader.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuIcebergPartitionReader.scala
@@ -117,7 +117,8 @@ class GpuIcebergPartitionReader(private val task: GpuSparkInputPartition,
       val file = inputFiles(locationOf(t.file()))
       val icebergFile = IcebergPartitionedFile(file,
         Some((t.start(), t.length())),
-        Some(t.residual()))
+        Some(t.residual()),
+        rapidsFileIO)
 
       icebergFile -> t
     }))

--- a/iceberg/iceberg-1-10-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg110x/ShimUtilsImpl.java
+++ b/iceberg/iceberg-1-10-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg110x/ShimUtilsImpl.java
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.iceberg.iceberg110x;
 import com.nvidia.spark.rapids.GpuMetric;
 import com.nvidia.spark.rapids.RapidsConf;
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile;
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.iceberg.IcebergShimUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.*;
@@ -73,10 +74,11 @@ public class ShimUtilsImpl implements IcebergShimUtils {
     @Override
     public ParquetFileReader openParquetReader(
             IcebergInputFile inputFile,
+            RapidsInputFile footerFile,
             Path filePath,
             ParquetReadOptions options,
             scala.collection.immutable.Map<String, GpuMetric> metrics) throws IOException {
-        return GpuParquetIOShim.openReader(inputFile, filePath, options, metrics);
+        return GpuParquetIOShim.openReader(inputFile, footerFile, filePath, options, metrics);
     }
 
     @Override

--- a/iceberg/iceberg-1-10-x/src/main/scala/com/nvidia/spark/rapids/iceberg/iceberg110x/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-10-x/src/main/scala/com/nvidia/spark/rapids/iceberg/iceberg110x/GpuParquetIOShim.scala
@@ -17,11 +17,13 @@
 package com.nvidia.spark.rapids.iceberg.iceberg110x
 
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.{GpuMetric, PerfIO}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import com.nvidia.spark.rapids.iceberg.parquet.converter.ToIcebergShaded
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile
 import com.nvidia.spark.rapids.parquet.{HMBInputFile, ParquetFooterUtils}
 import org.apache.hadoop.fs.Path
+import org.apache.iceberg.aws.s3.IcebergS3InputFile
 import org.apache.iceberg.parquet.GpuParquetIO
 import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
@@ -36,12 +38,22 @@ import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
 object GpuParquetIOShim {
   def openReader(
       inputFile: IcebergInputFile,
+      footerFile: RapidsInputFile,
       filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
     val metadata = withResource(ParquetFooterUtils.getFooterBuffer(
         inputFile, metrics,
-        ParquetFooterUtils.readFooterBufferFromInputFile(inputFile, filePath))) { hmb =>
+        footerFile match {
+          case s3File: IcebergS3InputFile =>
+            PerfIO.readIcebergParquetFooterBuffer(
+              filePath,
+              (length, output, outputOffset) =>
+                s3File.copyTailToHMB(length, output, outputOffset),
+              ParquetFooterUtils.verifyParquetMagic)
+          case _ =>
+            ParquetFooterUtils.readFooterBufferFromInputFile(footerFile, filePath)
+        })) { hmb =>
       val shadedHmbFile = ToIcebergShaded.shade(new HMBInputFile(hmb))
       withResource(shadedHmbFile.newStream()) { hmbStream =>
         ParquetFileReader.readFooter(shadedHmbFile, options, hmbStream)

--- a/iceberg/iceberg-1-11-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg111x/ShimUtilsImpl.java
+++ b/iceberg/iceberg-1-11-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg111x/ShimUtilsImpl.java
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.iceberg.iceberg111x;
 import com.nvidia.spark.rapids.GpuMetric;
 import com.nvidia.spark.rapids.RapidsConf;
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile;
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.iceberg.IcebergShimUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.*;
@@ -73,10 +74,11 @@ public class ShimUtilsImpl implements IcebergShimUtils {
     @Override
     public ParquetFileReader openParquetReader(
             IcebergInputFile inputFile,
+            RapidsInputFile footerFile,
             Path filePath,
             ParquetReadOptions options,
             scala.collection.immutable.Map<String, GpuMetric> metrics) throws IOException {
-        return GpuParquetIOShim.openReader(inputFile, filePath, options, metrics);
+        return GpuParquetIOShim.openReader(inputFile, footerFile, filePath, options, metrics);
     }
 
     @Override

--- a/iceberg/iceberg-1-11-x/src/main/scala/com/nvidia/spark/rapids/iceberg/iceberg111x/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-11-x/src/main/scala/com/nvidia/spark/rapids/iceberg/iceberg111x/GpuParquetIOShim.scala
@@ -17,11 +17,13 @@
 package com.nvidia.spark.rapids.iceberg.iceberg111x
 
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.{GpuMetric, PerfIO}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import com.nvidia.spark.rapids.iceberg.parquet.converter.ToIcebergShaded
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile
 import com.nvidia.spark.rapids.parquet.{HMBInputFile, ParquetFooterUtils}
 import org.apache.hadoop.fs.Path
+import org.apache.iceberg.aws.s3.IcebergS3InputFile
 import org.apache.iceberg.parquet.GpuParquetIO
 import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
@@ -36,12 +38,22 @@ import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
 object GpuParquetIOShim {
   def openReader(
       inputFile: IcebergInputFile,
+      footerFile: RapidsInputFile,
       filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
     val metadata = withResource(ParquetFooterUtils.getFooterBuffer(
         inputFile, metrics,
-        ParquetFooterUtils.readFooterBufferFromInputFile(inputFile, filePath))) { hmb =>
+        footerFile match {
+          case s3File: IcebergS3InputFile =>
+            PerfIO.readIcebergParquetFooterBuffer(
+              filePath,
+              (length, output, outputOffset) =>
+                s3File.copyTailToHMB(length, output, outputOffset),
+              ParquetFooterUtils.verifyParquetMagic)
+          case _ =>
+            ParquetFooterUtils.readFooterBufferFromInputFile(footerFile, filePath)
+        })) { hmb =>
       val shadedHmbFile = ToIcebergShaded.shade(new HMBInputFile(hmb))
       withResource(shadedHmbFile.newStream()) { hmbStream =>
         ParquetFileReader.readFooter(shadedHmbFile, options, hmbStream)


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Please read https://github.com/NVIDIA/spark-rapids/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request before making this PR.

The following are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.

Thank you for your cooperation!

-->

<!--
Please replace #xxxx with the ID of the issue fixed in this PR. If such issue does not exist, please consider filing one and link it here.
-->
Fixes https://github.com/NVIDIA/cudf-spark/issues/15363.

### Description

<!--
Please provide a description of the changes proposed in this pull request. Here are some questions to help you fill out the description:

- What is the problem you are trying to solve? Describe it from the user's perspective. If you have an existing github issue, please add a summary of the issue here.
- After this change, what will the user experience be like? Please describe any user-facing changes, such as new configurations or new behaviors. If you are introducing new configurations, please add some guidelines on how to use them.
- How are you fixing the problem? Please provide a technical description of your solution. You can add or link your design doc if it exists.
- How are the new features/behaviors tested? Please describe the test cases you added or modified. If they are tested in a cluster, please describe it as well.
-->

Use the existing Iceberg file-I/O factory to obtain an optimized input file when footer bytes are read, while retaining the decrypted Iceberg input file for the Iceberg reader. This is an alternative to #15362 for side-by-side design review.

Validated with Spark 3.5.7 Iceberg module and distribution builds, plus an S3-backed Iceberg smoke test.

### Checklists

<!-- 
For each category, check the one item that applies by putting "x" in the brackets.
-->

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
