### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Restore randomized window aggregation coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -606,7 +606,6 @@ def test_window_aggs_for_range_numeric_date(data_gen, batch_size):
 # In a distributed setup the order of the partitions returned might be different, so we must ignore the order
 # but small batch sizes can make sort very slow, so do the final order by locally
 @ignore_order(local=True)
-@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/9682")
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize('data_gen', [_grpkey_longs_with_no_nulls,
                                       _grpkey_longs_with_nulls,


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350 vs nightly b9; the raw +2 lines were the excluded recurring `MemoryCheckerImpl` local GPU-initialization artifact)

Contributes to #9682.

## Summary

- Remove the stale `datagen_overrides(seed=0)` marker from `test_window_aggs_for_rows`.
- Restore randomized data generation after #10917 fixed the float-to-decimal conversion path that closed #9682.
- Keep the test body, eight data generators, two batch sizes, configs, and CPU/GPU equality assertion unchanged.

## Validation

- Spark 3.5 build: `BUILD SUCCESS`; 11/11 reactor modules succeeded.
- Original failure seed before marker removal: `2 passed, 1038 deselected, 4 warnings in 8.50s`.
- Marker-free focused matrix at seeds `1698940723`, `0`, `1`, and `42`: 64/64 parameter instances passed.
- Post-rebase original-seed gate: `16 passed, 4 warnings in 26.49s`.
- Full `window_function_test.py`: `1031 passed, 5 skipped, 4 xfailed, 535 warnings in 800.29s`.
- GPU event log contains `GpuWindow`, `GpuProject`, `GpuSort`, and `GpuShuffleExchangeExecBase`.
- NT local review: 6 independent reviewers, 0 findings.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
