### PR TITLE
[FEA] [fast-ut] [reduced-it] Remove unreachable cost branch from RapidsMeta.getIndicatorChar

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -417,8 +417,6 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
         "^"  // Special indicator for CPU bridge expressions
       } else if (cannotRunOnGpuBecauseOfSparkPlan) {
         "@"
-      } else if (cannotRunOnGpuBecauseOfCost) {
-        "$"
       } else {
         "*"
       }


### PR DESCRIPTION
Fixes #15451.

### Description

`RapidsMeta.getIndicatorChar` checks `cannotRunOnGpuBecauseOfCost` before `canThisBeReplaced`, making the duplicate cost check inside that branch unreachable. This removes the dead branch without changing plan or explain rendering because cost-based fallback is still handled by the outer check.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
