### PR TITLE
Pass DSv2 WriteSummary from GPU MERGE commits [databricks]

### DIFF
--- a/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/write.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/write.scala
@@ -16,11 +16,15 @@
 
 package org.apache.iceberg.spark.source
 
+import com.nvidia.spark.rapids.shims.GpuV2BatchWriteSummaryCommit
+
 import org.apache.spark.sql.connector.write._
 
 abstract class GpuBaseBatchWrite(
     write: GpuSparkWrite,
-    cpuBatchWrite: BatchWrite) extends BatchWrite {
+    cpuBatchWrite: BatchWrite) extends BatchWrite with GpuV2BatchWriteSummaryCommit {
+  override protected def summaryCommitDelegate: BatchWrite = cpuBatchWrite
+
   override def createBatchWriterFactory(physicalWriteInfo: PhysicalWriteInfo): DataWriterFactory
   = write.createDataWriterFactory
 
@@ -76,8 +80,9 @@ class GpuCopyOnWriteOperation(write: GpuSparkWrite, cpuBatchWrite: BatchWrite)
  */
 class GpuPositionDeltaBatchWrite(write: GpuSparkPositionDeltaWrite,
                                  cpuBatchWrite: DeltaBatchWrite)
-  extends DeltaBatchWrite {
-  
+  extends DeltaBatchWrite with GpuV2BatchWriteSummaryCommit {
+
+  override protected def summaryCommitDelegate: BatchWrite = cpuBatchWrite
 
   override def commit(messages: Array[WriterCommitMessage]): Unit = {
     // Delegate to CPU PositionDeltaBatchWrite's commit method

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -570,7 +570,7 @@ protected case class GpuParquetFileFilterHandler(
     if (fileIO.isInstanceOf[HadoopFileIO]) {
       // We should remove this after https://github.com/NVIDIA/spark-rapids/issues/13306 is
       // implemented.
-      val result = PerfIO.readParquetFooterBuffer(filePath, conf, verifyParquetMagic)
+      val result = PerfIO.readParquetFooterBuffer(filePath, conf, verifyParquetMagic _)
       val scheme = filePath.toUri.getScheme
       if (scheme != null && scheme.startsWith("s3")) {
         GpuTaskMetrics.get.recordPerfioS3BackendOnce()

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/GpuMergeRowsExecMeta.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/GpuMergeRowsExecMeta.scala
@@ -39,6 +39,8 @@ spark-rapids-shim-json-lines ***/
 
 package com.nvidia.spark.rapids
 
+import com.nvidia.spark.rapids.shims.GpuMergeRowsKeepShims
+
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Instruction, Keep, Split}
 import org.apache.spark.sql.execution.datasources.v2.{GpuMergeRowsExec, MergeRowsExec}
@@ -79,7 +81,7 @@ class GpuKeepInstructionMeta(
   override def convertToGpuImpl(): GpuExpression = {
     val gpuCondition = childExprs.head.convertToGpu()
     val gpuOutputs = childExprs.tail.map(_.convertToGpu())
-    GpuKeep(gpuCondition, gpuOutputs)
+    GpuKeep(gpuCondition, gpuOutputs, GpuMergeRowsKeepShims.actionOf(keep))
   }
 }
 

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuMergeRowMetricsShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuMergeRowMetricsShims.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+/**
+ * Spark < 4.1 has no DSv2 WriteSummary commit API, so MERGE row accounting used for
+ * MergeSummary is unused and should be skipped.
+ */
+object GpuMergeRowMetricsShims {
+  val writeSummaryEnabled: Boolean = false
+}

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuMergeRowsKeepShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuMergeRowsKeepShims.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.Keep
+import org.apache.spark.sql.execution.datasources.v2.GpuMergeRowsExec
+
+/**
+ * Spark &lt; 4.1 Keep has no Context, so Keep actions cannot be classified for WriteSummary.
+ */
+object GpuMergeRowsKeepShims {
+  def actionOf(keep: Keep): String = GpuMergeRowsExec.ACTION_UNKNOWN
+}

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuV2BatchWriteSummaryCommit.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuV2BatchWriteSummaryCommit.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.connector.write.BatchWrite
+
+/**
+ * No-op on Spark versions that lack [[org.apache.spark.sql.connector.write.WriteSummary]].
+ * GPU [[BatchWrite]] wrappers mix this in so the Spark 4.1+ shim can override the summary
+ * commit path without breaking older builds.
+ */
+trait GpuV2BatchWriteSummaryCommit { this: BatchWrite =>
+  protected def summaryCommitDelegate: BatchWrite
+}

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
@@ -47,7 +47,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
-import com.nvidia.spark.rapids.shims.{ShimExpression, ShimUnaryExecNode}
+import com.nvidia.spark.rapids.shims.{GpuMergeRowMetricsShims, ShimExpression, ShimUnaryExecNode}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -105,24 +105,35 @@ case class GpuMergeRowsExec(
     AttributeSet.fromAttributeSets(usedExprs.map(_.references)) -- producedAttributes
   }
 
-  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
-    OP_TIME_LEGACY -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME_LEGACY),
-    NUM_OUTPUT_ROWS -> createMetric(ESSENTIAL_LEVEL, DESCRIPTION_NUM_OUTPUT_ROWS),
-    NUM_OUTPUT_BATCHES -> createMetric(MODERATE_LEVEL, DESCRIPTION_NUM_OUTPUT_BATCHES),
-    NUM_TARGET_ROWS_COPIED -> createMetric(ESSENTIAL_LEVEL,
-      "number of target rows copied unmodified because they did not match any action"),
-    NUM_TARGET_ROWS_INSERTED -> createMetric(ESSENTIAL_LEVEL, "number of target rows inserted"),
-    NUM_TARGET_ROWS_DELETED -> createMetric(ESSENTIAL_LEVEL, "number of target rows deleted"),
-    NUM_TARGET_ROWS_UPDATED -> createMetric(ESSENTIAL_LEVEL, "number of target rows updated"),
-    NUM_TARGET_ROWS_MATCHED_UPDATED -> createMetric(MODERATE_LEVEL,
-      "number of target rows updated by a matched clause"),
-    NUM_TARGET_ROWS_MATCHED_DELETED -> createMetric(MODERATE_LEVEL,
-      "number of target rows deleted by a matched clause"),
-    NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED -> createMetric(MODERATE_LEVEL,
-      "number of target rows updated by a not matched by source clause"),
-    NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED -> createMetric(MODERATE_LEVEL,
-      "number of target rows deleted by a not matched by source clause")
-  )
+  override lazy val additionalMetrics: Map[String, GpuMetric] = {
+    val common = Map(
+      OP_TIME_LEGACY -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME_LEGACY),
+      NUM_OUTPUT_ROWS -> createMetric(ESSENTIAL_LEVEL, DESCRIPTION_NUM_OUTPUT_ROWS),
+      NUM_OUTPUT_BATCHES -> createMetric(MODERATE_LEVEL, DESCRIPTION_NUM_OUTPUT_BATCHES))
+    // MergeSummary fields must stay ESSENTIAL: metrics.level must not change committed
+    // table metadata. Skip registration before Spark 4.1 where WriteSummary is unused.
+    if (GpuMergeRowMetricsShims.writeSummaryEnabled) {
+      common ++ Map(
+        NUM_TARGET_ROWS_COPIED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows copied unmodified because they did not match any action"),
+        NUM_TARGET_ROWS_INSERTED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows inserted"),
+        NUM_TARGET_ROWS_DELETED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows deleted"),
+        NUM_TARGET_ROWS_UPDATED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows updated"),
+        NUM_TARGET_ROWS_MATCHED_UPDATED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows updated by a matched clause"),
+        NUM_TARGET_ROWS_MATCHED_DELETED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows deleted by a matched clause"),
+        NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows updated by a not matched by source clause"),
+        NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED -> createMetric(ESSENTIAL_LEVEL,
+          "number of target rows deleted by a not matched by source clause"))
+    } else {
+      common
+    }
+  }
 
   override def supportsColumnar: Boolean = true
 
@@ -130,15 +141,19 @@ case class GpuMergeRowsExec(
     val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
     val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
     val opTime = gpuLongMetric(OP_TIME_LEGACY)
-    val mergeMetrics = MergeRowMetrics(
-      gpuLongMetric(NUM_TARGET_ROWS_COPIED),
-      gpuLongMetric(NUM_TARGET_ROWS_INSERTED),
-      gpuLongMetric(NUM_TARGET_ROWS_DELETED),
-      gpuLongMetric(NUM_TARGET_ROWS_UPDATED),
-      gpuLongMetric(NUM_TARGET_ROWS_MATCHED_UPDATED),
-      gpuLongMetric(NUM_TARGET_ROWS_MATCHED_DELETED),
-      gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED),
-      gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED))
+    val mergeMetrics = if (GpuMergeRowMetricsShims.writeSummaryEnabled) {
+      MergeRowMetrics(
+        gpuLongMetric(NUM_TARGET_ROWS_COPIED),
+        gpuLongMetric(NUM_TARGET_ROWS_INSERTED),
+        gpuLongMetric(NUM_TARGET_ROWS_DELETED),
+        gpuLongMetric(NUM_TARGET_ROWS_UPDATED),
+        gpuLongMetric(NUM_TARGET_ROWS_MATCHED_UPDATED),
+        gpuLongMetric(NUM_TARGET_ROWS_MATCHED_DELETED),
+        gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED),
+        gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED))
+    } else {
+      MergeRowMetrics.noop
+    }
 
     val dataTypes = GpuColumnVector.extractTypes(child.schema)
 
