### PR TITLE
Support collect_set RESPECT NULLS [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -890,6 +890,33 @@ def test_hash_groupby_collect_list_respect_nulls(use_obj_hash_agg):
         conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower()})
 
 
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set RESPECT NULLS is introduced in Spark 4.2')
+@allow_non_gpu("ProjectExec")
+@ignore_order(local=True)
+@pytest.mark.parametrize('use_obj_hash_agg', [True, False], ids=idfn)
+def test_hash_groupby_collect_set_respect_nulls(use_obj_hash_agg):
+    def doit(spark):
+        return spark.sql("""
+            SELECT a,
+                   sort_array(collect_set(b) IGNORE NULLS) AS ignore_set,
+                   sort_array(collect_set(b) RESPECT NULLS) AS respect_set
+            FROM VALUES
+                (1, 1),
+                (1, NULL),
+                (1, 1),
+                (1, NULL),
+                (2, NULL),
+                (2, 5)
+            AS tab(a, b)
+            GROUP BY a
+        """)
+
+    assert_gpu_and_cpu_are_equal_collect(
+        doit,
+        conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower()})
+
+
 @ignore_order(local=True)
 @pytest.mark.parametrize('use_obj_hash_agg', [True, False], ids=idfn)
 def test_hash_groupby_collect_list_of_maps(use_obj_hash_agg):

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -981,6 +981,33 @@ def test_hash_reduction_collect_set(data_gen):
         lambda spark: gen_df(spark, data_gen, length=100)
             .agg(f.sort_array(f.collect_set('b')), f.count('b')))
 
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set RESPECT NULLS is introduced in Spark 4.2')
+@allow_non_gpu("ProjectExec")
+@ignore_order(local=True)
+def test_hash_reduction_collect_set_respect_nulls():
+    def doit(spark):
+        return spark.sql("""
+            SELECT
+                sort_array(collect_set(i) IGNORE NULLS) AS ignore_int,
+                sort_array(collect_set(i) RESPECT NULLS) AS respect_int,
+                sort_array(collect_set(d) IGNORE NULLS) AS ignore_double,
+                sort_array(collect_set(d) RESPECT NULLS) AS respect_double,
+                sort_array(collect_set(CAST(NULL AS INT)) IGNORE NULLS) AS ignore_all_null,
+                sort_array(collect_set(CAST(NULL AS INT)) RESPECT NULLS) AS respect_all_null
+            FROM VALUES
+                (CAST(1 AS INT), CAST(1.0 AS DOUBLE)),
+                (CAST(NULL AS INT), CAST(NULL AS DOUBLE)),
+                (CAST(1 AS INT), CAST('NaN' AS DOUBLE)),
+                (CAST(NULL AS INT), CAST('NaN' AS DOUBLE)),
+                (CAST(2 AS INT), CAST(2.0 AS DOUBLE))
+            AS tab(i, d)
+        """)
+
+    assert_gpu_and_cpu_are_equal_collect(doit)
+
+
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_set_op, ids=idfn)
 @allow_non_gpu(*non_utc_allow)

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2485,7 +2485,8 @@ def test_window_aggs_for_rows_collect_set_respect_nulls():
 
     assert_gpu_and_cpu_are_equal_collect(
         do_it,
-        conf={'spark.rapids.sql.window.collectSet.enabled': True})
+        conf={'spark.rapids.sql.window.collectSet.enabled': True,
+              'spark.sql.adaptive.enabled': 'false'})
 
 
 @ignore_order(local=True)
