### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Preserve Delta DELETE file statistics [databricks]

### DIFF
--- a/delta-lake/common/src/main/db-350db143-400db173/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommandBase.scala
+++ b/delta-lake/common/src/main/db-350db143-400db173/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommandBase.scala
@@ -196,7 +196,7 @@ abstract class GpuDeleteCommandBase(
 
           val candidateFiles = txn.filterFiles(
             metadataPredicates ++ otherPredicates,
-            keepNumRecords = RowTracking.isEnabled(txn.protocol, txn.metadata))
+            keepNumRecords = true /* Preserve numRecords in generated RemoveFile actions. */)
 
           numFilesAfterSkipping = candidateFiles.size
           val (numCandidateBytes, numCandidatePartitions) =

--- a/integration_tests/src/main/python/delta_lake_delete_test.py
+++ b/integration_tests/src/main/python/delta_lake_delete_test.py
@@ -333,8 +333,7 @@ def test_delta_delete_partitions(spark_tmp_path, use_cdf, partition_columns, ena
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @datagen_overrides(seed=0, permanent=True, reason='https://github.com/NVIDIA/spark-rapids/issues/9884')
 @pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                                        enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12041",
-                                        disabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12047"), ids=idfn)
+                                        enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12041"), ids=idfn)
 def test_delta_delete_rows(spark_tmp_path, use_cdf, partition_columns, enable_deletion_vectors):
     # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
     num_slices_to_test = 1 if is_databricks_runtime() else 10
@@ -443,8 +442,7 @@ def test_delta_delete_twice_with_dv(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @datagen_overrides(seed=0, permanent=True, reason='https://github.com/NVIDIA/spark-rapids/issues/9884')
 @pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                                        enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12041",
-                                        disabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12047"), ids=idfn)
+                                        enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12041"), ids=idfn)
 def test_delta_delete_dataframe_api(spark_tmp_path, use_cdf, partition_columns, enable_deletion_vectors):
     from delta.tables import DeltaTable
     data_path = spark_tmp_path + "/DELTA_DATA"


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (the recovered xfail is Databricks-only; Apache shim 350 already runs the same DV-disabled parameters, and the production change is under `delta-lake/`)

Contributes to #12047

### Summary

Preserve `numRecords` statistics in Delta DELETE `RemoveFile` actions on Databricks Runtime 14.3 and 17.3, and recover the corresponding SQL and DataFrame API integration-test coverage.

PR #12196 fixed the same missing-statistics defect for UPDATE. The shared DELETE rewrite path still enabled `keepNumRecords` only when row tracking was active, so ordinary tables could emit GPU `RemoveFile` actions without `stats` while CPU retained `{"numRecords": ...}`.

### Changes

- Always retain `numRecords` while selecting candidate files in the shared DBR 14.3/17.3 `GpuDeleteCommandBase`.
- Recover the deletion-vector-disabled variants of:
  - `delta_lake_delete_test.py::test_delta_delete_rows`
  - `delta_lake_delete_test.py::test_delta_delete_dataframe_api`
- Keep the deletion-vector-enabled variants xfailed for #12041.
- Preserve the existing expected values and CPU/GPU Delta-log comparisons, including `RemoveFile.stats`.

The recovered matrix covers both DELETE APIs with CDF enabled and disabled, partitioned and unpartitioned tables, and deletion vectors disabled.

### Validation

#### Databricks Runtime 14.3 — Spark 3.5.0 / `spark350db143`

- Build: `BUILD SUCCESS` in `09:23`.
- Focused recovered-node run with `--runxfail`: `8 passed, 2 warnings in 159.04s`.
- Full `delta_lake_delete_test.py` gate:
  - 61 tests collected.
  - All 8 recovered nodes verified as passing in JUnit.
  - `39 passed, 14 skipped, 8 xfailed, 2 warnings in 488.85s`.

#### Databricks Runtime 17.3 — Spark 4.0.0 / `spark400db173`

- Build: `BUILD SUCCESS` in `09:49`.
- Focused recovered-node run with `--runxfail`: `8 passed, 5 warnings in 123.44s`.
- Full `delta_lake_delete_test.py` gate:
  - 59 tests collected.
  - All 8 recovered nodes verified as passing in JUnit.
  - `51 passed, 8 xfailed, 5 warnings in 315.59s`.

The remaining full-file xfails are the preserved #12041 deletion-vector-enabled cases.

### Coverage measurement

The removed `disabled_xfail_reason` applies only when `is_databricks_runtime()` is true. Apache Spark 3.5 already receives an ordinary `False` parameter for these tests, so the nightly shim-350 test graph is unchanged and the sql-plugin line increment is `+0`.

An anchor-aligned DBR 14.3 full-file run also passed all recovered nodes (`37 passed, 16 skipped, 8 xfailed`), but its JaCoCo exec was not merged into the Apache shim-350 nightly report because DBR and Apache shim bytecode differ.

### Performance impact

This changes only the metadata retained by the existing Delta candidate-file lookup. It does not add another data scan, shuffle, GPU kernel, or per-row operation. The expected cost is retaining the existing `numRecords` value for each already-enumerated candidate file when row tracking is disabled. No performance benchmark was run because this is a cold metadata-path correctness fix.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
