### PR TITLE
[SkipRecovery] Recover repeated-key JSON extractor tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -959,7 +959,7 @@ def test_from_json_strings(std_input_path, input_file):
     "bad_whitespace.json",
     "escaped_strings.json",
     pytest.param("nested_escaped_strings.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11387')),
-    pytest.param("repeated_columns.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11361')),
+    "repeated_columns.json",
     "mixed_objects.json",
     "timestamp_formatted_strings.json",
     "timestamp_tz_formatted_strings.json"])
@@ -989,7 +989,7 @@ def test_get_json_object_formats(std_input_path, input_file):
     "bad_whitespace.json",
     "escaped_strings.json",
     "nested_escaped_strings.json",
-    pytest.param("repeated_columns.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11361')),
+    "repeated_columns.json",
     "mixed_objects.json",
     "timestamp_formatted_strings.json",
     "timestamp_tz_formatted_strings.json"])
@@ -1029,7 +1029,7 @@ def test_get_json_object_child_formats(std_input_path, input_file):
     "bad_whitespace.json",
     "escaped_strings.json",
     pytest.param("nested_escaped_strings.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11387')),
-    pytest.param("repeated_columns.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11361')),
+    "repeated_columns.json",
     "mixed_objects.json",
     "timestamp_formatted_strings.json",
     "timestamp_tz_formatted_strings.json"])

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,9 +82,10 @@ case class GpuJsonTuple(children: Seq[Expression]) extends GpuGenerator
 
         var validPathsIndex = 0
         withResource(new Array[ColumnVector](fieldInstructions.length)) { validPathColumns =>
-          // Last argument -1 indicates to use automatically calculated parallelism
+          // A parallel override of -1 uses automatically calculated parallelism.
           withResource(JSONUtils.getJsonObjectMultiplePaths(
-              json, validPaths, 4 * targetBatchSize, -1)) { chunkedResult =>
+              json, validPaths, 4 * targetBatchSize, -1,
+              JSONUtils.NamedFieldMatchPolicy.LAST_NON_NULL)) { chunkedResult =>
               chunkedResult.foreach { cr =>
                 validPathColumns(validPathsIndex) = cr.incRefCount()
                 validPathsIndex += 1


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +2 lines** (`GpuJsonTuple.scala`; focused repeated-key `json_tuple` IT, shim 350)

Contributes to [NVIDIA/cudf-spark#11361](https://github.com/NVIDIA/cudf-spark/issues/11361).

Depends on [NVIDIA/cudf-spark-jni#4915](https://github.com/NVIDIA/cudf-spark-jni/pull/4915). This PR remains draft until the JNI change is merged and available to the build.

## Summary

- Request `LAST_NON_NULL` named-field matching from the JNI multi-path API used by `GpuJsonTuple`.
- Recover the repeated-key cases in:
  - `test_get_json_object_formats`
  - `test_get_json_object_child_formats`
  - `test_json_tuple_formats`
- Keep the remaining 18 issue-11361 exemptions for `from_json` and JSON scan paths. This is a partial recovery, not closure of the root issue.

## Validation

Validation used the exact JNI artifact built from the dependency PR (`sha256 cc47495dd18e769d96242738bcf8e3320290b53ec8f87163b42b93c5a514359a`).

- Offline `dist,integration_tests` Maven package, shim 350: `BUILD SUCCESS` (11/11 reactor modules, `03:05`)
- Three recovered cases: `3 passed in 4.94s`
- Broader `repeated_columns` cluster: `12 passed, 31 xfailed, 992 deselected, 6 warnings in 20.97s`
- Focused JaCoCo run: `1 passed in 4.44s`
- Added production lines covered by the focused run: `2 of 4`
- `python3 -m py_compile` and `git diff --check`: passed

## Performance impact

The Spark-side change adds one enum argument to the existing batched JNI call. It does not add JNI/native calls, input or output columns, allocations, or copies. `LAST_NON_NULL` scans duplicate named fields to match Spark semantics; no throughput benchmark was run.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
