### PR TITLE
Fix non-UTC ORC timestamp read correctness [databricks] [fast-ut] [reduced-it]

### DIFF
--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -145,6 +145,9 @@ def test_non_utc_timestamp_regressions(spark_tmp_path):
     with_cpu_session(
         lambda spark: spark.createDataFrame(
             [(0.0,),
+             (float('nan'),),
+             (float('inf'),),
+             (float('-inf'),),
              (-8589934591.999999,),
              (-7953731124.723491,),
              (-0.0015,),

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -17,7 +17,8 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error
 from conftest import is_not_utc
 from data_gen import *
-from marks import allow_non_gpu, datagen_overrides, tz_sensitive_test
+from marks import (allow_non_gpu, datagen_overrides, tz_sensitive_test,
+                   validate_execs_in_gpu_plan)
 from pyspark.sql.types import *
 from spark_session import with_cpu_session
 from orc_test import reader_opt_confs
@@ -131,6 +132,7 @@ def test_casting_from_double_to_timestamp(spark_tmp_path, data_gen):
 @tz_sensitive_test
 @pytest.mark.skipif(not is_not_utc(), reason="non-UTC ORC timestamp regression test")
 @allow_non_gpu(*non_utc_allow_orc_scan)
+@validate_execs_in_gpu_plan('GpuFileSourceScanExec')
 def test_non_utc_timestamp_regressions(spark_tmp_path):
     integer_path = spark_tmp_path + '/orc_integer_timestamp_regression'
     double_path = spark_tmp_path + '/orc_double_timestamp_regression'

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -125,6 +125,39 @@ def test_casting_from_double_to_timestamp(spark_tmp_path, data_gen):
     # the name of unique column is 'a', cast it into timestamp type
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.schema("a timestamp").orc(orc_path)
+    )
+
+
+@pytest.mark.skipif(not is_not_utc(), reason="non-UTC ORC timestamp regression test")
+@allow_non_gpu(*non_utc_allow_orc_scan)
+def test_non_utc_timestamp_regressions(spark_tmp_path):
+    integer_path = spark_tmp_path + '/orc_integer_timestamp_regression'
+    double_path = spark_tmp_path + '/orc_double_timestamp_regression'
+    physical_path = spark_tmp_path + '/orc_physical_timestamp_regression'
+
+    with_cpu_session(
+        lambda spark: spark.createDataFrame([(514952012,)], "a long")
+            .write.orc(integer_path)
+    )
+    with_cpu_session(
+        lambda spark: spark.createDataFrame(
+            [(0.0,), (-8589934591.999999,), (-7953731124.723491,)], "a double")
+            .write.orc(double_path)
+    )
+    with_cpu_session(
+        lambda spark: spark.range(1)
+            .selectExpr("timestamp_micros(-2957649381472612L) AS a")
+            .write.orc(physical_path)
+    )
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema("a timestamp").orc(integer_path)
+    )
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema("a timestamp").orc(double_path)
+    )
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.orc(physical_path)
     )
 
 

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error
 from conftest import is_not_utc
 from data_gen import *
-from marks import allow_non_gpu, datagen_overrides
+from marks import allow_non_gpu, datagen_overrides, tz_sensitive_test
 from pyspark.sql.types import *
 from spark_session import with_cpu_session
 from orc_test import reader_opt_confs
@@ -128,6 +128,7 @@ def test_casting_from_double_to_timestamp(spark_tmp_path, data_gen):
     )
 
 
+@tz_sensitive_test
 @pytest.mark.skipif(not is_not_utc(), reason="non-UTC ORC timestamp regression test")
 @allow_non_gpu(*non_utc_allow_orc_scan)
 def test_non_utc_timestamp_regressions(spark_tmp_path):
@@ -141,12 +142,20 @@ def test_non_utc_timestamp_regressions(spark_tmp_path):
     )
     with_cpu_session(
         lambda spark: spark.createDataFrame(
-            [(0.0,), (-8589934591.999999,), (-7953731124.723491,)], "a double")
+            [(0.0,),
+             (-8589934591.999999,),
+             (-7953731124.723491,),
+             (-0.0015,),
+             (-0.0005,),
+             (0.0005,),
+             (0.0015,)],
+            "a double")
             .write.orc(double_path)
     )
     with_cpu_session(
-        lambda spark: spark.range(1)
-            .selectExpr("timestamp_micros(-2957649381472612L) AS a")
+        lambda spark: spark.createDataFrame(
+            [(-2957649381472612,), (-3649379812521628,)], "a long")
+            .selectExpr("timestamp_micros(a) AS a")
             .write.orc(physical_path)
     )
 
@@ -162,10 +171,14 @@ def test_non_utc_timestamp_regressions(spark_tmp_path):
 
 
 @allow_non_gpu(*non_utc_allow_for_test_casting_from_overflow_long)
