### PR TITLE
Skip hybrid IT cases in premerge [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -149,11 +149,6 @@ mvn_verify() {
         TZ=$tz ./integration_tests/run_pyspark_from_build.sh -m tz_sensitive_test
     done
 
-    # test Hybrid feature
-    source "${WORKSPACE}/jenkins/hybrid_execution.sh"
-    if hybrid_prepare ; then
-        LOAD_HYBRID_BACKEND=1 ./integration_tests/run_pyspark_from_build.sh -m hybrid_test
-    fi
 }
 
 rapids_shuffle_smoke_test() {


### PR DESCRIPTION
Contributes to #15404.

### Description

#### Problem

Premerge invokes the Hybrid execution IT suite separately even though the nightly/default IT path already covers it. The invocation takes approximately 2 minutes 48 seconds, and reduced-IT selection only lowers the collected cases from 314 to 252 (19.7%). This makes case reduction ineffective for this scenario.

#### Change

Remove the Hybrid setup and `hybrid_test` invocation from `mvn_verify` in `jenkins/spark-premerge-build.sh`. Test definitions and the nightly test path are unchanged.

#### Impact

Premerge no longer spends approximately 2 minutes 48 seconds on this scenario. Hybrid execution remains fully covered by nightly CI, and developers can still run it explicitly with `TEST_MODE=HYBRID_EXECUTION`. There is no user-facing behavior change.

#### Validation

- `bash -n jenkins/spark-premerge-build.sh`
- `git diff --check`
- Verified that the existing `hybrid_test` suite still runs from `jenkins/spark-tests.sh` for `DEFAULT` and `HYBRID_EXECUTION`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`hybrid_test` remains in nightly `DEFAULT` and explicit `HYBRID_EXECUTION` modes.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
