### PR TITLE
Reduce timezone integration tests in precommit [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -40,6 +40,7 @@ markers =
     pyarrow_test: Mark pyarrow tests
     datagen_overrides: Mark that allows overriding datagen settings (i.e. seed) for a test
     tz_sensitive_test: Mark the test as a time zone sensitive test which will be tested against extra timezones
+    tz_sensitive_test_for_precommit: Mark a representative subset of time zone sensitive tests for pre-commit
     spark_job_timeout(seconds, dump_threads): Override the default timeout setting
 filterwarnings =
     ignore:.*pytest.mark.order.*:_pytest.warning_types.PytestUnknownMarkWarning

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -18,7 +18,8 @@ from asserts import *
 from conftest import is_not_utc, is_supported_time_zone, is_dataproc_serverless_runtime
 from data_gen import *
 from spark_session import *
-from marks import allow_non_gpu, approximate_float, datagen_overrides, disable_ansi_mode, tz_sensitive_test
+from marks import (allow_non_gpu, approximate_float, datagen_overrides, disable_ansi_mode,
+                   tz_sensitive_test, tz_sensitive_test_for_precommit)
 from pyspark.sql.types import *
 from spark_init_internal import spark_version
 from datetime import date, datetime, timedelta
@@ -167,7 +168,9 @@ def test_try_cast_string_date_fallback_340(invalid):
         'Cast',
         conf = ansi_enabled_conf)
 
