### PR TITLE
Migrate to ColumnVector mergeAndSetValidity API for substring

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -606,7 +606,7 @@ case class GpuSubstring(str: Expression, pos: Expression, len: Expression)
     }
   }
 
-  private[this] def substringColumn(strs: ColumnView, starts: ColumnView,
+  private[this] def substringColumn(strs: ColumnVector, starts: ColumnView,
       ends: ColumnView): ColumnVector = {
     // cudf does not allow nulls in starts and ends.
     val noNullStarts = new ColumnView(starts.getType, starts.getRowCount, Optional.of(0L),


### PR DESCRIPTION
Contributes to rapidsai/cudf#23249. This depends on propagation of https://github.com/rapidsai/cudf/pull/23030.

### Description

This prepares cudf-spark for rapidsai/cudf#23030, which adds the `ColumnVector.mergeAndSetValidity` API and deprecates the `ColumnView` API to enforce zero-copy semantics on no-op merges.

`substringColumn` currently declares its string input as a `ColumnView` even though every caller supplies a `ColumnVector`. So this just changes the parameter type to `ColumnVector` to go through the new API. There is no change in runtime behavior. The existing `test_substring` and `test_substring_column` integration tests cover this path.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
