### PR TITLE
Allow WriteFilesExec fallback for non-UTC ORC writes [databricks]

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -1125,7 +1125,8 @@ def test_orc_not_support_timestamp_ltz(std_input_path):
 # cannot record the JVM writer timezone (https://github.com/rapidsai/cudf/issues/23422), so a
 # GPU-written non-UTC file would be read back shifted by the zone offset by a CPU ORC reader.
 # The `tz_sensitive_test` mark runs this in both UTC and non-UTC JVM timezones.
-non_utc_orc_write_allow = ['DataWritingCommandExec'] if is_not_utc() else []
+non_utc_orc_write_allow = ['DataWritingCommandExec', 'WriteFilesExec'] \
+    if is_not_utc() else []
 
 @tz_sensitive_test
 @ignore_order(local=True)


### PR DESCRIPTION
Fixes #15405.

### Description

`test_orc_gpu_write_cpu_read_timestamp_in_non_utc_timezone` expects ORC timestamp
writes to fall back to CPU when the JVM and Spark session use a non-UTC timezone.
On Spark versions whose write plan exposes `WriteFilesExec`, that node is also
reported as a CPU fallback because its parent write command cannot run on GPU, but
the test only allowed `DataWritingCommandExec`.

This change allows `WriteFilesExec` only in the existing non-UTC allow list. UTC
test behavior remains unchanged.

Validation:
- `build/buildall --profile=noSnapshots -P=4` built the Scala 2.12 uber jar with
  20 shims.
- `build/buildall --scala213 --profile=noSnapshots -P=4` built the Scala 2.13
  uber jar with all 19 supported shims.
- `orc_test.py::test_orc_gpu_write_cpu_read_timestamp_in_non_utc_timezone` passed
  with `TZ=Asia/Shanghai` on all 20 supported Scala 2.12 Spark installations and
  all 19 supported Scala 2.13 Spark installations from Spark 3.3.0 through 4.2.0.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