-@pytest.mark.parametrize('data_gen', [StringGen(date_start_1_1_1),
+@pytest.mark.parametrize('data_gen', [
+                                      pytest.param(StringGen(date_start_1_1_1),
+                                                   marks=tz_sensitive_test_for_precommit),
                                       StringGen(date_start_1_1_1 + '[ T][0-3][0-9]:[0-6][0-9]:[0-6][0-9]'),
                                       StringGen(date_start_1_1_1 + '[ T][0-3][0-9]:[0-6][0-9]:[0-6][0-9]\.[0-9]{0,6}Z?'),
                                       # year < 2200, this is testing running on GPU when default TZ is DST
@@ -642,6 +645,7 @@ def test_cast_timestamp_to_string():
             .selectExpr("cast(a as string)"))
 
 @tz_sensitive_test
+@tz_sensitive_test_for_precommit
 @allow_non_gpu(*non_supported_tz_allow)
 def test_cast_timestamp_to_date():
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -18,7 +18,8 @@ from conftest import is_utc, get_test_tz, is_databricks_runtime
 from data_gen import *
 from datetime import date, datetime, timezone
 from dateutil import tz
-from marks import allow_non_gpu, approximate_float, datagen_overrides, disable_ansi_mode, ignore_order, incompat, tz_sensitive_test
+from marks import (allow_non_gpu, approximate_float, datagen_overrides, disable_ansi_mode,
+                   ignore_order, incompat, tz_sensitive_test, tz_sensitive_test_for_precommit)
 from pyspark.sql.types import *
 from spark_session import with_cpu_session, is_before_spark_350, is_before_spark_400
 import pyspark.sql.functions as f
@@ -661,7 +662,10 @@ def test_to_timestamp_runtime_fallback(parser_policy):
 
 @disable_ansi_mode  # ANSI mode is tested separately.
 @tz_sensitive_test
-@pytest.mark.parametrize('parser_policy', ["CORRECTED", "EXCEPTION"], ids=idfn)
+@pytest.mark.parametrize('parser_policy', [
+    pytest.param("CORRECTED", marks=tz_sensitive_test_for_precommit),
+    "EXCEPTION"
+], ids=idfn)
 def test_to_timestamp_tz_rules(parser_policy):
     gen = StringGen("(19[0-9]{2}|20[0-9]{2}|21[0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) ([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]")
     if get_test_tz() == "Asia/Shanghai":

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ large_data_test = pytest.mark.large_data_test
 pyarrow_test = pytest.mark.pyarrow_test
 datagen_overrides = pytest.mark.datagen_overrides
 tz_sensitive_test = pytest.mark.tz_sensitive_test
+tz_sensitive_test_for_precommit = pytest.mark.tz_sensitive_test_for_precommit
 hybrid_test = pytest.mark.hybrid_test
 
 # Specific mark for allowing non-GPU Delta writes based on certain conditions.

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -1144,7 +1144,12 @@ def test_orc_gpu_write_cpu_read_timestamp_in_non_utc_timezone(spark_tmp_path):
         assert_gpu_and_cpu_writes_are_equal_collect(write_func, read_func, data_path)
 
 
-@pytest.mark.parametrize("reader_confs", reader_opt_confs, ids=idfn)
+# One PERFILE reader configuration is sufficient to cover the GpuTimeZoneDB ORC paths.
+# Keep all timezone pairs and V1/V2 readers to exercise both fixed and recurring DST rules.
+@pytest.mark.parametrize("reader_confs", [
+    pytest.param(reader_opt_confs[0], marks=tz_sensitive_test_for_precommit),
+    *reader_opt_confs[1:]
+], ids=idfn)
 @pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
 @pytest.mark.parametrize("timezone_pair", [("UTC", "Asia/Shanghai"), ("Asia/Shanghai", "UTC"), ("Asia/Shanghai", "America/Los_Angeles")], ids=idfn)
 @tz_sensitive_test

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -140,13 +140,12 @@ mvn_verify() {
     # Triggering here until we change the jenkins file
     rapids_shuffle_smoke_test
 
-    # Test a portion of cases for non-UTC time zone because of limited GPU resources.
-    # Here testing: parquet scan, orc scan, csv scan, cast, TimeZoneAwareExpression, FromUTCTimestamp
-    # Nightly CIs will cover all the cases.
+    # Test a representative subset of non-UTC timezone cases in pre-commit.
+    # Nightly CIs cover all tests marked with tz_sensitive_test.
     source "$(dirname "$0")"/test-timezones.sh
     for tz in "${time_zones_test_cases[@]}"
     do
-        TZ=$tz ./integration_tests/run_pyspark_from_build.sh -m tz_sensitive_test
+        TZ=$tz ./integration_tests/run_pyspark_from_build.sh -m tz_sensitive_test_for_precommit
     done
 
     # test Hybrid feature


### PR DESCRIPTION
Fixes #15345.

### Description

#### Problem

Premerge currently reuses `tz_sensitive_test`, the marker intended for comprehensive nightly coverage. Its parameterized tests collect 1,542 cases for each additional timezone, so the two premerge runs take approximately 10 minutes in total.

Using reduced-IT selection alone would still retain 318 cases per timezone. The premerge path needs a smaller, coverage-oriented subset instead of the complete nightly matrix.

#### Change

Register `tz_sensitive_test_for_precommit` and apply it to nine representative cases per timezone:

- cast and date-time cases that exercise the core `GpuTimeZoneDB` conversion paths
- ORC coverage for fixed-offset and recurring-DST timezone pairs
- ORC V1 and V2 readers with one representative reader configuration

Update `spark-premerge-build.sh` to select the new marker. Existing `tz_sensitive_test` annotations and nightly selection remain unchanged.

#### Impact

Premerge collection decreases from 1,542 to 9 cases per timezone, or from 3,084 to 18 cases across both timezone runs—a 99.4% reduction. Nightly CI continues to run the complete timezone-sensitive matrix. There is no user-facing behavior change.

#### Validation

- Collected 1,542 cases with `-m tz_sensitive_test`
- Collected 9 cases with `-m tz_sensitive_test_for_precommit`
- Passed all 9 selected cases with `Asia/Shanghai`
- Passed all 9 selected cases with `America/New_York`
- Completed a Spark 3.5.6 clean build with JDK 17

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
