### PR TITLE
Harden GPU ORC reader close under interrupt [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/OrcShims320untilAllBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/OrcShims320untilAllBase.scala
@@ -19,10 +19,10 @@ package com.nvidia.spark.rapids.shims
 import java.nio.ByteBuffer
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.OrcOutputStripe
-import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.hadoop.conf.Configuration
 import org.apache.orc.{CompressionCodec, CompressionKind, DataReader, OrcConf, OrcFile, OrcProto, PhysicalWriter, Reader, StripeInformation, TypeDescription}
 import org.apache.orc.impl.{BufferChunk, DataReaderProperties, InStream, OrcCodecPool, OutStream, ReaderImpl, SchemaEvolution}
@@ -30,21 +30,35 @@ import org.apache.orc.impl.RecordReaderImpl.SargApplier
 import org.apache.orc.impl.reader.StripePlanner
 import org.apache.orc.impl.writer.StreamOptions
 
-trait OrcShims320untilAllBase {
+import org.apache.spark.internal.Logging
+
+trait OrcShims320untilAllBase extends Logging {
 
   // the ORC Reader in non-CDH Spark is closeable
   def withReader[T <: Reader, V](r: T)(block: T => V): V = {
     try {
       block(r)
     } finally {
-      r.safeClose()
+      closeReader(r)
     }
   }
 
   // the ORC Reader in non-CDH Spark is closeable
   def closeReader(reader: Reader): Unit = {
-    if(reader != null) {
-      reader.close()
+    if (reader != null) {
+      // Close without being aborted by a pending interrupt from task cancellation, then restore
+      // the interrupt status for the caller. This matches Spark's SPARK-57958 ORC reader hardening.
+      val interrupted = Thread.interrupted()
+      try {
+        reader.close()
+      } catch {
+        case NonFatal(t) =>
+          logWarning("Failed to close the ORC reader", t)
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt()
+        }
+      }
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shims/OrcShimsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shims/OrcShimsSuite.scala
@@ -18,11 +18,10 @@ package com.nvidia.spark.rapids.shims
 
 import java.io.IOException
 
+import org.apache.orc.Reader
 import org.mockito.Mockito.{doAnswer, doThrow, verify}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.mockito.MockitoSugar
-
-import org.apache.orc.Reader
 
 class OrcShimsSuite extends AnyFunSuite with MockitoSugar {
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shims/OrcShimsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shims/OrcShimsSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import java.io.IOException
+
+import org.mockito.Mockito.{doAnswer, doThrow, verify}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.orc.Reader
+
+class OrcShimsSuite extends AnyFunSuite with MockitoSugar {
+
+  test("closeReader clears and restores interrupt status") {
+    val reader = mock[Reader]
+    var closedWithInterruptSet = true
+    doAnswer { _ =>
+      closedWithInterruptSet = Thread.currentThread().isInterrupted
+      null
+    }.when(reader).close()
+
+    Thread.interrupted()
+    Thread.currentThread().interrupt()
+    try {
+      OrcShims.closeReader(reader)
+
+      assert(!closedWithInterruptSet)
+      assert(Thread.currentThread().isInterrupted)
+      verify(reader).close()
+    } finally {
+      Thread.interrupted()
+    }
+  }
+
+  test("closeReader restores interrupt status after non-fatal close failure") {
+    val reader = mock[Reader]
+    doThrow(new IOException("close failed")).when(reader).close()
+
+    Thread.interrupted()
+    Thread.currentThread().interrupt()
+    try {
+      OrcShims.closeReader(reader)
+
+      assert(Thread.currentThread().isInterrupted)
+      verify(reader).close()
+    } finally {
+      Thread.interrupted()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #15317.

### Description

- Harden GPU ORC `Reader` closing by clearing and restoring the thread interrupt status around `Reader.close()`, so task cancellation cannot prevent filesystem-backed reader resources from being released.
- Route `OrcShims.withReader` through the hardened `closeReader` helper and log/suppress non-fatal close failures, matching Spark's SPARK-57958 ORC reader hardening behavior.
- Add `OrcShimsSuite` coverage for interrupt restoration and non-fatal close failures; validated with `mvn -s ~/.m2/settings_art.xml -Dbuildver=330 -Dcuda.version=cuda13 -pl tests -am -DwildcardSuites=com.nvidia.spark.rapids.shims.OrcShimsSuite package`, `mvn -s ~/.m2/settings_art.xml -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests verify`, and `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=350 -Dcuda.version=cuda13 -DskipTests verify`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required