### PR TITLE
Fix Scala 2.12 eta-expansion for verifyParquetMagic [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -570,7 +570,7 @@ protected case class GpuParquetFileFilterHandler(
     if (fileIO.isInstanceOf[HadoopFileIO]) {
       // We should remove this after https://github.com/NVIDIA/spark-rapids/issues/13306 is
       // implemented.
-      val result = PerfIO.readParquetFooterBuffer(filePath, conf, verifyParquetMagic)
+      val result = PerfIO.readParquetFooterBuffer(filePath, conf, verifyParquetMagic _)
       val scheme = filePath.toUri.getScheme
       if (scheme != null && scheme.startsWith("s3")) {
         GpuTaskMetrics.get.recordPerfioS3BackendOnce()


### PR DESCRIPTION
Fixes #15475.

### Description

- Explicitly eta-expand `verifyParquetMagic` when passing it to `PerfIO.readParquetFooterBuffer` so Scala 2.12 (DB 14.3 / `350db143`) compiles; Scala 2.13 already auto-eta-expands and is unchanged.
- Unblocks Databricks nightly pre-release builds that failed at `GpuParquetScan.scala:573` with `missing argument list for method verifyParquetMagic`.
- Validate: `mvn -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests -pl sql-plugin compile` and `validate` on Scala 2.12.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required