@@ -2553,6 +2554,44 @@ def test_window_aggs_for_fully_unbounded_partitioned_collect_set():
         conf={'spark.rapids.sql.window.collectSet.enabled': True,
               'spark.rapids.sql.window.unboundedAgg.enabled': True,
               'spark.sql.parquet.int96RebaseModeInWrite': 'LEGACY',
+              'spark.sql.adaptive.enabled': 'false'},
+        validate_execs_in_gpu_plan=['GpuUnboundedToUnboundedAggWindowExec'])
+
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set RESPECT NULLS is introduced in Spark 4.2')
+@allow_non_gpu("ShuffleExchangeExec")
+@ignore_order(local=True)
+def test_window_aggs_for_fully_unbounded_partitioned_collect_set_respect_nulls():
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: spark.sql("""
+            SELECT * FROM VALUES
+                (1, 1, 1),
+                (1, 2, NULL),
+                (1, 3, 1),
+                (1, 4, NULL),
+                (2, 1, NULL),
+                (2, 2, 5)
+            AS tab(a, b, c)
+        """),
+        "window_collect_table",
+        """
+        SELECT a, b,
+               sort_array(ignore_set) AS ignore_set,
+               sort_array(respect_set) AS respect_set
+        FROM (
+            SELECT a, b,
+                   collect_set(c) IGNORE NULLS OVER
+                     (PARTITION BY a ORDER BY b
+                      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ignore_set,
+                   collect_set(c) RESPECT NULLS OVER
+                     (PARTITION BY a ORDER BY b
+                      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS respect_set
+            FROM window_collect_table
+        ) t
+        """,
+        conf={'spark.rapids.sql.window.collectSet.enabled': True,
+              'spark.rapids.sql.window.unboundedAgg.enabled': True,
               'spark.sql.adaptive.enabled': 'false'},
         validate_execs_in_gpu_plan=['GpuUnboundedToUnboundedAggWindowExec'])
 

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2451,6 +2451,43 @@ def test_window_aggs_for_rows_collect_set():
               'spark.sql.adaptive.enabled': 'false'})
 
 
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set RESPECT NULLS is introduced in Spark 4.2')
+@allow_non_gpu("ShuffleExchangeExec")
+@ignore_order(local=True)
+def test_window_aggs_for_rows_collect_set_respect_nulls():
+    def do_it(spark):
+        spark.sql("""
+            SELECT * FROM VALUES
+                (1, 1, 1),
+                (1, 2, NULL),
+                (1, 3, 1),
+                (1, 4, NULL),
+                (2, 1, NULL),
+                (2, 2, 5)
+            AS tab(a, b, c)
+        """).createOrReplaceTempView("window_collect_table")
+        return spark.sql("""
+            SELECT a, b,
+                   sort_array(ignore_set) AS ignore_set,
+                   sort_array(respect_set) AS respect_set
+            FROM (
+                SELECT a, b,
+                       collect_set(c) IGNORE NULLS OVER
+                         (PARTITION BY a ORDER BY b
+                          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS ignore_set,
+                       collect_set(c) RESPECT NULLS OVER
+                         (PARTITION BY a ORDER BY b
+                          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS respect_set
+                FROM window_collect_table
+            ) t
+        """)
+
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it,
+        conf={'spark.rapids.sql.window.collectSet.enabled': True})
+
+
 @ignore_order(local=True)
 @allow_non_gpu(*non_utc_allow)
 def test_window_aggs_for_fully_unbounded_partitioned_collect_set():

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2455,16 +2455,31 @@ def test_window_aggs_for_rows_collect_set():
                     reason='collect_set RESPECT NULLS is introduced in Spark 4.2')
 @allow_non_gpu("ShuffleExchangeExec")
 @ignore_order(local=True)
-def test_window_aggs_for_rows_collect_set_respect_nulls():
+@pytest.mark.parametrize('data_type', ['INT', 'FLOAT', 'DOUBLE'], ids=idfn)
+def test_window_aggs_for_rows_collect_set_respect_nulls(data_type):
     def do_it(spark):