@@ -245,6 +260,18 @@ object GpuMergeRowsExec {
         other.numTargetRowsNotMatchedBySourceDeleted.value
     }
 
+    /** Clear staging counters before a retry attempt. */
+    def reset(): Unit = {
+      numTargetRowsCopied.set(0L)
+      numTargetRowsInserted.set(0L)
+      numTargetRowsDeleted.set(0L)
+      numTargetRowsUpdated.set(0L)
+      numTargetRowsMatchedUpdated.set(0L)
+      numTargetRowsMatchedDeleted.set(0L)
+      numTargetRowsNotMatchedBySourceUpdated.set(0L)
+      numTargetRowsNotMatchedBySourceDeleted.set(0L)
+    }
+
     def record(instruction: GpuInstruction, numRows: Long, sourcePresent: Boolean): Unit = {
       if (numRows > 0) {
         instruction match {
@@ -266,7 +293,12 @@ object GpuMergeRowsExec {
   }
 
   object MergeRowMetrics {
-    /** Per-attempt staging metrics that are discarded on OOM retry. */
+    /** Shared no-op metrics when WriteSummary accounting is disabled (Spark < 4.1). */
+    val noop: MergeRowMetrics = MergeRowMetrics(
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric,
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+
+    /** Per-iterator staging metrics that are reset on each OOM retry attempt. */
     def local(): MergeRowMetrics = MergeRowMetrics(
       new LocalGpuMetric(),
       new LocalGpuMetric(),
@@ -276,6 +308,10 @@ object GpuMergeRowsExec {
       new LocalGpuMetric(),
       new LocalGpuMetric(),
       new LocalGpuMetric())
+
+    def forAttempt(): MergeRowMetrics = {
+      if (GpuMergeRowMetricsShims.writeSummaryEnabled) local() else noop
+    }
   }
 
   sealed trait GpuInstruction extends GpuUnevaluable with ShimExpression {
@@ -356,6 +392,9 @@ class GpuMergeBatchIterator(
 
   import GpuMergeRowsExec.MergeRowMetrics
 
+  // Reused across batches/attempts; reset() clears counts before each retry attempt.
+  private val attemptMetrics: MergeRowMetrics = MergeRowMetrics.forAttempt()
+
   override def hasNext: Boolean = inputIter.hasNext
 
   override def next(): ColumnarBatch = {
@@ -378,10 +417,8 @@ class GpuMergeBatchIterator(
    * reprocesses the same batch.
    */
   private def processBatch(batch: ColumnarBatch): ColumnarBatch = {
-    var attemptMetrics: MergeRowMetrics = null
     val result = withRetryNoSplit(batch) { _ =>
-      // Fresh staging metrics for each attempt so failed retries are discarded.
-      attemptMetrics = MergeRowMetrics.local()
+      attemptMetrics.reset()
       // Evaluate presence flags
       val outputs = new ArrayBuffer[SpillableColumnarBatch](
         matchedInstructionExecs.size + notMatchedInstructionExecs.size

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
@@ -87,6 +87,7 @@ case class GpuMergeRowsExec(
     child: SparkPlan) extends ShimUnaryExecNode with GpuExec {
 
   import GpuMetric._
+  import GpuMergeRowsExec._
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -107,7 +108,20 @@ case class GpuMergeRowsExec(
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
     OP_TIME_LEGACY -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME_LEGACY),
     NUM_OUTPUT_ROWS -> createMetric(ESSENTIAL_LEVEL, DESCRIPTION_NUM_OUTPUT_ROWS),
-    NUM_OUTPUT_BATCHES -> createMetric(MODERATE_LEVEL, DESCRIPTION_NUM_OUTPUT_BATCHES)
+    NUM_OUTPUT_BATCHES -> createMetric(MODERATE_LEVEL, DESCRIPTION_NUM_OUTPUT_BATCHES),
+    NUM_TARGET_ROWS_COPIED -> createMetric(ESSENTIAL_LEVEL,
+      "number of target rows copied unmodified because they did not match any action"),
+    NUM_TARGET_ROWS_INSERTED -> createMetric(ESSENTIAL_LEVEL, "number of target rows inserted"),
+    NUM_TARGET_ROWS_DELETED -> createMetric(ESSENTIAL_LEVEL, "number of target rows deleted"),
+    NUM_TARGET_ROWS_UPDATED -> createMetric(ESSENTIAL_LEVEL, "number of target rows updated"),
+    NUM_TARGET_ROWS_MATCHED_UPDATED -> createMetric(MODERATE_LEVEL,
+      "number of target rows updated by a matched clause"),
+    NUM_TARGET_ROWS_MATCHED_DELETED -> createMetric(MODERATE_LEVEL,
+      "number of target rows deleted by a matched clause"),
+    NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED -> createMetric(MODERATE_LEVEL,
+      "number of target rows updated by a not matched by source clause"),
+    NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED -> createMetric(MODERATE_LEVEL,
+      "number of target rows deleted by a not matched by source clause")
   )
 
   override def supportsColumnar: Boolean = true
@@ -116,6 +130,15 @@ case class GpuMergeRowsExec(
     val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
     val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
     val opTime = gpuLongMetric(OP_TIME_LEGACY)
+    val mergeMetrics = MergeRowMetrics(
+      gpuLongMetric(NUM_TARGET_ROWS_COPIED),
+      gpuLongMetric(NUM_TARGET_ROWS_INSERTED),
+      gpuLongMetric(NUM_TARGET_ROWS_DELETED),
+      gpuLongMetric(NUM_TARGET_ROWS_UPDATED),
+      gpuLongMetric(NUM_TARGET_ROWS_MATCHED_UPDATED),
+      gpuLongMetric(NUM_TARGET_ROWS_MATCHED_DELETED),
+      gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED),
+      gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED))
 
     val dataTypes = GpuColumnVector.extractTypes(child.schema)
 
@@ -144,7 +167,8 @@ case class GpuMergeRowsExec(
         boundMatchedBySourceInsts,
         numOutputRows,
         numOutputBatches,
-        opTime)
+        opTime,
+        mergeMetrics)
     }
   }
 
@@ -157,6 +181,75 @@ case class GpuMergeRowsExec(
 }
 
 object GpuMergeRowsExec {
+
+  // Metric names must match Spark MergeRowsExec / MergeSummaryImpl field names.
+  val NUM_TARGET_ROWS_COPIED = "numTargetRowsCopied"
+  val NUM_TARGET_ROWS_INSERTED = "numTargetRowsInserted"
+  val NUM_TARGET_ROWS_DELETED = "numTargetRowsDeleted"
+  val NUM_TARGET_ROWS_UPDATED = "numTargetRowsUpdated"
+  val NUM_TARGET_ROWS_MATCHED_UPDATED = "numTargetRowsMatchedUpdated"
+  val NUM_TARGET_ROWS_MATCHED_DELETED = "numTargetRowsMatchedDeleted"
+  val NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED = "numTargetRowsNotMatchedBySourceUpdated"
+  val NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED = "numTargetRowsNotMatchedBySourceDeleted"
+
+  /** Action tags used for WriteSummary metrics; values come from version shims. */
+  val ACTION_COPY = "copy"
+  val ACTION_INSERT = "insert"
+  val ACTION_UPDATE = "update"
+  val ACTION_DELETE = "delete"
+  val ACTION_UNKNOWN = "unknown"
+
+  case class MergeRowMetrics(
+      numTargetRowsCopied: GpuMetric,
+      numTargetRowsInserted: GpuMetric,
+      numTargetRowsDeleted: GpuMetric,
+      numTargetRowsUpdated: GpuMetric,
+      numTargetRowsMatchedUpdated: GpuMetric,
+      numTargetRowsMatchedDeleted: GpuMetric,
+      numTargetRowsNotMatchedBySourceUpdated: GpuMetric,
+      numTargetRowsNotMatchedBySourceDeleted: GpuMetric) {
+
+    def incrementCopy(n: Long): Unit = numTargetRowsCopied += n
+
+    def incrementInsert(n: Long): Unit = numTargetRowsInserted += n
+
+    def incrementDelete(n: Long, sourcePresent: Boolean): Unit = {
+      numTargetRowsDeleted += n
+      if (sourcePresent) {
+        numTargetRowsMatchedDeleted += n
+      } else {
+        numTargetRowsNotMatchedBySourceDeleted += n
+      }
+    }
+
+    def incrementUpdate(n: Long, sourcePresent: Boolean): Unit = {
+      numTargetRowsUpdated += n
+      if (sourcePresent) {
+        numTargetRowsMatchedUpdated += n
+      } else {
+        numTargetRowsNotMatchedBySourceUpdated += n
+      }
+    }
+
+    def record(instruction: GpuInstruction, numRows: Long, sourcePresent: Boolean): Unit = {
+      if (numRows > 0) {
+        instruction match {
+          case keep: GpuKeep =>
+            keep.action match {
+              case ACTION_COPY => incrementCopy(numRows)
+              case ACTION_INSERT => incrementInsert(numRows)
+              case ACTION_UPDATE => incrementUpdate(numRows, sourcePresent)
+              case ACTION_DELETE => incrementDelete(numRows, sourcePresent)
+              case ACTION_UNKNOWN => // Spark < 4.1 Keep has no context; skip ambiguous counts
+              case other =>
+                throw new IllegalArgumentException(s"Unexpected Keep action: $other")
+            }
+          case _: GpuDiscard => incrementDelete(numRows, sourcePresent)
+          case _: GpuSplit => incrementUpdate(numRows, sourcePresent)
+        }
+      }
+    }
+  }
 
   sealed trait GpuInstruction extends GpuUnevaluable with ShimExpression {
     def condition: Expression
@@ -175,7 +268,13 @@ object GpuMergeRowsExec {
     override def dataType: DataType = NullType
   }
 
-  case class GpuKeep(condition: Expression, output: Seq[Expression]) extends GpuInstruction {
+  /**
+   * @param action one of ACTION_* tags; on Spark 4.1+ this mirrors Keep.context
+   */
+  case class GpuKeep(
+      condition: Expression,
+      output: Seq[Expression],
+      action: String) extends GpuInstruction {
 
     override def children: Seq[Expression] = Seq(condition) ++ output
     override def outputs: Seq[Seq[Expression]] = Seq(output)
@@ -213,6 +312,7 @@ object GpuMergeRowsExec {
  * @param numOutputRows Metric for output rows
  * @param numOutputBatches Metric for output batches
  * @param opTime Metric for operation time
+ * @param mergeMetrics DML metrics forwarded to WriteSummary on Spark 4.1+
  */
 class GpuMergeBatchIterator(
     inputDataTypes: Array[DataType],
@@ -224,7 +324,8 @@ class GpuMergeBatchIterator(
     notMatchedBySourceInstructionExecs: Seq[GpuInstruction],
     numOutputRows: GpuMetric,
     numOutputBatches: GpuMetric,
-    opTime: GpuMetric) extends Iterator[ColumnarBatch] {
+    opTime: GpuMetric,
+    mergeMetrics: GpuMergeRowsExec.MergeRowMetrics) extends Iterator[ColumnarBatch] {
 
   override def hasNext: Boolean = inputIter.hasNext
 
@@ -260,19 +361,19 @@ class GpuMergeBatchIterator(
 
             val matchedMask = sourcePresent.getBase.and(targetPresent.getBase)
             processInstructionSet(inputDataTypes, outputs, batch,
-              matchedMask, matchedInstructionExecs)
+              matchedMask, matchedInstructionExecs, sourcePresent = true)
 
             val notMatchedMask = withResource(targetPresent.getBase.not()) { noTargetMask =>
               sourcePresent.getBase.and(noTargetMask)
             }
             processInstructionSet(inputDataTypes, outputs, batch, notMatchedMask,
-                notMatchedInstructionExecs)
+                notMatchedInstructionExecs, sourcePresent = true)
 
             val notMatchedBySrcMask = withResource(sourcePresent.getBase.not()) { noSourceMask =>
               targetPresent.getBase.and(noSourceMask)
             }
             processInstructionSet(inputDataTypes, outputs, batch, notMatchedBySrcMask,
-                notMatchedBySourceInstructionExecs)
+                notMatchedBySourceInstructionExecs, sourcePresent = false)
           }
         }
       }
@@ -295,7 +396,8 @@ class GpuMergeBatchIterator(
      outputs: ArrayBuffer[SpillableColumnarBatch],
      batch: ColumnarBatch,
      mask: ColumnVector,
-     instructionExecs: Seq[GpuInstruction]): Unit = {
+     instructionExecs: Seq[GpuInstruction],
+     sourcePresent: Boolean): Unit = {
 
     if (instructionExecs.isEmpty) {
       mask.close()
@@ -328,15 +430,17 @@ class GpuMergeBatchIterator(
     closeOnExcept(nextMask) { _ =>
       withResource(condMask) { _ =>
         val thisFilteredBatch = GpuColumnVector.filter(batch, dataTypes, condMask)
-        withResource(thisFilteredBatch) { _ =>
-          outputs ++= instructionExec.applyOutputs(thisFilteredBatch)
+        withResource(thisFilteredBatch) { filtered =>
+          mergeMetrics.record(instructionExec, filtered.numRows(), sourcePresent)
+          outputs ++= instructionExec.applyOutputs(filtered)
             .map(SpillableColumnarBatch
               .apply(_, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
         }
       }
     }
 
-    processInstructionSet(dataTypes, outputs, batch, nextMask, instructionExecs.tail)
+    processInstructionSet(dataTypes, outputs, batch, nextMask, instructionExecs.tail,
+      sourcePresent)
   }
 }
 

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
@@ -152,7 +152,7 @@ case class GpuMergeRowsExec(
         gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED),
         gpuLongMetric(NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED))
     } else {
-      MergeRowMetrics.noop
+      MergeRowMetrics.NOOP
     }
 
     val dataTypes = GpuColumnVector.extractTypes(child.schema)
@@ -294,7 +294,7 @@ object GpuMergeRowsExec {
 
   object MergeRowMetrics {
     /** Shared no-op metrics when WriteSummary accounting is disabled (Spark < 4.1). */
-    val noop: MergeRowMetrics = MergeRowMetrics(
+    val NOOP: MergeRowMetrics = MergeRowMetrics(
       NoopMetric, NoopMetric, NoopMetric, NoopMetric,
       NoopMetric, NoopMetric, NoopMetric, NoopMetric)
 
@@ -309,8 +309,9 @@ object GpuMergeRowsExec {
       new LocalGpuMetric(),
       new LocalGpuMetric())
 
+    /** Staging metrics for one retry attempt; NOOP when WriteSummary is unused. */
     def forAttempt(): MergeRowMetrics = {
-      if (GpuMergeRowMetricsShims.writeSummaryEnabled) local() else noop
+      if (GpuMergeRowMetricsShims.writeSummaryEnabled) local() else NOOP
     }
   }
 
@@ -392,6 +393,8 @@ class GpuMergeBatchIterator(
 
   import GpuMergeRowsExec.MergeRowMetrics
 
+  // Skip staging/publish work before Spark 4.1 where WriteSummary is unused.
+  private val writeSummaryEnabled: Boolean = GpuMergeRowMetricsShims.writeSummaryEnabled
   // Reused across batches/attempts; reset() clears counts before each retry attempt.
   private val attemptMetrics: MergeRowMetrics = MergeRowMetrics.forAttempt()
 
@@ -418,7 +421,9 @@ class GpuMergeBatchIterator(
    */
   private def processBatch(batch: ColumnarBatch): ColumnarBatch = {
     val result = withRetryNoSplit(batch) { _ =>
-      attemptMetrics.reset()
+      if (writeSummaryEnabled) {
+        attemptMetrics.reset()
+      }
       // Evaluate presence flags
       val outputs = new ArrayBuffer[SpillableColumnarBatch](
         matchedInstructionExecs.size + notMatchedInstructionExecs.size
@@ -458,7 +463,9 @@ class GpuMergeBatchIterator(
         spillable.get.getColumnarBatch()
       }
     }
-    mergeMetrics.addAll(attemptMetrics)
+    if (writeSummaryEnabled) {
+      mergeMetrics.addAll(attemptMetrics)
+    }
     result
   }
 
@@ -507,7 +514,9 @@ class GpuMergeBatchIterator(
       withResource(condMask) { _ =>
         val thisFilteredBatch = GpuColumnVector.filter(batch, dataTypes, condMask)
         withResource(thisFilteredBatch) { filtered =>
-          attemptMetrics.record(instructionExec, filtered.numRows(), sourcePresent)
+          if (writeSummaryEnabled) {
+            attemptMetrics.record(instructionExec, filtered.numRows(), sourcePresent)
+          }
           outputs ++= instructionExec.applyOutputs(filtered)
             .map(SpillableColumnarBatch
               .apply(_, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowsExec.scala
@@ -231,6 +231,20 @@ object GpuMergeRowsExec {
       }
     }
 
+    /** Add counts from a successful attempt; used after withRetryNoSplit returns. */
+    def addAll(other: MergeRowMetrics): Unit = {
+      numTargetRowsCopied += other.numTargetRowsCopied.value
+      numTargetRowsInserted += other.numTargetRowsInserted.value
+      numTargetRowsDeleted += other.numTargetRowsDeleted.value
+      numTargetRowsUpdated += other.numTargetRowsUpdated.value
+      numTargetRowsMatchedUpdated += other.numTargetRowsMatchedUpdated.value
+      numTargetRowsMatchedDeleted += other.numTargetRowsMatchedDeleted.value
+      numTargetRowsNotMatchedBySourceUpdated +=
+        other.numTargetRowsNotMatchedBySourceUpdated.value
+      numTargetRowsNotMatchedBySourceDeleted +=
+        other.numTargetRowsNotMatchedBySourceDeleted.value
+    }
+
     def record(instruction: GpuInstruction, numRows: Long, sourcePresent: Boolean): Unit = {
       if (numRows > 0) {
         instruction match {
@@ -249,6 +263,19 @@ object GpuMergeRowsExec {
         }
       }
     }
+  }
+
+  object MergeRowMetrics {
+    /** Per-attempt staging metrics that are discarded on OOM retry. */
+    def local(): MergeRowMetrics = MergeRowMetrics(
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric())
   }
 
   sealed trait GpuInstruction extends GpuUnevaluable with ShimExpression {
@@ -327,6 +354,8 @@ class GpuMergeBatchIterator(
     opTime: GpuMetric,
     mergeMetrics: GpuMergeRowsExec.MergeRowMetrics) extends Iterator[ColumnarBatch] {
 
+  import GpuMergeRowsExec.MergeRowMetrics
+
   override def hasNext: Boolean = inputIter.hasNext
 
   override def next(): ColumnarBatch = {
@@ -342,10 +371,17 @@ class GpuMergeBatchIterator(
 
   /**
    * Process a single columnar batch, applying merge logic.
+   *
+   * MERGE row metrics are staged per attempt and only flushed after
+   * `withRetryNoSplit` succeeds. Recording into the published metrics inside
+   * the retry callback would double-count rows when a retryable GPU OOM
+   * reprocesses the same batch.
    */
   private def processBatch(batch: ColumnarBatch): ColumnarBatch = {
-
-    withRetryNoSplit(batch) { _ =>
+    var attemptMetrics: MergeRowMetrics = null
+    val result = withRetryNoSplit(batch) { _ =>
+      // Fresh staging metrics for each attempt so failed retries are discarded.
+      attemptMetrics = MergeRowMetrics.local()
       // Evaluate presence flags
       val outputs = new ArrayBuffer[SpillableColumnarBatch](
         matchedInstructionExecs.size + notMatchedInstructionExecs.size
@@ -361,19 +397,19 @@ class GpuMergeBatchIterator(
 
             val matchedMask = sourcePresent.getBase.and(targetPresent.getBase)
             processInstructionSet(inputDataTypes, outputs, batch,
-              matchedMask, matchedInstructionExecs, sourcePresent = true)
+              matchedMask, matchedInstructionExecs, sourcePresent = true, attemptMetrics)
 
             val notMatchedMask = withResource(targetPresent.getBase.not()) { noTargetMask =>
               sourcePresent.getBase.and(noTargetMask)
             }
             processInstructionSet(inputDataTypes, outputs, batch, notMatchedMask,
-                notMatchedInstructionExecs, sourcePresent = true)
+                notMatchedInstructionExecs, sourcePresent = true, attemptMetrics)
 
             val notMatchedBySrcMask = withResource(sourcePresent.getBase.not()) { noSourceMask =>
               targetPresent.getBase.and(noSourceMask)
             }
             processInstructionSet(inputDataTypes, outputs, batch, notMatchedBySrcMask,
-                notMatchedBySourceInstructionExecs, sourcePresent = false)
+                notMatchedBySourceInstructionExecs, sourcePresent = false, attemptMetrics)
           }
         }
       }
@@ -385,6 +421,8 @@ class GpuMergeBatchIterator(
         spillable.get.getColumnarBatch()
       }
     }
+    mergeMetrics.addAll(attemptMetrics)
+    result
   }
 
   /**
@@ -397,7 +435,8 @@ class GpuMergeBatchIterator(
      batch: ColumnarBatch,
      mask: ColumnVector,
      instructionExecs: Seq[GpuInstruction],
-     sourcePresent: Boolean): Unit = {
+     sourcePresent: Boolean,
+     attemptMetrics: MergeRowMetrics): Unit = {
 
     if (instructionExecs.isEmpty) {
       mask.close()
@@ -431,7 +470,7 @@ class GpuMergeBatchIterator(
       withResource(condMask) { _ =>
         val thisFilteredBatch = GpuColumnVector.filter(batch, dataTypes, condMask)
         withResource(thisFilteredBatch) { filtered =>
-          mergeMetrics.record(instructionExec, filtered.numRows(), sourcePresent)
+          attemptMetrics.record(instructionExec, filtered.numRows(), sourcePresent)
           outputs ++= instructionExec.applyOutputs(filtered)
             .map(SpillableColumnarBatch
               .apply(_, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
@@ -440,7 +479,7 @@ class GpuMergeBatchIterator(
     }
 
     processInstructionSet(dataTypes, outputs, batch, nextMask, instructionExecs.tail,
-      sourcePresent)
+      sourcePresent, attemptMetrics)
   }
 }
 

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteCommitShims.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteCommitShims.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.connector.write.{BatchWrite, WriterCommitMessage}
+import org.apache.spark.sql.execution.SparkPlan
+
+/**
+ * Spark versions before 4.1 do not have the DSv2 WriteSummary commit API.
+ * Commit without a summary.
+ */
+object GpuV2WriteCommitShims {
+  def commit(
+      batchWrite: BatchWrite,
+      messages: Array[WriterCommitMessage],
+      query: SparkPlan): Unit = {
+    batchWrite.commit(messages)
+  }
+}

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -215,7 +215,8 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
       postFinalPlanUpdateToSqlUi()
 
       logInfo(s"Data source write support $batchWrite is committing.")
-      batchWrite.commit(messages)
+      // Spark 4.1+ forwards a WriteSummary (e.g. MergeSummary from GpuMergeRowsExec).
+      GpuV2WriteCommitShims.commit(batchWrite, messages, finalQuery)
       logInfo(s"Data source write support $batchWrite committed.")
       commitProgress = Some(StreamWriterCommitProgress(totalNumRowsAccumulator.value))
     } catch {

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/GpuMergeRowMetricsShims.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/GpuMergeRowMetricsShims.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+/**
+ * Spark 4.1+ forwards MergeSummary via BatchWrite.commit(messages, summary).
+ */
+object GpuMergeRowMetricsShims {
+  val writeSummaryEnabled: Boolean = true
+}

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/GpuMergeRowsKeepShims.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/GpuMergeRowsKeepShims.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Insert, Keep, Update}
+import org.apache.spark.sql.execution.datasources.v2.GpuMergeRowsExec
+
+/**
+ * Map Spark 4.1+ Keep.context onto GpuKeep action tags used for MergeSummary metrics.
+ */
+object GpuMergeRowsKeepShims {
+  def actionOf(keep: Keep): String = keep.context match {
+    case Copy => GpuMergeRowsExec.ACTION_COPY
+    case Insert => GpuMergeRowsExec.ACTION_INSERT
+    case Update => GpuMergeRowsExec.ACTION_UPDATE
+    case Delete => GpuMergeRowsExec.ACTION_DELETE
+  }
+}

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/GpuV2BatchWriteSummaryCommit.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/GpuV2BatchWriteSummaryCommit.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.connector.write.{BatchWrite, WriterCommitMessage, WriteSummary}
+
+/**
+ * Forward [[BatchWrite.commit]] with a [[WriteSummary]] to the CPU delegate.
+ *
+ * Without this override, the default interface method calls `commit(messages)` and drops the
+ * summary, so Iceberg/Delta commit metadata would miss DML metrics on the GPU path.
+ */
+trait GpuV2BatchWriteSummaryCommit { this: BatchWrite =>
+  protected def summaryCommitDelegate: BatchWrite
+
+  override def commit(messages: Array[WriterCommitMessage], summary: WriteSummary): Unit = {
+    summaryCommitDelegate.commit(messages, summary)
+  }
+}

--- a/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteCommitShims.scala
+++ b/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteCommitShims.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 
 /**
  * Spark 4.1+ passes a WriteSummary to BatchWrite.commit. For MERGE, collect metrics from
- * GpuMergeRowsExec the same way Spark CPU collects them from MergeRowsExec.
+ * GpuMergeRowsExec (or a CPU MergeRowsExec fallback child) the same way Spark CPU does.
  *
  * Lives under org.apache.spark.sql so it can construct private[sql] MergeSummaryImpl.
  */
@@ -56,9 +56,10 @@ object GpuV2WriteCommitShims extends AdaptiveSparkPlanHelper {
 
   /** Visible for tests. */
   private[v2] def getWriteSummary(query: SparkPlan): Option[WriteSummary] = {
-    collectFirst(query) { case m: GpuMergeRowsExec => m }.map { mergeRows =>
-      mergeSummaryFromMetrics(mergeRows.metrics)
-    }
+    collectFirst(query) {
+      case m: GpuMergeRowsExec => m.metrics
+      case m: MergeRowsExec => m.metrics
+    }.map(mergeSummaryFromMetrics)
   }
 
   /** Visible for tests. */

--- a/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteCommitShims.scala
+++ b/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteCommitShims.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.connector.write.{BatchWrite, MergeSummaryImpl, WriterCommitMessage,
+  WriteSummary}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.datasources.v2.GpuMergeRowsExec._
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+/**
+ * Spark 4.1+ passes a WriteSummary to BatchWrite.commit. For MERGE, collect metrics from
+ * GpuMergeRowsExec the same way Spark CPU collects them from MergeRowsExec.
+ *
+ * Lives under org.apache.spark.sql so it can construct private[sql] MergeSummaryImpl.
+ */
+object GpuV2WriteCommitShims extends AdaptiveSparkPlanHelper {
+  def commit(
+      batchWrite: BatchWrite,
+      messages: Array[WriterCommitMessage],
+      query: SparkPlan): Unit = {
+    commitWithOptionalSummary(batchWrite, messages, getWriteSummary(query))
+  }
+
+  /** Visible for tests. */
+  private[v2] def commitWithOptionalSummary(
+      batchWrite: BatchWrite,
+      messages: Array[WriterCommitMessage],
+      summary: Option[WriteSummary]): Unit = {
+    summary match {
+      case Some(s) => batchWrite.commit(messages, s)
+      case None => batchWrite.commit(messages)
+    }
+  }
+
+  /** Visible for tests. */
+  private[v2] def getWriteSummary(query: SparkPlan): Option[WriteSummary] = {
+    collectFirst(query) { case m: GpuMergeRowsExec => m }.map { mergeRows =>
+      mergeSummaryFromMetrics(mergeRows.metrics)
+    }
+  }
+
+  /** Visible for tests. */
+  private[v2] def mergeSummaryFromMetrics(metrics: Map[String, SQLMetric]): MergeSummaryImpl = {
+    MergeSummaryImpl(
+      getMetricValue(metrics, NUM_TARGET_ROWS_COPIED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_DELETED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_UPDATED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_INSERTED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_MATCHED_UPDATED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_MATCHED_DELETED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED),
+      getMetricValue(metrics, NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED))
+  }
+
+  private def getMetricValue(metrics: Map[String, SQLMetric], name: String): Long = {
+    metrics.get(name).map(_.value).getOrElse(-1L)
+  }
+}

--- a/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
+++ b/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
@@ -102,21 +102,19 @@ class GpuMergeRowMetricsSuite extends AnyFunSuite with FQSuiteName {
     assert(m.numTargetRowsDeleted.value === 0)
   }
 
-  test("addAll flushes a successful attempt and discards failed-attempt staging") {
+  test("reset clears staging so a reused attempt does not accumulate retries") {
     val published = metrics()
-    val failedAttempt = MergeRowMetrics.local()
-    failedAttempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
-    failedAttempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
-    // Failed OOM retry discards staging; only the successful attempt is flushed.
-    val successAttempt = MergeRowMetrics.local()
-    successAttempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
-    successAttempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
-    published.addAll(successAttempt)
+    val attempt = MergeRowMetrics.local()
+    attempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
+    attempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
+    // Simulate a failed attempt that is discarded by reset before retry.
+    attempt.reset()
+    attempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
+    attempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
+    published.addAll(attempt)
 
     assert(published.numTargetRowsInserted.value === 7)
     assert(published.numTargetRowsDeleted.value === 4)
     assert(published.numTargetRowsMatchedDeleted.value === 4)
-    // Failed attempt was never flushed.
-    assert(failedAttempt.numTargetRowsInserted.value === 7)
   }
 }

--- a/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
+++ b/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
@@ -38,11 +38,11 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2
 
 import com.nvidia.spark.rapids.{FQSuiteName, LocalGpuMetric}
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.execution.datasources.v2.GpuMergeRowsExec._
 import org.apache.spark.sql.types.BooleanType
-import org.scalatest.funsuite.AnyFunSuite
 
 class GpuMergeRowMetricsSuite extends AnyFunSuite with FQSuiteName {
 

--- a/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
+++ b/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
@@ -38,6 +38,7 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2
 
 import com.nvidia.spark.rapids.{FQSuiteName, LocalGpuMetric}
+import com.nvidia.spark.rapids.shims.GpuMergeRowMetricsShims
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -102,19 +103,23 @@ class GpuMergeRowMetricsSuite extends AnyFunSuite with FQSuiteName {
     assert(m.numTargetRowsDeleted.value === 0)
   }
 
-  test("reset clears staging so a reused attempt does not accumulate retries") {
-    val published = metrics()
-    val attempt = MergeRowMetrics.local()
-    attempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
-    attempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
-    // Simulate a failed attempt that is discarded by reset before retry.
-    attempt.reset()
-    attempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
-    attempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
-    published.addAll(attempt)
-
-    assert(published.numTargetRowsInserted.value === 7)
-    assert(published.numTargetRowsDeleted.value === 4)
-    assert(published.numTargetRowsMatchedDeleted.value === 4)
+  test("forAttempt respects writeSummaryEnabled capability") {
+    val attempt = MergeRowMetrics.forAttempt()
+    if (GpuMergeRowMetricsShims.writeSummaryEnabled) {
+      assert(attempt ne MergeRowMetrics.NOOP)
+      attempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
+      attempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
+      // Simulate a failed attempt that is discarded by reset before retry.
+      attempt.reset()
+      attempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
+      attempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
+      val published = metrics()
+      published.addAll(attempt)
+      assert(published.numTargetRowsInserted.value === 7)
+      assert(published.numTargetRowsDeleted.value === 4)
+      assert(published.numTargetRowsMatchedDeleted.value === 4)
+    } else {
+      assert(attempt eq MergeRowMetrics.NOOP)
+    }
   }
 }

--- a/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
+++ b/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
@@ -101,4 +101,22 @@ class GpuMergeRowMetricsSuite extends AnyFunSuite with FQSuiteName {
     assert(m.numTargetRowsInserted.value === 0)
     assert(m.numTargetRowsDeleted.value === 0)
   }
+
+  test("addAll flushes a successful attempt and discards failed-attempt staging") {
+    val published = metrics()
+    val failedAttempt = MergeRowMetrics.local()
+    failedAttempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
+    failedAttempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
+    // Failed OOM retry discards staging; only the successful attempt is flushed.
+    val successAttempt = MergeRowMetrics.local()
+    successAttempt.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 7, sourcePresent = true)
+    successAttempt.record(GpuDiscard(trueLit), 4, sourcePresent = true)
+    published.addAll(successAttempt)
+
+    assert(published.numTargetRowsInserted.value === 7)
+    assert(published.numTargetRowsDeleted.value === 4)
+    assert(published.numTargetRowsMatchedDeleted.value === 4)
+    // Failed attempt was never flushed.
+    assert(failedAttempt.numTargetRowsInserted.value === 7)
+  }
 }

--- a/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
+++ b/sql-plugin/src/test/spark350/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeRowMetricsSuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2
+
+import com.nvidia.spark.rapids.{FQSuiteName, LocalGpuMetric}
+
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.execution.datasources.v2.GpuMergeRowsExec._
+import org.apache.spark.sql.types.BooleanType
+import org.scalatest.funsuite.AnyFunSuite
+
+class GpuMergeRowMetricsSuite extends AnyFunSuite with FQSuiteName {
+
+  private def metrics(): MergeRowMetrics = MergeRowMetrics(
+    new LocalGpuMetric(),
+    new LocalGpuMetric(),
+    new LocalGpuMetric(),
+    new LocalGpuMetric(),
+    new LocalGpuMetric(),
+    new LocalGpuMetric(),
+    new LocalGpuMetric(),
+    new LocalGpuMetric())
+
+  private val trueLit = Literal(true, BooleanType)
+
+  test("record Keep actions onto MergeSummary metric fields") {
+    val m = metrics()
+    m.record(GpuKeep(trueLit, Nil, ACTION_COPY), 2, sourcePresent = true)
+    m.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 3, sourcePresent = true)
+    m.record(GpuKeep(trueLit, Nil, ACTION_UPDATE), 4, sourcePresent = true)
+    m.record(GpuKeep(trueLit, Nil, ACTION_DELETE), 5, sourcePresent = false)
+
+    assert(m.numTargetRowsCopied.value === 2)
+    assert(m.numTargetRowsInserted.value === 3)
+    assert(m.numTargetRowsUpdated.value === 4)
+    assert(m.numTargetRowsMatchedUpdated.value === 4)
+    assert(m.numTargetRowsDeleted.value === 5)
+    assert(m.numTargetRowsNotMatchedBySourceDeleted.value === 5)
+    assert(m.numTargetRowsMatchedDeleted.value === 0)
+  }
+
+  test("record Discard and Split like Spark MergeRowsExec") {
+    val m = metrics()
+    m.record(GpuDiscard(trueLit), 2, sourcePresent = true)
+    m.record(GpuSplit(trueLit, Nil, Nil), 3, sourcePresent = false)
+
+    assert(m.numTargetRowsDeleted.value === 2)
+    assert(m.numTargetRowsMatchedDeleted.value === 2)
+    assert(m.numTargetRowsUpdated.value === 3)
+    assert(m.numTargetRowsNotMatchedBySourceUpdated.value === 3)
+  }
+
+  test("ACTION_UNKNOWN Keep rows are skipped to avoid ambiguous counts") {
+    val m = metrics()
+    m.record(GpuKeep(trueLit, Nil, ACTION_UNKNOWN), 10, sourcePresent = true)
+    assert(m.numTargetRowsCopied.value === 0)
+    assert(m.numTargetRowsInserted.value === 0)
+    assert(m.numTargetRowsUpdated.value === 0)
+    assert(m.numTargetRowsDeleted.value === 0)
+  }
+
+  test("zero-row batches do not change metrics") {
+    val m = metrics()
+    m.record(GpuKeep(trueLit, Nil, ACTION_INSERT), 0, sourcePresent = true)
+    m.record(GpuDiscard(trueLit), 0, sourcePresent = true)
+    assert(m.numTargetRowsInserted.value === 0)
+    assert(m.numTargetRowsDeleted.value === 0)
+  }
+}

--- a/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
+++ b/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
@@ -22,8 +22,8 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2
 
-import com.nvidia.spark.rapids.FQSuiteName
-import com.nvidia.spark.rapids.shims.{GpuMergeRowsKeepShims, GpuV2BatchWriteSummaryCommit}
+import com.nvidia.spark.rapids.{FQSuiteName, GpuRowToColumnarExec, RapidsConf, TargetSize}
+import com.nvidia.spark.rapids.shims.GpuMergeRowsKeepShims
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.SparkSession
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Insert, Keep, Update}
 import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, MergeSummary,
   MergeSummaryImpl, PhysicalWriteInfo, WriterCommitMessage, WriteSummary}
+import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType}
 
@@ -115,7 +116,7 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
     }
   }
 
-  test("commit traverses GpuMergeRowsExec and uses summary-aware overload") {
+  test("commit finds GpuMergeRowsExec under an ancestor via plan traversal") {
     withSparkSession { spark =>
       val child = spark.range(1).queryExecution.executedPlan
       val output = Seq(AttributeReference("id", LongType, nullable = false)())
@@ -127,15 +128,17 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
         output,
         child)
       seedAllMergeMetrics(merge)
+      // Root is not the MERGE node; commit must walk descendants.
+      val root = ProjectExec(merge.output, merge)
       val recorder = new RecordingBatchWrite
-      GpuV2WriteCommitShims.commit(recorder, Array.empty, merge)
+      GpuV2WriteCommitShims.commit(recorder, Array.empty, root)
       assert(recorder.summaryCommitCount === 1)
       assert(recorder.plainCommitCount === 0)
       assertAllMergeSummaryFields(recorder.lastSummary.get.asInstanceOf[MergeSummary])
     }
   }
 
-  test("commit preserves summary for CPU MergeRowsExec fallback child") {
+  test("commit finds CPU MergeRowsExec under GpuRowToColumnarExec fallback wrapper") {
     withSparkSession { spark =>
       val child = spark.range(1).queryExecution.executedPlan
       val output = Seq(AttributeReference("id", LongType, nullable = false)())
@@ -147,22 +150,14 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
         output,
         child)
       seedAllMergeMetrics(merge)
+      // Mixed plan: GPU writer above a CPU MERGE child wrapped for columnar output.
+      val root = GpuRowToColumnarExec(merge, TargetSize(1L << 20))
       val recorder = new RecordingBatchWrite
-      GpuV2WriteCommitShims.commit(recorder, Array.empty, merge)
+      GpuV2WriteCommitShims.commit(recorder, Array.empty, root)
       assert(recorder.summaryCommitCount === 1)
       assert(recorder.plainCommitCount === 0)
       assertAllMergeSummaryFields(recorder.lastSummary.get.asInstanceOf[MergeSummary])
     }
-  }
-
-  test("GpuV2BatchWriteSummaryCommit forwards summary to CPU delegate") {
-    val cpu = new RecordingBatchWrite
-    val gpu = new ForwardingGpuBatchWrite(cpu)
-    val summary: WriteSummary = MergeSummaryImpl(9, 0, 0, 1, 0, 0, 0, 0)
-    gpu.commit(Array.empty, summary)
-    assert(cpu.summaryCommitCount === 1)
-    assert(cpu.lastSummary.get.asInstanceOf[MergeSummary].numTargetRowsCopied === 9)
-    assert(cpu.lastSummary.get.asInstanceOf[MergeSummary].numTargetRowsInserted === 1)
   }
 
   private def withSparkSession[T](f: SparkSession => T): T = {
@@ -171,6 +166,8 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
       .appName(getClass.getSimpleName)
       .config("spark.ui.enabled", "false")
       .config("spark.driver.host", "127.0.0.1")
+      // ESSENTIAL must still expose all MergeSummary fields used as commit metadata.
+      .config(RapidsConf.METRICS_LEVEL.key, "ESSENTIAL")
       .getOrCreate()
     try {
       f(spark)
@@ -180,6 +177,19 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
   }
 
   private def seedAllMergeMetrics(plan: org.apache.spark.sql.execution.SparkPlan): Unit = {
+    // Under ESSENTIAL, every MergeSummary field must still be present (not NoopMetric).
+    Seq(
+      GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_DELETED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_UPDATED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_INSERTED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_UPDATED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_DELETED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED,
+      GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED).foreach { name =>
+      assert(plan.metrics.contains(name),
+        s"$name missing from plan.metrics at ESSENTIAL metrics level")
+    }
     plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED).add(1L)
     plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_DELETED).add(2L)
     plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_UPDATED).add(3L)
@@ -220,18 +230,5 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
     }
 
     override def abort(messages: Array[WriterCommitMessage]): Unit = ()
-  }
-
-  private class ForwardingGpuBatchWrite(cpu: BatchWrite)
-    extends BatchWrite with GpuV2BatchWriteSummaryCommit {
-    override protected def summaryCommitDelegate: BatchWrite = cpu
-
-    override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
-      cpu.createBatchWriterFactory(info)
-    }
-
-    override def commit(messages: Array[WriterCommitMessage]): Unit = cpu.commit(messages)
-
-    override def abort(messages: Array[WriterCommitMessage]): Unit = cpu.abort(messages)
   }
 }

--- a/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
+++ b/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
@@ -24,6 +24,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import com.nvidia.spark.rapids.FQSuiteName
 import com.nvidia.spark.rapids.shims.{GpuMergeRowsKeepShims, GpuV2BatchWriteSummaryCommit}
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -32,7 +33,6 @@ import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, Merg
   MergeSummaryImpl, PhysicalWriteInfo, WriterCommitMessage, WriteSummary}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.{BooleanType, IntegerType}
-import org.scalatest.funsuite.AnyFunSuite
 
 class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
 

--- a/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
+++ b/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2
+
+import com.nvidia.spark.rapids.FQSuiteName
+import com.nvidia.spark.rapids.shims.{GpuMergeRowsKeepShims, GpuV2BatchWriteSummaryCommit}
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Insert, Keep, Update}
+import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, MergeSummary,
+  MergeSummaryImpl, PhysicalWriteInfo, WriterCommitMessage, WriteSummary}
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.types.{BooleanType, IntegerType}
+import org.scalatest.funsuite.AnyFunSuite
+
+class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
+
+  test("GpuMergeRowsKeepShims maps Keep.context to action tags") {
+    val cond = Literal(true, BooleanType)
+    val out = Seq(Literal(1, IntegerType))
+    assert(GpuMergeRowsKeepShims.actionOf(Keep(Copy, cond, out)) ===
+      GpuMergeRowsExec.ACTION_COPY)
+    assert(GpuMergeRowsKeepShims.actionOf(Keep(Insert, cond, out)) ===
+      GpuMergeRowsExec.ACTION_INSERT)
+    assert(GpuMergeRowsKeepShims.actionOf(Keep(Update, cond, out)) ===
+      GpuMergeRowsExec.ACTION_UPDATE)
+    assert(GpuMergeRowsKeepShims.actionOf(Keep(Delete, cond, out)) ===
+      GpuMergeRowsExec.ACTION_DELETE)
+  }
+
+  test("commitWithOptionalSummary forwards WriteSummary when present") {
+    val recorder = new RecordingBatchWrite
+    val summary: WriteSummary = MergeSummaryImpl(1, 2, 3, 4, 5, 6, 7, 8)
+    GpuV2WriteCommitShims.commitWithOptionalSummary(
+      recorder, Array.empty, Some(summary))
+    assert(recorder.summaryCommitCount === 1)
+    assert(recorder.plainCommitCount === 0)
+    val merge = recorder.lastSummary.get.asInstanceOf[MergeSummary]
+    assert(merge.numTargetRowsCopied === 1)
+    assert(merge.numTargetRowsDeleted === 2)
+    assert(merge.numTargetRowsUpdated === 3)
+    assert(merge.numTargetRowsInserted === 4)
+  }
+
+  test("commitWithOptionalSummary falls back to plain commit without summary") {
+    val recorder = new RecordingBatchWrite
+    GpuV2WriteCommitShims.commitWithOptionalSummary(recorder, Array.empty, None)
+    assert(recorder.summaryCommitCount === 0)
+    assert(recorder.plainCommitCount === 1)
+  }
+
+  test("mergeSummaryFromMetrics reads GpuMergeRowsExec metric names") {
+    val conf = new SparkConf().setMaster("local[1]").setAppName(getClass.getSimpleName)
+      .set("spark.driver.host", "127.0.0.1")
+      .set("spark.ui.enabled", "false")
+    val sc = new SparkContext(conf)
+    try {
+      val metrics = Map(
+        GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED ->
+          SQLMetrics.createMetric(sc, "copied"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_DELETED ->
+          SQLMetrics.createMetric(sc, "deleted"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_UPDATED ->
+          SQLMetrics.createMetric(sc, "updated"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_INSERTED ->
+          SQLMetrics.createMetric(sc, "inserted"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_UPDATED ->
+          SQLMetrics.createMetric(sc, "matchedUpdated"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_DELETED ->
+          SQLMetrics.createMetric(sc, "matchedDeleted"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED ->
+          SQLMetrics.createMetric(sc, "nmbsUpdated"),
+        GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED ->
+          SQLMetrics.createMetric(sc, "nmbsDeleted"))
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED).add(10)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_INSERTED).add(20)
+      val summary = GpuV2WriteCommitShims.mergeSummaryFromMetrics(metrics)
+      assert(summary.numTargetRowsCopied === 10)
+      assert(summary.numTargetRowsInserted === 20)
+      assert(summary.numTargetRowsDeleted === 0)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  test("GpuV2BatchWriteSummaryCommit forwards summary to CPU delegate") {
+    val cpu = new RecordingBatchWrite
+    val gpu = new ForwardingGpuBatchWrite(cpu)
+    val summary: WriteSummary = MergeSummaryImpl(9, 0, 0, 1, 0, 0, 0, 0)
+    gpu.commit(Array.empty, summary)
+    assert(cpu.summaryCommitCount === 1)
+    assert(cpu.lastSummary.get.asInstanceOf[MergeSummary].numTargetRowsCopied === 9)
+    assert(cpu.lastSummary.get.asInstanceOf[MergeSummary].numTargetRowsInserted === 1)
+  }
+
+  private class RecordingBatchWrite extends BatchWrite {
+    var plainCommitCount = 0
+    var summaryCommitCount = 0
+    var lastSummary: Option[WriteSummary] = None
+
+    override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+      throw new UnsupportedOperationException
+    }
+
+    override def commit(messages: Array[WriterCommitMessage]): Unit = {
+      plainCommitCount += 1
+    }
+
+    override def commit(messages: Array[WriterCommitMessage], summary: WriteSummary): Unit = {
+      summaryCommitCount += 1
+      lastSummary = Some(summary)
+    }
+
+    override def abort(messages: Array[WriterCommitMessage]): Unit = ()
+  }
+
+  private class ForwardingGpuBatchWrite(cpu: BatchWrite)
+    extends BatchWrite with GpuV2BatchWriteSummaryCommit {
+    override protected def summaryCommitDelegate: BatchWrite = cpu
+
+    override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+      cpu.createBatchWriterFactory(info)
+    }
+
+    override def commit(messages: Array[WriterCommitMessage]): Unit = cpu.commit(messages)
+
+    override def abort(messages: Array[WriterCommitMessage]): Unit = cpu.abort(messages)
+  }
+}

--- a/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
+++ b/sql-plugin/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuV2WriteSummarySuite.scala
@@ -26,13 +26,13 @@ import com.nvidia.spark.rapids.FQSuiteName
 import com.nvidia.spark.rapids.shims.{GpuMergeRowsKeepShims, GpuV2BatchWriteSummaryCommit}
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Copy, Delete, Insert, Keep, Update}
 import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, MergeSummary,
   MergeSummaryImpl, PhysicalWriteInfo, WriterCommitMessage, WriteSummary}
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.types.{BooleanType, IntegerType}
+import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType}
 
 class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
 
@@ -70,12 +70,9 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
     assert(recorder.plainCommitCount === 1)
   }
 
-  test("mergeSummaryFromMetrics reads GpuMergeRowsExec metric names") {
-    val conf = new SparkConf().setMaster("local[1]").setAppName(getClass.getSimpleName)
-      .set("spark.driver.host", "127.0.0.1")
-      .set("spark.ui.enabled", "false")
-    val sc = new SparkContext(conf)
-    try {
+  test("mergeSummaryFromMetrics maps all eight fields and missing-key sentinel") {
+    withSparkSession { spark =>
+      val sc = spark.sparkContext
       val metrics = Map(
         GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED ->
           SQLMetrics.createMetric(sc, "copied"),
@@ -93,14 +90,68 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
           SQLMetrics.createMetric(sc, "nmbsUpdated"),
         GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED ->
           SQLMetrics.createMetric(sc, "nmbsDeleted"))
-      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED).add(10)
-      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_INSERTED).add(20)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED).add(1L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_DELETED).add(2L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_UPDATED).add(3L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_INSERTED).add(4L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_UPDATED).add(5L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_DELETED).add(6L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED).add(7L)
+      metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED).add(8L)
       val summary = GpuV2WriteCommitShims.mergeSummaryFromMetrics(metrics)
-      assert(summary.numTargetRowsCopied === 10)
-      assert(summary.numTargetRowsInserted === 20)
-      assert(summary.numTargetRowsDeleted === 0)
-    } finally {
-      sc.stop()
+      assert(summary.numTargetRowsCopied === 1L)
+      assert(summary.numTargetRowsDeleted === 2L)
+      assert(summary.numTargetRowsUpdated === 3L)
+      assert(summary.numTargetRowsInserted === 4L)
+      assert(summary.numTargetRowsMatchedUpdated === 5L)
+      assert(summary.numTargetRowsMatchedDeleted === 6L)
+      assert(summary.numTargetRowsNotMatchedBySourceUpdated === 7L)
+      assert(summary.numTargetRowsNotMatchedBySourceDeleted === 8L)
+
+      val missingDeleted = metrics - GpuMergeRowsExec.NUM_TARGET_ROWS_DELETED
+      val withMissing = GpuV2WriteCommitShims.mergeSummaryFromMetrics(missingDeleted)
+      assert(withMissing.numTargetRowsDeleted === -1L)
+      assert(withMissing.numTargetRowsCopied === 1L)
+    }
+  }
+
+  test("commit traverses GpuMergeRowsExec and uses summary-aware overload") {
+    withSparkSession { spark =>
+      val child = spark.range(1).queryExecution.executedPlan
+      val output = Seq(AttributeReference("id", LongType, nullable = false)())
+      val merge = GpuMergeRowsExec(
+        Literal(true, BooleanType),
+        Literal(true, BooleanType),
+        Nil, Nil, Nil,
+        checkCardinality = false,
+        output,
+        child)
+      seedAllMergeMetrics(merge)
+      val recorder = new RecordingBatchWrite
+      GpuV2WriteCommitShims.commit(recorder, Array.empty, merge)
+      assert(recorder.summaryCommitCount === 1)
+      assert(recorder.plainCommitCount === 0)
+      assertAllMergeSummaryFields(recorder.lastSummary.get.asInstanceOf[MergeSummary])
+    }
+  }
+
+  test("commit preserves summary for CPU MergeRowsExec fallback child") {
+    withSparkSession { spark =>
+      val child = spark.range(1).queryExecution.executedPlan
+      val output = Seq(AttributeReference("id", LongType, nullable = false)())
+      val merge = MergeRowsExec(
+        Literal(true, BooleanType),
+        Literal(true, BooleanType),
+        Nil, Nil, Nil,
+        checkCardinality = false,
+        output,
+        child)
+      seedAllMergeMetrics(merge)
+      val recorder = new RecordingBatchWrite
+      GpuV2WriteCommitShims.commit(recorder, Array.empty, merge)
+      assert(recorder.summaryCommitCount === 1)
+      assert(recorder.plainCommitCount === 0)
+      assertAllMergeSummaryFields(recorder.lastSummary.get.asInstanceOf[MergeSummary])
     }
   }
 
@@ -112,6 +163,42 @@ class GpuV2WriteSummarySuite extends AnyFunSuite with FQSuiteName {
     assert(cpu.summaryCommitCount === 1)
     assert(cpu.lastSummary.get.asInstanceOf[MergeSummary].numTargetRowsCopied === 9)
     assert(cpu.lastSummary.get.asInstanceOf[MergeSummary].numTargetRowsInserted === 1)
+  }
+
+  private def withSparkSession[T](f: SparkSession => T): T = {
+    val spark = SparkSession.builder()
+      .master("local[1]")
+      .appName(getClass.getSimpleName)
+      .config("spark.ui.enabled", "false")
+      .config("spark.driver.host", "127.0.0.1")
+      .getOrCreate()
+    try {
+      f(spark)
+    } finally {
+      spark.stop()
+    }
+  }
+
+  private def seedAllMergeMetrics(plan: org.apache.spark.sql.execution.SparkPlan): Unit = {
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_COPIED).add(1L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_DELETED).add(2L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_UPDATED).add(3L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_INSERTED).add(4L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_UPDATED).add(5L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_MATCHED_DELETED).add(6L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_UPDATED).add(7L)
+    plan.metrics(GpuMergeRowsExec.NUM_TARGET_ROWS_NOT_MATCHED_BY_SOURCE_DELETED).add(8L)
+  }
+
+  private def assertAllMergeSummaryFields(summary: MergeSummary): Unit = {
+    assert(summary.numTargetRowsCopied === 1L)
+    assert(summary.numTargetRowsDeleted === 2L)
+    assert(summary.numTargetRowsUpdated === 3L)
+    assert(summary.numTargetRowsInserted === 4L)
+    assert(summary.numTargetRowsMatchedUpdated === 5L)
+    assert(summary.numTargetRowsMatchedDeleted === 6L)
+    assert(summary.numTargetRowsNotMatchedBySourceUpdated === 7L)
+    assert(summary.numTargetRowsNotMatchedBySourceDeleted === 8L)
   }
 
   private class RecordingBatchWrite extends BatchWrite {

--- a/tests/src/test/spark411/scala/org/apache/iceberg/spark/source/GpuIcebergWriteSummaryCommitSuite.scala
+++ b/tests/src/test/spark411/scala/org/apache/iceberg/spark/source/GpuIcebergWriteSummaryCommitSuite.scala
@@ -16,9 +16,6 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "411"}
-{"spark": "412"}
-{"spark": "413"}
-{"spark": "420"}
 spark-rapids-shim-json-lines ***/
 package org.apache.iceberg.spark.source
 
@@ -30,7 +27,7 @@ import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, Delt
 
 /**
  * Verifies production Iceberg GPU BatchWrite types forward WriteSummary via
- * GpuV2BatchWriteSummaryCommit (not only a synthetic trait mixin).
+ * GpuV2BatchWriteSummaryCommit (Spark 4.1.1 only; later shims use iceberg-stub).
  */
 class GpuIcebergWriteSummaryCommitSuite extends AnyFunSuite {
 

--- a/tests/src/test/spark411/scala/org/apache/iceberg/spark/source/GpuIcebergWriteSummaryCommitSuite.scala
+++ b/tests/src/test/spark411/scala/org/apache/iceberg/spark/source/GpuIcebergWriteSummaryCommitSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package org.apache.iceberg.spark.source
+
+import org.mockito.Mockito.mock
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, DeltaBatchWrite,
+  DeltaWriterFactory, PhysicalWriteInfo, WriterCommitMessage, WriteSummary}
+
+/**
+ * Verifies production Iceberg GPU BatchWrite types forward WriteSummary via
+ * GpuV2BatchWriteSummaryCommit (not only a synthetic trait mixin).
+ */
+class GpuIcebergWriteSummaryCommitSuite extends AnyFunSuite {
+
+  test("GpuBatchAppend forwards WriteSummary to CPU BatchAppend delegate") {
+    val cpu = new RecordingBatchWrite
+    val gpu = new GpuBatchAppend(mock(classOf[GpuSparkWrite]), cpu)
+    val summary = new WriteSummary {}
+    gpu.commit(Array.empty, summary)
+    assert(cpu.summaryCommitCount === 1)
+    assert(cpu.plainCommitCount === 0)
+    assert(cpu.lastSummary.contains(summary))
+  }
+
+  test("GpuPositionDeltaBatchWrite forwards WriteSummary to CPU delta delegate") {
+    val cpu = new RecordingDeltaBatchWrite
+    val gpu = new GpuPositionDeltaBatchWrite(mock(classOf[GpuSparkPositionDeltaWrite]), cpu)
+    val summary = new WriteSummary {}
+    gpu.commit(Array.empty, summary)
+    assert(cpu.summaryCommitCount === 1)
+    assert(cpu.plainCommitCount === 0)
+    assert(cpu.lastSummary.contains(summary))
+  }
+
+  private class RecordingBatchWrite extends BatchWrite {
+    var plainCommitCount = 0
+    var summaryCommitCount = 0
+    var lastSummary: Option[WriteSummary] = None
+
+    override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+      throw new UnsupportedOperationException
+    }
+
+    override def commit(messages: Array[WriterCommitMessage]): Unit = {
+      plainCommitCount += 1
+    }
+
+    override def commit(messages: Array[WriterCommitMessage], summary: WriteSummary): Unit = {
+      summaryCommitCount += 1
+      lastSummary = Some(summary)
+    }
+
+    override def abort(messages: Array[WriterCommitMessage]): Unit = ()
+  }
+
+  private class RecordingDeltaBatchWrite extends RecordingBatchWrite with DeltaBatchWrite {
+    override def createBatchWriterFactory(info: PhysicalWriteInfo): DeltaWriterFactory = {
+      throw new UnsupportedOperationException
+    }
+  }
+}

--- a/tests/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeBatchIteratorRetrySuite.scala
+++ b/tests/src/test/spark411/scala/org/apache/spark/sql/execution/datasources/v2/GpuMergeBatchIteratorRetrySuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2
+
+import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuLiteral, LocalGpuMetric,
+  NoopMetric, RmmSparkRetrySuiteBase}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.jni.RmmSpark
+
+import org.apache.spark.sql.catalyst.expressions.ExprId
+import org.apache.spark.sql.execution.datasources.v2.GpuMergeRowsExec._
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Verifies MERGE WriteSummary metrics are published only for the successful
+ * withRetryNoSplit attempt. The injected OOM is placed after attemptMetrics.record
+ * (during applyOutputs/project) so a regression that publishes inside the retry
+ * callback would double-count and fail the assertions.
+ *
+ * Spark 4.1+ only: earlier shims use NoopMetric staging when WriteSummary is unused.
+ */
+class GpuMergeBatchIteratorRetrySuite extends RmmSparkRetrySuiteBase {
+
+  private def buildBatch(): ColumnarBatch = {
+    val table = new Table.TestBuilder()
+      .column(Integer.valueOf(42))
+      .build()
+    withResource(table) { tbl =>
+      GpuColumnVector.from(tbl, Array[DataType](IntegerType))
+    }
+  }
+
+  // Allocations before attemptMetrics.record in this setup:
+  // 2x presence GpuLiteral eval, matched and-mask, notMatched not+and masks,
+  // Keep condition literal, and/replaceNulls/not/and for masks, then filter.
+  // The next GPU allocation is applyOutputs/project after record.
+  private val oomSkipBeforeProjectAfterRecord = 10
+
+  test("MERGE metrics publish only the successful retry attempt") {
+    val published = MergeRowMetrics(
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric(),
+      new LocalGpuMetric())
+    val insert = GpuKeep(
+      GpuLiteral.create(true, BooleanType),
+      Seq(GpuBoundReference(0, IntegerType, nullable = true)(ExprId(0), "id")),
+      ACTION_INSERT)
+    val it = new GpuMergeBatchIterator(
+      Array(IntegerType),
+      Seq(buildBatch()).iterator,
+      isTargetRowPresent = GpuLiteral.create(false, BooleanType),
+      isSourceRowPresent = GpuLiteral.create(true, BooleanType),
+      matchedInstructionExecs = Nil,
+      notMatchedInstructionExecs = Seq(insert),
+      notMatchedBySourceInstructionExecs = Nil,
+      numOutputRows = NoopMetric,
+      numOutputBatches = NoopMetric,
+      opTime = NoopMetric,
+      mergeMetrics = published)
+
+    RmmSpark.forceRetryOOM(
+      RmmSpark.getCurrentThreadId,
+      1,
+      RmmSpark.OomInjectionType.GPU.ordinal,
+      oomSkipBeforeProjectAfterRecord)
+    withResource(it.next()) { batch =>
+      assert(batch.numRows() === 1)
+    }
+    assert(RmmSpark.getAndResetNumRetryThrow(/* taskId = */ 1) > 0)
+    // One successful attempt inserts the single input row once.
+    assert(published.numTargetRowsInserted.value === 1L)
+    assert(published.numTargetRowsCopied.value === 0L)
+    assert(published.numTargetRowsDeleted.value === 0L)
+    assert(published.numTargetRowsUpdated.value === 0L)
+  }
+}


### PR DESCRIPTION
Fixes #15349.

### Description

- Spark 4.1+ (`SPARK-52689` / `SPARK-53891`) expects DSv2 writes to pass a `WriteSummary` into `BatchWrite.commit(messages, summary)`, but the GPU V2 write path still called single-arg `commit(messages)`, so MERGE row metrics never reached Iceberg/Delta committers.
- Collect MERGE metrics on `GpuMergeRowsExec` (copied/inserted/deleted/updated and matched / not-matched-by-source variants), build `MergeSummaryImpl` on Spark 4.1+, and commit through versioned `GpuV2WriteCommitShims` (no-op summary path before 4.1).
- Stage MERGE row metrics in `LocalGpuMetric` per `withRetryNoSplit` attempt and flush only after success, so a retryable GPU OOM cannot double-count rows in the committed `WriteSummary`.
- Mix `GpuV2BatchWriteSummaryCommit` into Iceberg GPU `BatchWrite` wrappers so the 2-arg `commit` forwards the summary to the CPU delegate instead of the default interface method dropping it.
- Shim `Keep.context` → action tags via `GpuMergeRowsKeepShims` so metric attribution matches Spark CPU on 4.1+.
- Validation: `mvn -s ~/.m2/settings_art.xml -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests validate` SUCCESS; `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=400 -Dcuda.version=cuda13 -DskipTests validate` SUCCESS; `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=411 -Dcuda.version=cuda13 -DskipTests validate` SUCCESS; all-module scalastyle 0 errors; unit suites `GpuMergeRowMetricsSuite` (5) and `GpuV2WriteSummarySuite` (5) passed on buildver=411.

Known gaps (not in this PR): Append/Update/Delete write summaries, Iceberg IT for snapshot summary.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
