### PR TITLE
[AutoSparkUT] Migrate four Spark SQL suites [fast-ut] [reduced-it]

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDeprecatedAPISuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDeprecatedAPISuite.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DeprecatedAPISuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDeprecatedAPISuite
+    extends DeprecatedAPISuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDeprecatedDatasetAggregatorSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDeprecatedDatasetAggregatorSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DeprecatedDatasetAggregatorSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+@scala.annotation.nowarn("cat=deprecation")
+class RapidsDeprecatedDatasetAggregatorSuite
+    extends DeprecatedDatasetAggregatorSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsStatisticsCollectionSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsStatisticsCollectionSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.StatisticsCollectionSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsStatisticsCollectionSuite
+    extends StatisticsCollectionSuite with RapidsSQLTestsTrait {
+
+  // The upstream suite validates statistics rather than JSON scan or cache serialization.
+  // Its zero-column table is not supported by the GPU JSON reader, and its view-size assertions
+  // are defined in terms of Spark's default cache serializer. Keep those setup paths on CPU while
+  // retaining GPU execution for the suite's query, aggregation, and statistics paths.
+  override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.rapids.sql.format.json.read.enabled", "false")
+      .set("spark.sql.cache.serializer",
+        "org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer")
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsUserDefinedTypeSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsUserDefinedTypeSuite.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.UserDefinedTypeSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsUserDefinedTypeSuite
+    extends UserDefinedTypeSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -167,6 +167,10 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-24596 Non-cascading Cache Invalidation - verify cached data reuse", ADJUST_UT("Replaced by testRapids version that checks non-cascading cache invalidation reuses loaded cached data without re-evaluating the UDF."))
     .exclude("SPARK-26708 Cache data and cached plan should stay consistent", ADJUST_UT("Replaced by testRapids version that checks loaded and unloaded dependent caches keep consistent cached plans under RAPIDS."))
   enableSuite[RapidsDatasetPrimitiveSuite]
+  enableSuite[RapidsUserDefinedTypeSuite]
+  enableSuite[RapidsDeprecatedAPISuite]
+  enableSuite[RapidsDeprecatedDatasetAggregatorSuite]
+  enableSuite[RapidsStatisticsCollectionSuite]
   enableSuite[RapidsFileSourceStrategySuite]
     .exclude("partitioned table - after scan filters", ADJUST_UT("Replaced by testRapids version that checks GpuFilterExec residual filters."))
     .exclude("[SPARK-16818] partition pruned file scans implement sameResult correctly", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15161"))


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: not measurable locally — official shim 350 nightly b22 class set could not be reproduced**

Closes #15447

## Summary

Migrate four Spark 3.3 SQL suites with minimal RAPIDS wrappers and register them in `RapidsTestSettings`:

- `RapidsUserDefinedTypeSuite`
- `RapidsDeprecatedAPISuite`
- `RapidsDeprecatedDatasetAggregatorSuite`
- `RapidsStatisticsCollectionSuite`

`NestedDataSourceSuite` was evaluated but deferred because its only test is analysis-only duplicate-column validation and has no GPU execution path.

## Spark v3.3.0 traceability

Spark source commit: `f74867bddfbcdd4d08076db36851e88b15e66556` (`v3.3.0`).

| RAPIDS suite | Original Spark tests | Source | Executed |
|---|---|---|---:|
| `RapidsUserDefinedTypeSuite` | `UserDefinedTypeSuite` including its four Parquet mode variants | [UserDefinedTypeSuite.scala:55-275](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala#L55-L275) | 20 |
| `RapidsDeprecatedAPISuite` | `DeprecatedAPISuite` | [DeprecatedAPISuite.scala:24-220](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala#L24-L220) | 11 |
| `RapidsDeprecatedDatasetAggregatorSuite` | `DeprecatedDatasetAggregatorSuite` | [DeprecatedDatasetAggregatorSuite.scala:25-77](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedDatasetAggregatorSuite.scala#L25-L77) | 5 |
| `RapidsStatisticsCollectionSuite` | `StatisticsCollectionSuite` plus inherited base tests | [StatisticsCollectionSuite.scala:47-801](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala#L47-L801), [StatisticsCollectionTestBase.scala:344-379](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala#L344-L379) | 35 |

Total: 71 tests.

## Statistics suite adaptation

The suite validates `ANALYZE TABLE(S)` statistics, not JSON scan or cache serialization. The RAPIDS wrapper keeps two setup-only paths on CPU without changing expected values or excluding tests:

- Disable the GPU JSON reader for the zero-column JSON table, which otherwise fails in `GpuTextBasedPartitionReader` with `empty.min`.
- Use the Spark default cache serializer because upstream view-size assertions are defined in terms of that CPU representation.

Query, aggregation, and statistics paths remain RAPIDS-enabled.

## Validation

```text
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsUserDefinedTypeSuite,org.apache.spark.sql.rapids.suites.RapidsDeprecatedAPISuite,org.apache.spark.sql.rapids.suites.RapidsDeprecatedDatasetAggregatorSuite,org.apache.spark.sql.rapids.suites.RapidsStatisticsCollectionSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm

Tests: succeeded 71, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

## Coverage measurement note

The official shim 350 nightly b22 CSV reports 1,713 sql-plugin classes and 32,348/39,721 covered lines. A clean build pinned to the exact nightly commit produced 3,704 classes; 72 published class keys were absent, so the baseline could not be reproduced exactly. Per the coverage honesty rule, no numeric increment is claimed.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required