-def test_casting_from_overflow_double_to_timestamp(spark_tmp_path):
+# Keep both signs beyond the Long microsecond range after any timezone correction.
+@pytest.mark.parametrize("overflow_value", [9223372123255.0, -9223372123255.0])
+def test_casting_from_overflow_double_to_timestamp(spark_tmp_path, overflow_value):
     orc_path = spark_tmp_path + '/orc_casting_from_overflow_double_to_timestamp'
     with_cpu_session(
-        lambda spark: unary_op_df(spark, DoubleGen(min_exp=38)).write.orc(orc_path)
+        lambda spark: spark.createDataFrame(
+            [(overflow_value,)], "a double")
+            .write.orc(orc_path)
     )
     assert_gpu_and_cpu_error(
         df_fun=lambda spark: spark.read.schema("a timestamp").orc(orc_path).collect(),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -23,6 +23,7 @@ import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
 import java.time.ZoneId
 import java.util
+import java.util.TimeZone
 import java.util.regex.Pattern
 
 import scala.annotation.tailrec
@@ -446,32 +447,49 @@ object GpuOrcScan {
   }
 
   /**
-   * Apply Spark's java.time timezone rules before ORC's millisecond rounding and overflow check.
-   * Looking up the offset with a microsecond timestamp preserves the original floating-point
-   * value: only the integral timezone delta is taken from the converted timestamp.
+   * Apply ORC's offset lookup ordering before its millisecond rounding and overflow check.
+   * ORC looks up the offset at `(localMillis - rawOffset)`, while Spark materializes the final
+   * timestamp with java.time rules. Apply only that integral timezone delta to the original
+   * floating-point value so both the DST and historical behavior match Spark's CPU ORC path.
    */
   private def convertOrcFloatingPointSeconds(seconds: ColumnView): ColumnVector = {
     withResource(Scalar.fromDouble(DateTimeConstants.MICROS_PER_SECOND)) { microsPerSecond =>
-      val localMicros = withResource(seconds.mul(microsPerSecond, DType.FLOAT64)) {
-        doubleMicros =>
-        doubleMicros.castTo(DType.INT64)
-      }
-      withResource(localMicros) { _ =>
-        val utcMicros = withResource(localMicros.castTo(DType.TIMESTAMP_MICROSECONDS)) {
-          localTimestamp =>
-          withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
-              localTimestamp, ZoneId.systemDefault().normalized())) { utcTimestamp =>
-            utcTimestamp.castTo(DType.INT64)
-          }
-        }
-        withResource(utcMicros) { _ =>
-          val offsetSeconds = withResource(utcMicros.sub(localMicros)) { offsetMicros =>
-            withResource(offsetMicros.castTo(DType.FLOAT64)) { doubleOffsetMicros =>
-              doubleOffsetMicros.div(microsPerSecond, DType.FLOAT64)
+      val localTimestamp = withResource(
+          Scalar.fromDouble(DateTimeConstants.MILLIS_PER_SECOND)) { millisPerSecond =>
+        withResource(seconds.mul(millisPerSecond, DType.FLOAT64)) { doubleMillis =>
+          withResource(doubleMillis.castTo(DType.INT64)) { localMillis =>
+            withResource(localMillis.bitCastTo(DType.TIMESTAMP_MILLISECONDS)) {
+              localMillisTimestamp =>
+              localMillisTimestamp.castTo(DType.TIMESTAMP_MICROSECONDS)
             }
           }
-          withResource(offsetSeconds) { _ =>
-            seconds.add(offsetSeconds, DType.FLOAT64)
+        }
+      }
+      withResource(localTimestamp) { _ =>
+        withResource(localTimestamp.bitCastTo(DType.INT64)) { localMicros =>
+          val rawOffsetMicros = TimeZone.getDefault.getRawOffset.toLong *
+            DateTimeConstants.MICROS_PER_MILLIS
+          withResource(Scalar.fromLong(rawOffsetMicros)) { rawOffset =>
+            withResource(localMicros.sub(rawOffset)) { offsetLookupMicros =>
+              withResource(offsetLookupMicros.castTo(DType.TIMESTAMP_MICROSECONDS)) {
+                offsetLookupTimestamp =>
+                val localAtLookup = GpuTimeZoneDB.fromUtcTimestampToTimestamp(
+                  offsetLookupTimestamp, ZoneId.systemDefault().normalized())
+                withResource(localAtLookup) { _ =>
+                  withResource(localAtLookup.bitCastTo(DType.INT64)) { localAtLookupMicros =>
+                    val offsetSeconds = withResource(
+                        localAtLookupMicros.sub(offsetLookupMicros)) { offsetMicros =>
+                      withResource(offsetMicros.castTo(DType.FLOAT64)) { doubleOffsetMicros =>
+                        doubleOffsetMicros.div(microsPerSecond, DType.FLOAT64)
+                      }
+                    }
+                    withResource(offsetSeconds) { _ =>
+                      seconds.sub(offsetSeconds, DType.FLOAT64)
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -452,22 +452,26 @@ object GpuOrcScan {
    */
   private def convertOrcFloatingPointSeconds(seconds: ColumnView): ColumnVector = {
     withResource(Scalar.fromDouble(DateTimeConstants.MICROS_PER_SECOND)) { microsPerSecond =>
-      withResource(seconds.mul(microsPerSecond, DType.FLOAT64)) { doubleMicros =>
-        withResource(doubleMicros.castTo(DType.INT64)) { localMicros =>
-          withResource(localMicros.castTo(DType.TIMESTAMP_MICROSECONDS)) { localTimestamp =>
-            withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
-                localTimestamp, ZoneId.systemDefault().normalized())) { utcTimestamp =>
-              withResource(utcTimestamp.castTo(DType.INT64)) { utcMicros =>
-                withResource(utcMicros.sub(localMicros)) { offsetMicros =>
-                  withResource(offsetMicros.castTo(DType.FLOAT64)) { doubleOffsetMicros =>
-                    withResource(doubleOffsetMicros.div(microsPerSecond, DType.FLOAT64)) {
-                      offsetSeconds =>
-                      seconds.add(offsetSeconds, DType.FLOAT64)
-                    }
-                  }
-                }
-              }
+      val localMicros = withResource(seconds.mul(microsPerSecond, DType.FLOAT64)) {
+        doubleMicros =>
+        doubleMicros.castTo(DType.INT64)
+      }
+      withResource(localMicros) { _ =>
+        val utcMicros = withResource(localMicros.castTo(DType.TIMESTAMP_MICROSECONDS)) {
+          localTimestamp =>
+          withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
+              localTimestamp, ZoneId.systemDefault().normalized())) { utcTimestamp =>
+            utcTimestamp.castTo(DType.INT64)
+          }
+        }
+        withResource(utcMicros) { _ =>
+          val offsetSeconds = withResource(utcMicros.sub(localMicros)) { offsetMicros =>
+            withResource(offsetMicros.castTo(DType.FLOAT64)) { doubleOffsetMicros =>
+              doubleOffsetMicros.div(microsPerSecond, DType.FLOAT64)
             }
+          }
+          withResource(offsetSeconds) { _ =>
+            seconds.add(offsetSeconds, DType.FLOAT64)
           }
         }
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -452,7 +452,10 @@ object GpuOrcScan {
    * timestamp with java.time rules. Apply only that integral timezone delta to the original
    * floating-point value so both the DST and historical behavior match Spark's CPU ORC path.
    */
-  private def convertOrcFloatingPointSeconds(seconds: ColumnView): ColumnVector = {
+  private def convertOrcFloatingPointSeconds(seconds: ColumnVector): ColumnVector = {
+    if (GpuOverrides.isUTCTimezone(ZoneId.systemDefault())) {
+      return seconds.incRefCount()
+    }
     withResource(Scalar.fromDouble(DateTimeConstants.MICROS_PER_SECOND)) { microsPerSecond =>
       val localTimestamp = withResource(
           Scalar.fromDouble(DateTimeConstants.MILLIS_PER_SECOND)) { millisPerSecond =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -322,8 +322,7 @@ object GpuOrcScan {
       case (DType.BOOL8 | DType.INT8 | DType.INT16 | DType.INT32 | DType.INT64,
       DType.TIMESTAMP_MICROSECONDS) =>
         withResource(OrcCastingShims.castIntegerToTimestamp(col, fromDt)) { timestamp =>
-          GpuTimeZoneDB.fromTimestampToUtcTimestamp(
-            timestamp, ZoneId.systemDefault().normalized())
+          GpuTimeZoneDB.convertOrcFromUtc(timestamp, ZoneId.systemDefault().getId)
         }
 
       // float to bool/integral
@@ -382,16 +381,19 @@ object GpuOrcScan {
         // Math.round half up can be implemented in terms of floor
         // Math.round(x) = n iff x is in [n-0.5, n+0.5) iff x+0.5 is in [n,n+1) iff floor(x+0.5) = n
         //
-        val milliseconds = withResource(Scalar.fromDouble(DateTimeConstants.MILLIS_PER_SECOND)) {
-          thousand =>
-          // ORC assumes value is in seconds
-          withResource(col.mul(thousand, DType.FLOAT64)) { doubleMillis =>
-            withResource(Scalar.fromDouble(0.5)) { half =>
-              withResource(doubleMillis.add(half)) { doubleMillisPlusHalf =>
-                withResource(doubleMillisPlusHalf.floor()) { millis =>
-                  withResource(getOverflowFlags(doubleMillis, millis)) { overflowFlags =>
-                    withResource(Scalar.fromNull(millis.getType)) { nullVal =>
-                      overflowFlags.ifElse(millis, nullVal)
+        val milliseconds = withResource(col.castTo(DType.FLOAT64)) { doubleSeconds =>
+          withResource(convertOrcFloatingPointSeconds(doubleSeconds)) { convertedSeconds =>
+            withResource(Scalar.fromDouble(DateTimeConstants.MILLIS_PER_SECOND)) { thousand =>
+              // ORC applies timezone conversion while the value is still in seconds.
+              withResource(convertedSeconds.mul(thousand, DType.FLOAT64)) { doubleMillis =>
+                withResource(Scalar.fromDouble(0.5)) { half =>
+                  withResource(doubleMillis.add(half)) { doubleMillisPlusHalf =>
+                    withResource(doubleMillisPlusHalf.floor()) { millis =>
+                      withResource(getOverflowFlags(doubleMillis, millis)) { overflowFlags =>
+                        withResource(Scalar.fromNull(millis.getType)) { nullVal =>
+                          overflowFlags.ifElse(millis, nullVal)
+                        }
+                      }
                     }
                   }
                 }
@@ -419,12 +421,11 @@ object GpuOrcScan {
           }
           withResource(Scalar.fromDouble(DateTimeConstants.MICROS_PER_MILLIS)) { thousand =>
             withResource(milliseconds.mul(thousand)) { microseconds =>
-                withResource(microseconds.castTo(DType.INT64)) { longVec =>
-                  withResource(longVec.castTo(DType.TIMESTAMP_MICROSECONDS)) { timestamp =>
-                    GpuTimeZoneDB.fromTimestampToUtcTimestamp(
-                      timestamp, ZoneId.systemDefault().normalized())
-                  }
+              withResource(microseconds.castTo(DType.INT64)) { longVec =>
+                withResource(longVec.castTo(DType.TIMESTAMP_MICROSECONDS)) { timestamp =>
+                  timestamp.incRefCount()
                 }
+              }
             }
           }
         }
@@ -441,6 +442,35 @@ object GpuOrcScan {
       // TODO more types, tracked in https://github.com/NVIDIA/spark-rapids/issues/5895
       case (f, t) =>
         throw new QueryExecutionException(s"Unsupported type casting: $f -> $t")
+    }
+  }
+
+  /**
+   * Apply Spark's java.time timezone rules before ORC's millisecond rounding and overflow check.
+   * Looking up the offset with a microsecond timestamp preserves the original floating-point
+   * value: only the integral timezone delta is taken from the converted timestamp.
+   */
+  private def convertOrcFloatingPointSeconds(seconds: ColumnView): ColumnVector = {
+    withResource(Scalar.fromDouble(DateTimeConstants.MICROS_PER_SECOND)) { microsPerSecond =>
+      withResource(seconds.mul(microsPerSecond, DType.FLOAT64)) { doubleMicros =>
+        withResource(doubleMicros.castTo(DType.INT64)) { localMicros =>
+          withResource(localMicros.castTo(DType.TIMESTAMP_MICROSECONDS)) { localTimestamp =>
+            withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
+                localTimestamp, ZoneId.systemDefault().normalized())) { utcTimestamp =>
+              withResource(utcTimestamp.castTo(DType.INT64)) { utcMicros =>
+                withResource(utcMicros.sub(localMicros)) { offsetMicros =>
+                  withResource(offsetMicros.castTo(DType.FLOAT64)) { doubleOffsetMicros =>
+                    withResource(doubleOffsetMicros.div(microsPerSecond, DType.FLOAT64)) {
+                      offsetSeconds =>
+                      seconds.add(offsetSeconds, DType.FLOAT64)
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
@@ -21,7 +21,7 @@ import java.util.Optional
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ColumnView, DType, Table}
+import ai.rapids.cudf.{ColumnView, DType, Scalar, Table}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
@@ -77,16 +77,17 @@ object GpuOrcTimezoneUtils {
    */
   private def rebaseWithWriterTimezone(
       input: Table, writerTz: String, readerTz: String): Table = {
+    val readerZone = ZoneId.of(readerTz, ZoneId.SHORT_IDS)
     withResource(input) { _ =>
       withResource(GpuTimeZoneDB.buildOrcTimezoneContext(writerTz, readerTz)) { tzCtx =>
         val newColumns = (0 until input.getNumberOfColumns).safeMap { colIdx =>
           val col = input.getColumn(colIdx)
           val dType = col.getType
           if (dType.hasTimeResolution) {
-            GpuTimeZoneDB.convertOrcTimezones(col, tzCtx)
+            convertOrcTimestamp(col, tzCtx, readerZone)
           } else if (dType == DType.LIST || dType == DType.STRUCT) {
             withResource(new ArrayBuffer[ColumnView]) { toClose =>
-              val rebased = rebaseNestedWithWriterTimezone(col, tzCtx, toClose)
+              val rebased = rebaseNestedWithWriterTimezone(col, tzCtx, readerZone, toClose)
               if (rebased eq col) {
                 col.incRefCount()
               } else {
@@ -105,18 +106,61 @@ object GpuOrcTimezoneUtils {
     }
   }
 
+  /**
+   * Match the full Spark ORC timestamp path. Apache ORC uses java.util.TimeZone while decoding,
+   * but Spark materializes the resulting java.sql.Timestamp using java.time rules. Those rule
+   * sets can differ for historical and projected timestamps.
+   */
+  private def convertOrcTimestamp(
+      col: ColumnView,
+      tzCtx: GpuTimeZoneDB.OrcTimezoneContext,
+      readerZone: ZoneId): ai.rapids.cudf.ColumnVector = {
+    withResource(GpuTimeZoneDB.convertOrcTimezones(col, tzCtx)) { orcTimestamp =>
+      val firstTransitionUs = tzCtx.getReaderFirstTransitionUs
+      if (firstTransitionUs == Long.MinValue) {
+        orcTimestamp.incRefCount()
+      } else {
+        withResource(GpuTimeZoneDB.convertOrcFromUtc(orcTimestamp, tzCtx)) { utilUtc =>
+          withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
+              orcTimestamp, readerZone.normalized())) { zoneUtc =>
+            withResource(orcTimestamp.castTo(DType.INT64)) { orcMicros =>
+              withResource(utilUtc.castTo(DType.INT64)) { utilMicros =>
+                withResource(zoneUtc.castTo(DType.INT64)) { zoneMicros =>
+                  withResource(zoneMicros.sub(utilMicros)) { ruleCorrection =>
+                    withResource(orcMicros.add(ruleCorrection)) { corrected =>
+                      withResource(corrected.castTo(DType.TIMESTAMP_MICROSECONDS)) {
+                        correctedTimestamp =>
+                        withResource(Scalar.timestampFromLong(
+                            DType.TIMESTAMP_MICROSECONDS, firstTransitionUs)) { firstTransition =>
+                          withResource(orcTimestamp.lessThan(firstTransition)) { needsCorrection =>
+                            needsCorrection.ifElse(correctedTimestamp, orcTimestamp)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   private def rebaseNestedWithWriterTimezone(
       col: ColumnView,
       tzCtx: GpuTimeZoneDB.OrcTimezoneContext,
+      readerZone: ZoneId,
       toClose: ArrayBuffer[ColumnView]): ColumnView = {
     val addToClose = (v: ColumnView) => { toClose += v; v }
     val dType = col.getType
 
     if (dType.hasTimeResolution) {
-      GpuTimeZoneDB.convertOrcTimezones(col, tzCtx)
+      convertOrcTimestamp(col, tzCtx, readerZone)
     } else if (dType == DType.LIST) {
       val child = addToClose(col.getChildColumnView(0))
-      val newChild = rebaseNestedWithWriterTimezone(child, tzCtx, toClose)
+      val newChild = rebaseNestedWithWriterTimezone(child, tzCtx, readerZone, toClose)
       if (newChild ne child) {
         col.replaceListChild(addToClose(newChild))
       } else {
@@ -125,7 +169,7 @@ object GpuOrcTimezoneUtils {
     } else if (dType == DType.STRUCT) {
       val newViews = (0 until col.getNumChildren).map { i =>
         val child = addToClose(col.getChildColumnView(i))
-        val newChild = rebaseNestedWithWriterTimezone(child, tzCtx, toClose)
+        val newChild = rebaseNestedWithWriterTimezone(child, tzCtx, readerZone, toClose)
         if (newChild ne child) addToClose(newChild)
         newChild
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
@@ -117,11 +117,7 @@ object GpuOrcTimezoneUtils {
       readerZone: ZoneId): ai.rapids.cudf.ColumnVector = {
     withResource(GpuTimeZoneDB.convertOrcTimezones(col, tzCtx)) { orcTimestamp =>
       val firstTransitionUs = tzCtx.getReaderFirstTransitionUs
-      val needsHistoricalCorrection = firstTransitionUs != Long.MinValue &&
-        withResource(orcTimestamp.min()) { minTimestamp =>
-          minTimestamp.isValid && minTimestamp.getLong < firstTransitionUs
-        }
-      if (!needsHistoricalCorrection) {
+      if (firstTransitionUs == Long.MinValue) {
         orcTimestamp.incRefCount()
       } else {
         val utilMicros = withResource(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
@@ -117,7 +117,11 @@ object GpuOrcTimezoneUtils {
       readerZone: ZoneId): ai.rapids.cudf.ColumnVector = {
     withResource(GpuTimeZoneDB.convertOrcTimezones(col, tzCtx)) { orcTimestamp =>
       val firstTransitionUs = tzCtx.getReaderFirstTransitionUs
-      if (firstTransitionUs == Long.MinValue) {
+      val needsHistoricalCorrection = firstTransitionUs != Long.MinValue &&
+        withResource(orcTimestamp.min()) { minTimestamp =>
+          minTimestamp.isValid && minTimestamp.getLong < firstTransitionUs
+        }
+      if (!needsHistoricalCorrection) {
         orcTimestamp.incRefCount()
       } else {
         val utilMicros = withResource(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcTimezoneUtils.scala
@@ -120,25 +120,28 @@ object GpuOrcTimezoneUtils {
       if (firstTransitionUs == Long.MinValue) {
         orcTimestamp.incRefCount()
       } else {
-        withResource(GpuTimeZoneDB.convertOrcFromUtc(orcTimestamp, tzCtx)) { utilUtc =>
-          withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
+        val utilMicros = withResource(
+            GpuTimeZoneDB.convertOrcFromUtc(orcTimestamp, tzCtx)) { utilUtc =>
+          utilUtc.castTo(DType.INT64)
+        }
+        withResource(utilMicros) { _ =>
+          val ruleCorrection = withResource(GpuTimeZoneDB.fromTimestampToUtcTimestamp(
               orcTimestamp, readerZone.normalized())) { zoneUtc =>
-            withResource(orcTimestamp.castTo(DType.INT64)) { orcMicros =>
-              withResource(utilUtc.castTo(DType.INT64)) { utilMicros =>
-                withResource(zoneUtc.castTo(DType.INT64)) { zoneMicros =>
-                  withResource(zoneMicros.sub(utilMicros)) { ruleCorrection =>
-                    withResource(orcMicros.add(ruleCorrection)) { corrected =>
-                      withResource(corrected.castTo(DType.TIMESTAMP_MICROSECONDS)) {
-                        correctedTimestamp =>
-                        withResource(Scalar.timestampFromLong(
-                            DType.TIMESTAMP_MICROSECONDS, firstTransitionUs)) { firstTransition =>
-                          withResource(orcTimestamp.lessThan(firstTransition)) { needsCorrection =>
-                            needsCorrection.ifElse(correctedTimestamp, orcTimestamp)
-                          }
-                        }
-                      }
-                    }
-                  }
+            withResource(zoneUtc.castTo(DType.INT64)) { zoneMicros =>
+              zoneMicros.sub(utilMicros)
+            }
+          }
+          withResource(ruleCorrection) { _ =>
+            val correctedTimestamp = withResource(orcTimestamp.castTo(DType.INT64)) { orcMicros =>
+              withResource(orcMicros.add(ruleCorrection)) { corrected =>
+                corrected.castTo(DType.TIMESTAMP_MICROSECONDS)
+              }
+            }
+            withResource(correctedTimestamp) { _ =>
+              withResource(Scalar.timestampFromLong(
+                  DType.TIMESTAMP_MICROSECONDS, firstTransitionUs)) { firstTransition =>
+                withResource(orcTimestamp.lessThan(firstTransition)) { needsCorrection =>
+                  needsCorrection.ifElse(correctedTimestamp, orcTimestamp)
                 }
               }
             }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
@@ -315,6 +315,42 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     spark.sql(selects.mkString(" UNION ALL "))
   }
 
+  Seq(false, true).foreach { useChunkedReader =>
+    test(s"all-null ORC timestamps stay on the GPU, chunked=$useChunkedReader") {
+      val originalTimeZone = TimeZone.getDefault
+      val conf = baseConf("orc")
+        .set(RapidsConf.CHUNKED_READER.key, useChunkedReader.toString)
+
+      try {
+        withTempPath { fileRoot =>
+          withCpuSparkSession(spark => {
+            setSessionTimeZone(spark, "UTC")
+            spark.range(4).selectExpr("CAST(NULL AS TIMESTAMP) AS ts")
+              .write.orc(fileRoot.getCanonicalPath)
+          }, conf = conf)
+
+          val (fromCpu, fromGpu) = runOnCpuAndGpu(
+            spark => {
+              setSessionTimeZone(spark, "Europe/Paris")
+              spark.read.orc(fileRoot.getCanonicalPath)
+            },
+            identity,
+            conf = conf,
+            repart = 0,
+            skipCanonicalizationCheck = true,
+            existClasses = "GpuFileSourceScanExec")
+          compareResults(
+            sort = false,
+            floatEpsilon = 0.0,
+            fromCpu = fromCpu,
+            fromGpu = fromGpu)
+        }
+      } finally {
+        TimeZone.setDefault(originalTimeZone)
+      }
+    }
+  }
+
   test("skip writer timezone validation without a timestamp projection") {
     val originalTimeZone = TimeZone.getDefault
     val conf = baseConf("orc")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
@@ -285,6 +285,8 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
       "NULL",
       "-8589934591.999999",
       "-7953731124.723491",
+      "1710037800.0", // 2024-03-10 02:30:00, inside the America/New_York DST gap
+      "1730597400.0", // 2024-11-03 01:30:00, inside the America/New_York DST overlap
       "-0.0015",
       "-0.0005",
       "0.0",

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.timezone
 import java.io.File
 import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime, ZoneId, ZoneOffset}
-import java.util.{Random, TimeZone}
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -33,7 +33,7 @@ import org.apache.orc.impl.{RecordReaderImpl, WriterImpl}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType, TimestampType}
 
 /**
  * Test suite for ORC reader/writer timezones.
@@ -43,6 +43,7 @@ import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
  *   - `America/New_York`
  *   - `America/Los_Angeles`
  *   - `Asia/Shanghai`
+ *   - `Europe/Paris`
  *   - `US/Pacific` (alias of `America/Los_Angeles`)
  *   - `PST` (legacy short ID)
  *
@@ -57,7 +58,8 @@ import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
  * which also resets TimeZone.getDefault().
  *
  * Run it manually with:
- *   mvn test -DwildcardSuites=com.nvidia.spark.rapids.OrcTimezoneSuite -Dbuildver=xxx
+ *   mvn package -pl tests -am -Dbuildver=xxx \
+ *     -DwildcardSuites=com.nvidia.spark.rapids.timezone.OrcTimezoneSuite
  *
  * Note: use `orc-tool meta -t orc_file` to view the timezone in each stripe metadata.
  * Each stripe has a timezone in its metadata.
@@ -84,9 +86,11 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     assert(error.getMessage.contains("Not/AZone"))
   }
 
-  private val RandomRowCount = 4096L
   // Exact Asia/Shanghai writer=reader reproducer for the ORC epoch borrow correction.
   private val ShanghaiEpochBorrowTsUs = -7713116127L
+  // Exact pre-first-transition values from non-UTC schema-evolution failures.
+  private val newYorkHistoricalTsUs = -2957649381472612L
+  private val shanghaiHistoricalTsUs = -3649379812521628L
 
   // Includes legacy/alias IDs ("US/Pacific", "PST") alongside canonical region IDs to
   // exercise the read path against the kinds of writer-timezone strings ORC footers can
@@ -97,6 +101,7 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     "America/New_York",
     "America/Los_Angeles",
     "Asia/Shanghai",
+    "Europe/Paris",
     "US/Pacific",
     "PST"
   )
@@ -108,12 +113,14 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     LocalDateTime.of(9999, 12, 31, 23, 59, 59).toEpochSecond(ZoneOffset.UTC) *
       TimeUnit.SECONDS.toMicros(1) + 999999L
 
-  // 2024 DST transitions for the two canonical DST zones in the test matrix.
+  // 2024 DST transitions for the three canonical DST zones in the test matrix.
   private val DstTransitions = Seq(
     Instant.parse("2024-03-10T07:00:00Z"), // America/New_York spring forward
     Instant.parse("2024-11-03T06:00:00Z"), // America/New_York fall back
     Instant.parse("2024-03-10T10:00:00Z"), // America/Los_Angeles spring forward
-    Instant.parse("2024-11-03T09:00:00Z")  // America/Los_Angeles fall back
+    Instant.parse("2024-11-03T09:00:00Z"), // America/Los_Angeles fall back
+    Instant.parse("2024-03-31T01:00:00Z"), // Europe/Paris spring forward
+    Instant.parse("2024-10-27T01:00:00Z")  // Europe/Paris fall back
   )
 
   private val ExplicitTimestampMicros = {
@@ -122,7 +129,12 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
         TimeUnit.NANOSECONDS.toMicros(transition.getNano)
       Seq(atTransition - 1L, atTransition, atTransition + 1L)
     }
-    Seq(ShanghaiEpochBorrowTsUs, minTs, maxTs) ++ dstBoundaries
+    Seq(
+      newYorkHistoricalTsUs,
+      shanghaiHistoricalTsUs,
+      ShanghaiEpochBorrowTsUs,
+      minTs,
+      maxTs) ++ dstBoundaries
   }
 
   private def setSessionTimeZone(spark: SparkSession, tzId: String): Unit = {
@@ -152,13 +164,8 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
         |  CAST(NULL AS ARRAY<TIMESTAMP>)) AS array_ts""".stripMargin)
   }
 
-  private def fileDataFrame(
-      spark: SparkSession,
-      random: Random,
-      idOffset: Long = 0L): DataFrame = {
-    val randomMicros = random.longs(RandomRowCount, minTs, maxTs).toArray
-    timestampDataFrame(spark, ExplicitTimestampMicros ++ randomMicros, idOffset)
-  }
+  private def fileDataFrame(spark: SparkSession, idOffset: Long = 0L): DataFrame =
+    timestampDataFrame(spark, ExplicitTimestampMicros, idOffset)
 
   private val v1SourceLists = Seq("orc", "")
 
@@ -167,8 +174,8 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
       .set("spark.sql.sources.useV1SourceList", v1SourceList)
   }
 
-  private def writeFile(spark: SparkSession, outputPath: File, random: Random): Unit = {
-    fileDataFrame(spark, random)
+  private def writeFile(spark: SparkSession, outputPath: File): Unit = {
+    fileDataFrame(spark)
       .coalesce(1)
       .write
       .mode("overwrite")
@@ -241,6 +248,59 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     "bigint" -> Seq("NULL", "-1", "0", "1593604800"),
     "float" -> Seq("NULL", "-0.25", "0.0", "1593604800.25"),
     "double" -> Seq("NULL", "-0.25", "0.0", "1593604800.25"))
+
+  private case class TimestampSchemaEvolutionCase(sourceType: String, values: Seq[String])
+
+  private val timestampSchemaEvolutionCases = Seq(
+    TimestampSchemaEvolutionCase("timestamp", Seq(
+      "NULL",
+      s"timestamp_micros(${newYorkHistoricalTsUs}L)",
+      s"timestamp_micros(${shanghaiHistoricalTsUs}L)",
+      "timestamp_micros(0L)")),
+    TimestampSchemaEvolutionCase("bigint", Seq(
+      "NULL",
+      "-1",
+      "0",
+      "1",
+      "514952012")),
+    TimestampSchemaEvolutionCase("float", Seq(
+      "NULL",
+      "-0.0015",
+      "-0.0005",
+      "0.0",
+      "0.0005",
+      "0.0015")),
+    TimestampSchemaEvolutionCase("double", Seq(
+      "NULL",
+      "-8589934591.999999",
+      "-7953731124.723491",
+      "-0.0015",
+      "-0.0005",
+      "0.0",
+      "0.0005",
+      "0.0015")))
+
+  // Covers same-zone, same-rules aliases, and both directions between UTC and a DST zone.
+  private val timestampSchemaEvolutionZonePairs = Seq(
+    "UTC" -> "UTC",
+    "America/New_York" -> "America/New_York",
+    "Asia/Shanghai" -> "Asia/Shanghai",
+    "Europe/Paris" -> "Europe/Paris",
+    "America/Los_Angeles" -> "US/Pacific",
+    "US/Pacific" -> "PST",
+    "UTC" -> "America/New_York",
+    "America/New_York" -> "UTC",
+    "UTC" -> "Europe/Paris",
+    "Europe/Paris" -> "UTC")
+
+  private def timestampSchemaEvolutionDataFrame(
+      spark: SparkSession,
+      testCase: TimestampSchemaEvolutionCase): DataFrame = {
+    val selects = testCase.values.zipWithIndex.map { case (value, id) =>
+      s"SELECT $id AS id, CAST($value AS ${testCase.sourceType}) AS ts"
+    }
+    spark.sql(selects.mkString(" UNION ALL "))
+  }
 
   test("skip writer timezone validation without a timestamp projection") {
     val originalTimeZone = TimeZone.getDefault
@@ -340,6 +400,54 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     }
   }
 
+  for {
+    testCase <- timestampSchemaEvolutionCases
+    useChunkedReader <- Seq(false, true)
+  } {
+    test(s"schema evolution matrix from ${testCase.sourceType} to timestamp, " +
+        s"chunked=$useChunkedReader") {
+      val originalTimeZone = TimeZone.getDefault
+      val conf = baseConf("orc")
+        .set(RapidsConf.CHUNKED_READER.key, useChunkedReader.toString)
+      val readSchema = StructType(Seq(
+        StructField("id", IntegerType),
+        StructField("ts", TimestampType)))
+
+      try {
+        timestampSchemaEvolutionZonePairs.foreach { case (writerTimeZone, readerTimeZone) =>
+          withClue(s"writerTimezone=$writerTimeZone readerTimezone=$readerTimeZone " +
+              s"sourceType=${testCase.sourceType}") {
+            withTempPath { fileRoot =>
+              withCpuSparkSession(spark => {
+                setSessionTimeZone(spark, writerTimeZone)
+                timestampSchemaEvolutionDataFrame(spark, testCase)
+                  .write.orc(fileRoot.getCanonicalPath)
+              }, conf = conf)
+
+              val (fromCpu, fromGpu) = runOnCpuAndGpu(
+                spark => {
+                  setSessionTimeZone(spark, readerTimeZone)
+                  spark.read.schema(readSchema).orc(fileRoot.getCanonicalPath)
+                },
+                _.orderBy("id"),
+                conf = conf,
+                repart = 0,
+                skipCanonicalizationCheck = true,
+                existClasses = "GpuFileSourceScanExec")
+              compareResults(
+                sort = false,
+                floatEpsilon = 0.0,
+                fromCpu = fromCpu,
+                fromGpu = fromGpu)
+            }
+          }
+        }
+      } finally {
+        TimeZone.setDefault(originalTimeZone)
+      }
+    }
+  }
+
   Seq(false, true).foreach { useChunkedReader =>
     test(s"coalescing files with different writer timezones, chunked=$useChunkedReader") {
       val originalTimeZone = TimeZone.getDefault
@@ -356,13 +464,13 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
           val losAngelesPath = new File(fileRoot, "los-angeles")
           withCpuSparkSession(spark => {
             setSessionTimeZone(spark, "UTC")
-            fileDataFrame(spark, new Random(1L))
+            fileDataFrame(spark)
               .coalesce(1)
               .write
               .orc(utcPath.getCanonicalPath)
 
             setSessionTimeZone(spark, "America/Los_Angeles")
-            fileDataFrame(spark, new Random(2L), idOffset = RandomRowCount * 2)
+            fileDataFrame(spark, idOffset = ExplicitTimestampMicros.length)
               .coalesce(1)
               .write
               .orc(losAngelesPath.getCanonicalPath)
@@ -447,9 +555,6 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     val dsLabel = if (v1SourceList == "orc") "v1" else "v2"
     test(s"ORC timezone matrix ($dsLabel) for writer timezone $writerTimeZone") {
       val originalTimeZone = TimeZone.getDefault
-      // Use a fixed seed for reproducibility; tests must not be non-deterministic.
-      val runSeed = 42L
-      val random = new Random(runSeed)
       val conf = baseConf(v1SourceList)
       val existClass = if (v1SourceList == "orc") "GpuFileSourceScanExec" else "GpuBatchScan"
 
@@ -457,7 +562,7 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
         withTempPath { fileRoot =>
           withCpuSparkSession(spark => {
             setSessionTimeZone(spark, writerTimeZone)
-            writeFile(spark, fileRoot, random)
+            writeFile(spark, fileRoot)
           }, conf = conf)
 
           timezones.foreach { readerTimeZone =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/OrcTimezoneSuite.scala
@@ -123,18 +123,29 @@ class OrcTimezoneSuite extends SparkQueryCompareTestSuite {
     Instant.parse("2024-10-27T01:00:00Z")  // Europe/Paris fall back
   )
 
+  private val ParisFirstTransitionLocalUs = {
+    val paris = ZoneId.of("Europe/Paris")
+    val firstTransitionMs = paris.getRules.getTransitions.get(0).getInstant.toEpochMilli
+    TimeUnit.MILLISECONDS.toMicros(
+      firstTransitionMs + TimeZone.getTimeZone(paris.getId).getRawOffset)
+  }
+
   private val ExplicitTimestampMicros = {
     val dstBoundaries = DstTransitions.flatMap { transition =>
       val atTransition = TimeUnit.SECONDS.toMicros(transition.getEpochSecond) +
         TimeUnit.NANOSECONDS.toMicros(transition.getNano)
       Seq(atTransition - 1L, atTransition, atTransition + 1L)
     }
+    val firstTransitionBoundaries = Seq(
+      ParisFirstTransitionLocalUs - 1L,
+      ParisFirstTransitionLocalUs,
+      ParisFirstTransitionLocalUs + 1L)
     Seq(
       newYorkHistoricalTsUs,
       shanghaiHistoricalTsUs,
       ShanghaiEpochBorrowTsUs,
       minTs,
-      maxTs) ++ dstBoundaries
+      maxTs) ++ dstBoundaries ++ firstTransitionBoundaries
   }
 
   private def setSessionTimeZone(spark: SparkSession, tzId: String): Unit = {


### PR DESCRIPTION
Fixes #15449.

Depends on:
* NVIDIA/cudf-spark-jni#4917.

### Description

GPU ORC reads could return incorrect timestamps in non-UTC timezones for both
physical timestamp columns and schema-evolution casts. Symptoms included
one-hour DST shifts, `NULL` for valid double-to-timestamp values, and historical
offset mismatches before a timezone's first recorded transition.

Spark delegates these conversions to Apache ORC. ORC uses
`java.util.TimeZone` rules from the writer footer and reader timezone, applies
timezone conversion before millisecond rounding and overflow handling, and
skips cross-timezone conversion when writer and reader have the same rules.
The GPU path differed in all three areas: it compared timezone identities
instead of rules, performed parts of schema-evolution rounding/overflow before
timezone conversion, and used transition data that did not reproduce
`java.util.TimeZone` behavior before the first recorded transition.

This change aligns the GPU path with Spark/ORC and adds deterministic regression
coverage in three layers:

- a small boundary corpus across canonical, alias, fixed-offset, DST, and
  non-DST timezone pairs, including `Europe/Paris`;
- a table-driven `timestamp`, `bigint`, `float`, and `double` to `timestamp`
  schema-evolution matrix;
- pinned historical, DST transition `-1us/at/+1us`, integer `514952012`,
  zero, rounding, and positive/negative overflow values.

The previous broad randomized tests sampled a large date range but were very
unlikely to hit exact DST boundaries, pre-first-transition values, zero and
overflow behavior, or the relevant same-zone/alias/directional combinations.

### Validation

- A/B with the original two fixed seeds:
  - baseline: all 7 reported cases reproduced (`3 failed` in
    `Asia/Shanghai`, `4 failed` in `America/New_York`);
  - fixed build: the same 7 cases passed.
- `OrcTimezoneSuite`: `46 succeeded, 0 failed`.
- Targeted Python regressions:
  - `America/New_York`: `3 passed`;
  - `Asia/Shanghai`: `3 passed`.
- Spark 3.4.0 / Scala 2.12 package: `BUILD SUCCESS`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
