### PR TITLE
Re-enable string split anchor fuzz test

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -975,8 +975,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     }
   }
 
-  // Disabled until https://github.com/NVIDIA/cudf-spark/issues/15293 is fixed
-  ignore("string split fuzz - anchor focused") {
+  test("string split fuzz - anchor focused") {
     val (data, patterns) = generateDataAndPatterns(validDataChars = Some("\r\nabc"),
       validPatternChars = "^$\\AZz\r\n()", RegexSplitMode)
     doStringSplitTest(patterns, data, -1)


### PR DESCRIPTION
Related to #15293.

### Description

The cuDF Glushkov fast path no longer treats a lazy quantifier as greedy in split_re (rapidsai/cudf#23381), and the fix is present in the cuDF revision built into the consumed `cudf-spark-jni` snapshot, so the test that was disabled for #15293 can run again.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required