-        spark.sql("""
-            SELECT * FROM VALUES
-                (1, 1, 1),
+        if data_type == 'INT':
+            values = """
+                (1, 1, '1'),
                 (1, 2, NULL),
-                (1, 3, 1),
+                (1, 3, '1'),
                 (1, 4, NULL),
                 (2, 1, NULL),
-                (2, 2, 5)
+                (2, 2, '5')
+            """
+        else:
+            values = """
+                (1, 1, '1.0'),
+                (1, 2, NULL),
+                (1, 3, 'NaN'),
+                (1, 4, 'NaN'),
+                (2, 1, NULL),
+                (2, 2, '5.0')
+            """
+        spark.sql(f"""
+            SELECT a, b, CAST(c AS {data_type}) AS c
+            FROM VALUES
+                {values}
             AS tab(a, b, c)
         """).createOrReplaceTempView("window_collect_table")
         return spark.sql("""

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3850,7 +3850,8 @@ object GpuOverrides extends Logging {
         }
 
         override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
-          GpuCollectSet(childExprs.head, c.mutableAggBufferOffset, c.inputAggBufferOffset)
+          GpuCollectSet(childExprs.head, c.mutableAggBufferOffset, c.inputAggBufferOffset,
+            TypeUtilsShims.collectSetIgnoreNulls(c))
 
         override def aggBufferAttribute: AttributeReference = {
           val aggBuffer = c.aggBufferAttributes.head
@@ -3858,7 +3859,8 @@ object GpuOverrides extends Logging {
         }
 
         override def createCpuToGpuBufferConverter(): CpuToGpuAggregateBufferConverter =
-          new CpuToGpuCollectBufferConverter(c.child.dataType)
+          new CpuToGpuCollectBufferConverter(c.child.dataType,
+            !TypeUtilsShims.collectSetIgnoreNulls(c))
 
         override def createGpuToCpuBufferConverter(): GpuToCpuAggregateBufferConverter =
           new GpuToCpuCollectBufferConverter()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -115,26 +115,26 @@ class CudfMergeLists(override val dataType: DataType) extends CudfAggregate {
  * for the non-nested NaN equality in CudfCollectSet and CudfMergeSets.
  * Note that dataType is ArrayType(child.dataType) here.
  */
-class CudfCollectSet(override val dataType: DataType) extends CudfAggregate {
+class CudfCollectSet(override val dataType: DataType, nullPolicy: NullPolicy) extends CudfAggregate {
   override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
     (col: cudf.ColumnVector) => {
       val collectSet = dataType match {
         case ArrayType(FloatType | DoubleType, _) =>
           ReductionAggregation.collectSet(
-            NullPolicy.EXCLUDE, NullEquality.EQUAL, TypeUtilsShims.collectSetFloatNanEquality)
+            nullPolicy, NullEquality.EQUAL, TypeUtilsShims.collectSetFloatNanEquality)
         case _: DataType =>
           ReductionAggregation.collectSet(
-            NullPolicy.EXCLUDE, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
+            nullPolicy, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
       }
       col.reduce(collectSet, DType.LIST)
     }
   override lazy val groupByAggregate: GroupByAggregation = dataType match {
     case ArrayType(FloatType | DoubleType, _) =>
       GroupByAggregation.collectSet(
-        NullPolicy.EXCLUDE, NullEquality.EQUAL, TypeUtilsShims.collectSetFloatNanEquality)
+        nullPolicy, NullEquality.EQUAL, TypeUtilsShims.collectSetFloatNanEquality)
     case _: DataType =>
       GroupByAggregation.collectSet(
-        NullPolicy.EXCLUDE, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
+        nullPolicy, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
   }
   override val name: String = "CudfCollectSet"
 }
@@ -1970,10 +1970,17 @@ case class GpuCollectList(
 case class GpuCollectSet(
     child: Expression,
     mutableAggBufferOffset: Int = 0,
-    inputAggBufferOffset: Int = 0)
+    inputAggBufferOffset: Int = 0,
+    ignoreNulls: Boolean = true)
     extends GpuCollectBase with GpuUnboundedToUnboundedWindowAgg {
 
-  override lazy val updateAggregates: Seq[CudfAggregate] = Seq(new CudfCollectSet(dataType))
+  private lazy val nullPolicy: NullPolicy =
+    if (ignoreNulls) NullPolicy.EXCLUDE else NullPolicy.INCLUDE
+
+  override protected def arrayContainsNull: Boolean = !ignoreNulls
+
+  override lazy val updateAggregates: Seq[CudfAggregate] =
+    Seq(new CudfCollectSet(dataType, nullPolicy))
   override lazy val mergeAggregates: Seq[CudfAggregate] = Seq(new CudfMergeSets(dataType))
   override lazy val evaluateExpression: Expression = outputBuf
   override def aggBufferAttributes: Seq[AttributeReference] = outputBuf :: Nil
@@ -1987,10 +1994,10 @@ case class GpuCollectSet(
   override def windowAggregation(
       inputs: Seq[(ColumnVector, Int)]): RollingAggregationOnColumn = child.dataType match {
     case FloatType | DoubleType =>
-      RollingAggregation.collectSet(NullPolicy.EXCLUDE, NullEquality.EQUAL,
+      RollingAggregation.collectSet(nullPolicy, NullEquality.EQUAL,
         TypeUtilsShims.collectSetFloatNanEquality).onColumn(inputs.head._2)
     case _ =>
-      RollingAggregation.collectSet(NullPolicy.EXCLUDE, NullEquality.EQUAL,
+      RollingAggregation.collectSet(nullPolicy, NullEquality.EQUAL,
         NaNEquality.ALL_EQUAL).onColumn(inputs.head._2)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -118,18 +118,15 @@ class CudfMergeLists(override val dataType: DataType) extends CudfAggregate {
 class CudfCollectSet(
     override val dataType: DataType,
     nullPolicy: NullPolicy) extends CudfAggregate {
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (col: cudf.ColumnVector) => {
-      val collectSet = dataType match {
-        case ArrayType(FloatType | DoubleType, _) =>
-          ReductionAggregation.collectSet(
-            nullPolicy, NullEquality.EQUAL, TypeUtilsShims.collectSetFloatNanEquality)
-        case _: DataType =>
-          ReductionAggregation.collectSet(
-            nullPolicy, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
-      }
-      col.reduce(collectSet, DType.LIST)
-    }
+  private lazy val reductionCollectSet: ReductionAggregation = dataType match {
+    case ArrayType(FloatType | DoubleType, _) =>
+      ReductionAggregation.collectSet(
+        nullPolicy, NullEquality.EQUAL, TypeUtilsShims.collectSetFloatNanEquality)
+    case _: DataType =>
+      ReductionAggregation.collectSet(
+        nullPolicy, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
+  }
+
   override lazy val groupByAggregate: GroupByAggregation = dataType match {
     case ArrayType(FloatType | DoubleType, _) =>
       GroupByAggregation.collectSet(
@@ -139,6 +136,25 @@ class CudfCollectSet(
         nullPolicy, NullEquality.EQUAL, NaNEquality.ALL_EQUAL)
   }
   override val name: String = "CudfCollectSet"
+
+  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
+    (col: cudf.ColumnVector) => {
+      if (nullPolicy == NullPolicy.INCLUDE && col.getRowCount > 0) {
+        // cuDF reduction collectSet currently drops nulls for some INCLUDE cases. Use the
+        // group-by implementation for single-group reductions to preserve Spark's null semantics.
+        withResource(Scalar.fromInt(0)) { keyScalar =>
+          withResource(ColumnVector.fromScalar(keyScalar, col.getRowCount.toInt)) { keys =>
+            withResource(new cudf.Table(keys, col)) { table =>
+              withResource(table.groupBy(0).aggregate(groupByAggregate.onColumn(1))) { result =>
+                result.getColumn(1).getScalarElement(0)
+              }
+            }
+          }
+        }
+      } else {
+        col.reduce(reductionCollectSet, DType.LIST)
+      }
+    }
 }
 
 class CudfMergeSets(override val dataType: DataType) extends CudfAggregate {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -139,11 +139,12 @@ class CudfCollectSet(
 
   override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
     (col: cudf.ColumnVector) => {
-      if (nullPolicy == NullPolicy.INCLUDE && col.getRowCount > 0) {
+      val rowCount = Math.toIntExact(col.getRowCount)
+      if (nullPolicy == NullPolicy.INCLUDE && rowCount > 0) {
         // cuDF reduction collectSet currently drops nulls for some INCLUDE cases. Use the
         // group-by implementation for single-group reductions to preserve Spark's null semantics.
         withResource(Scalar.fromInt(0)) { keyScalar =>
-          withResource(ColumnVector.fromScalar(keyScalar, col.getRowCount.toInt)) { keys =>
+          withResource(ColumnVector.fromScalar(keyScalar, rowCount)) { keys =>
             withResource(new cudf.Table(keys, col)) { table =>
               withResource(table.groupBy(0).aggregate(groupByAggregate.onColumn(1))) { result =>
                 result.getColumn(1).getScalarElement(0)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -115,7 +115,9 @@ class CudfMergeLists(override val dataType: DataType) extends CudfAggregate {
  * for the non-nested NaN equality in CudfCollectSet and CudfMergeSets.
  * Note that dataType is ArrayType(child.dataType) here.
  */
-class CudfCollectSet(override val dataType: DataType, nullPolicy: NullPolicy) extends CudfAggregate {
+class CudfCollectSet(
+    override val dataType: DataType,
+    nullPolicy: NullPolicy) extends CudfAggregate {
   override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
     (col: cudf.ColumnVector) => {
       val collectSet = dataType match {

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
@@ -25,7 +25,7 @@ package com.nvidia.spark.rapids.shims
 
 import ai.rapids.cudf.NaNEquality
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.CollectList
+import org.apache.spark.sql.catalyst.expressions.aggregate.{CollectList, CollectSet}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 
 /**
@@ -38,6 +38,8 @@ object TypeUtilsShims {
   val collectSetFloatNanEquality: NaNEquality = NaNEquality.UNEQUAL
 
   def collectListIgnoreNulls(_collectList: CollectList): Boolean = true
+
+  def collectSetIgnoreNulls(_collectSet: CollectSet): Boolean = true
 
   val useImprovedAsinhByDefault: Boolean = false
 

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
@@ -48,7 +48,7 @@ package com.nvidia.spark.rapids.shims
 import ai.rapids.cudf.NaNEquality
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.aggregate.CollectList
+import org.apache.spark.sql.catalyst.expressions.aggregate.{CollectList, CollectSet}
 import org.apache.spark.sql.types.{DataType, NullType, NumericType}
 
 /**
@@ -67,6 +67,8 @@ object TypeUtilsShims {
   val collectSetFloatNanEquality: NaNEquality = NaNEquality.UNEQUAL
 
   def collectListIgnoreNulls(_collectList: CollectList): Boolean = true
+
+  def collectSetIgnoreNulls(_collectSet: CollectSet): Boolean = true
 
   val useImprovedAsinhByDefault: Boolean = false
 

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
@@ -21,7 +21,7 @@ package com.nvidia.spark.rapids.shims
 import ai.rapids.cudf.NaNEquality
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.aggregate.CollectList
+import org.apache.spark.sql.catalyst.expressions.aggregate.{CollectList, CollectSet}
 import org.apache.spark.sql.types.{DataType, NullType, NumericType}
 
 /**
@@ -41,6 +41,8 @@ object TypeUtilsShims {
   val collectSetFloatNanEquality: NaNEquality = NaNEquality.ALL_EQUAL
 
   def collectListIgnoreNulls(collectList: CollectList): Boolean = collectList.ignoreNulls
+
+  def collectSetIgnoreNulls(collectSet: CollectSet): Boolean = collectSet.ignoreNulls
 
   // Spark 4.2 uses fdlibm asinh, so the default CPU behavior matches the stable cuDF kernel.
   val useImprovedAsinhByDefault: Boolean = true


### PR DESCRIPTION
Fixes #15219.

### Description

- Added Spark 4.2 `collect_set RESPECT NULLS` support on GPU by plumbing `ignoreNulls` through shims, expression metadata, GPU aggregate data types, CPU buffer conversion, and cuDF null policy so GPU results preserve one null like Spark CPU.
- Added Spark 4.2 group-by, global reduction, rolling-window, and fully unbounded partitioned-window integration coverage for `collect_set IGNORE NULLS` and `collect_set RESPECT NULLS` because the new SQL clause changes null handling semantics.
- Validated the Spark 4.2 jars and focused integration tests with `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=400 -Dcuda.version=cuda13 -DskipTests validate`, `mvn -s ~/.m2/settings_art.xml -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests validate`, `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -pl dist -am -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests -Dmaven.javadoc.skip=true package`, `SPARK_HOME=/path/to/spark-4.2.0-bin-hadoop3 TESTS="hash_aggregate_test.py window_function_test.py" TEST="test_hash_reduction_collect_set_respect_nulls or test_window_aggs_for_rows_collect_set_respect_nulls" TEST_PARALLEL=0 ./run_pyspark_from_build.sh`, and earlier focused coverage for group-by and fully unbounded windows.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required