### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Restore float struct join coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -1112,15 +1112,15 @@ def test_broadcast_join_right_struct_mixed_key(data_gen, join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/2140')
 @pytest.mark.parametrize('data_gen', [basic_struct_gen_with_floats], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
 def test_sortmerge_join_struct_with_floats_key(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(right, left.a == right.r_a, join_type)
-    conf = copy_and_update(_sortmerge_join_conf,
-                           {})
+    conf = copy_and_update(_sortmerge_join_conf, {
+        'spark.sql.adaptive.enabled': 'false'  # Disable AQE as it can change the join type.
+    })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 @allow_non_gpu('SortMergeJoinExec', 'SortExec', 'NormalizeNaNAndZero', 'CreateNamedStruct',


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (the raw +2 delta was only the recurring `MemoryCheckerImpl` local GPU-initialization artifact; shim 350 vs nightly b9)

Contributes to #2140

## Summary

- remove the stale `#2140` xfail from `test_sortmerge_join_struct_with_floats_key`
- disable AQE only for this sort-merge-path test, matching adjacent coverage and avoiding the separate #14319 intermediate-plan validation limitation
- preserve strict GPU-plan validation; no `allow_non_gpu` fallback is added

## Validation

- Spark 3.5 integration-test package: `BUILD SUCCESS` (11/11 reactor modules)
- Spark 3.5 exact test: 24/24 parameter runs passed across seeds 2140, 0, 1, and 42
- Spark 3.3 + Python 3.10 exact test: 6/6 parameter runs passed
- GPU plan evidence for each focused run: 432 `GpuShuffleExchangeExec`, 30 `GpuShuffledHashJoinExec`, and 0 CPU `SortMergeJoinExec`
- Spark 3.5 full `join_test.py`: 2305 passed, 17 skipped, 0 failed
- NT local review: standard effort, redundancy 2, no unresolved findings

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
