### PR TITLE
Preserve BroadcastHashJoin isSkewJoin in GPU plan display [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
@@ -120,6 +120,13 @@ abstract class GpuBroadcastHashJoinExecBase(
     isNullAwareAntiJoin: Boolean) extends ShimBinaryExecNode with GpuHashJoin {
   import GpuMetric._
 
+  // Mirror Spark BroadcastHashJoinExec: show skew status in plan strings after AQE
+  // OptimizeSkewedJoin (Spark 4.2+). Subclasses override isSkewJoin when propagating
+  // the CPU flag; older Spark versions keep the GpuHashJoin default of false.
+  override def nodeName: String = {
+    if (isSkewJoin) super.nodeName + "(skew=true)" else super.nodeName
+  }
+
   // Same checks as Spark
   if (isNullAwareAntiJoin) {
     require(leftKeys.length == 1, "leftKeys length should be 1")

--- a/sql-plugin/src/main/spark420/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark420/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -15,29 +15,7 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "340"}
-{"spark": "341"}
-{"spark": "342"}
-{"spark": "343"}
-{"spark": "344"}
-{"spark": "350"}
-{"spark": "351"}
-{"spark": "352"}
-{"spark": "353"}
-{"spark": "354"}
-{"spark": "355"}
-{"spark": "356"}
-{"spark": "357"}
-{"spark": "358"}
-{"spark": "359"}
-{"spark": "400"}
-{"spark": "401"}
-{"spark": "402"}
-{"spark": "403"}
-{"spark": "404"}
-{"spark": "411"}
-{"spark": "412"}
-{"spark": "413"}
+{"spark": "420"}
 spark-rapids-shim-json-lines ***/
 
 package org.apache.spark.sql.rapids.execution
@@ -72,7 +50,8 @@ class GpuBroadcastHashJoinMeta(
       buildSide,
       extractedCondition.joinCondition,
       extractedCondition.left, extractedCondition.right,
-      join.isNullAwareAntiJoin)
+      join.isNullAwareAntiJoin,
+      join.isSkewJoin)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
     val filteredJoinExec =
@@ -89,5 +68,6 @@ case class GpuBroadcastHashJoinExec(
     override val condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan,
-    isNullAwareAntiJoin: Boolean) extends GpuBroadcastHashJoinExecBase(
+    isNullAwareAntiJoin: Boolean,
+    override val isSkewJoin: Boolean) extends GpuBroadcastHashJoinExecBase(
       leftKeys, rightKeys, joinType, buildSide, condition, left, right, isNullAwareAntiJoin)

--- a/tests/src/test/spark420/scala/com/nvidia/spark/rapids/BroadcastHashJoinSkewSuite.scala
+++ b/tests/src/test/spark420/scala/com/nvidia/spark/rapids/BroadcastHashJoinSkewSuite.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
+import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.execution.GpuBroadcastHashJoinExecBase
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
+
+/**
+ * SPARK-44065 added BroadcastHashJoinExec.isSkewJoin. Verify the GPU conversion
+ * preserves the flag and plan-string marker.
+ */
+class BroadcastHashJoinSkewSuite
+    extends SparkQueryCompareTestSuite
+    with AdaptiveSparkPlanHelper {
+
+  private def runAdaptiveAndVerifyResult(
+      spark: SparkSession, query: String): SparkPlan = {
+    val dfAdaptive = spark.sql(query)
+    assert(dfAdaptive.queryExecution.executedPlan.toString
+      .startsWith("AdaptiveSparkPlan isFinalPlan=false"))
+    dfAdaptive.collect()
+    val planAfter = dfAdaptive.queryExecution.executedPlan
+    assert(planAfter.toString.startsWith("AdaptiveSparkPlan isFinalPlan=true"))
+    val adaptivePlan = planAfter.asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+    assert(adaptivePlan.collect { case e: Exchange => e }.isEmpty,
+      "The final plan should not contain any Exchange node.")
+    adaptivePlan
+  }
+
+  test("SPARK-44065: GPU BroadcastHashJoin preserves isSkewJoin in plan display") {
+    val conf = new SparkConf()
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+      .set(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "1000")
+      .set(SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key, "false")
+      .set(SQLConf.SHUFFLE_PARTITIONS.key, "10")
+      .set(SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key, "600")
+      .set(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key, "600")
+      .set(SQLConf.ADAPTIVE_FORCE_OPTIMIZE_SKEWED_JOIN.key, "true")
+
+    withGpuSparkSession(spark => {
+      spark.range(0, 1000, 1, 10)
+        .selectExpr("if(id >= 5, 5, id) as key1", "id as value1")
+        .createOrReplaceTempView("skewData1")
+      spark.range(0, 5, 1, 10)
+        .selectExpr("id as key2", "id as value2")
+        .createOrReplaceTempView("smallData")
+
+      val adaptivePlan = runAdaptiveAndVerifyResult(spark,
+        """select a.key1, count(*) from skewData1 a join smallData b
+          | on a.key1 = b.key2 group by a.key1""".stripMargin)
+      val bhjs = collect(adaptivePlan) {
+        case j: GpuBroadcastHashJoinExecBase => j
+      }
+      assert(bhjs.nonEmpty, s"Expected GpuBroadcastHashJoin in plan:\n$adaptivePlan")
+      assert(bhjs.forall(_.isSkewJoin),
+        s"Expected isSkewJoin=true, got: ${
+          bhjs.map(j => j.getClass.getSimpleName -> j.isSkewJoin)}")
+      assert(bhjs.forall(_.nodeName.endsWith("(skew=true)")),
+        s"Expected (skew=true) in nodeName, got: ${bhjs.map(_.nodeName)}")
+    }, conf)
+  }
+}


### PR DESCRIPTION
Fixes #15379.

### Description

- Propagate `BroadcastHashJoinExec.isSkewJoin` into `GpuBroadcastHashJoinExec` on Spark 4.2 so AQE skew-optimized broadcast joins keep the flag after GPU conversion, matching Spark's SPARK-44065 plan display.
- Override `nodeName` in `GpuBroadcastHashJoinExecBase` to append `(skew=true)` when `isSkewJoin` is set, so GPU explain output mirrors CPU behavior.
- Split the Spark 4.2 BHJ shim from the shared `spark340` path because `isSkewJoin` only exists on BHJ in Spark 4.2+, avoiding compile failures on older shims.
- Add `BroadcastHashJoinSkewSuite` for Spark 4.2 to assert the GPU join preserves `isSkewJoin` and the plan-string marker.

Validation:
- `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests verify -pl sql-plugin,tests -am`
- `mvn -s ~/.m2/settings_art.xml -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests verify -pl sql-plugin -am`
- `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 package -pl tests -am -DwildcardSuites=com.nvidia.spark.rapids.BroadcastHashJoinSkewSuite`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required