### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Restore Delta deletion vector write coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -196,8 +196,7 @@ def test_delta_write_disabled_fallback(spark_tmp_path, disable_conf, enable_dele
 @ignore_order(local=True)
 @pytest.mark.xfail(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/13106")
 @pytest.mark.xfail(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/11169")
-@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-    enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
+@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_write_round_trip_managed(spark_tmp_table_factory, enable_deletion_vectors):
     gen_list = [("c" + str(i), gen) for i, gen in enumerate(delta_write_gens)]
     conf = copy_and_update(writer_confs, delta_writes_enabled_conf)
@@ -612,8 +611,7 @@ def _run_delta_db173_native_sql_ctas_rtas(
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                            enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
+@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_write_round_trip_unmanaged(spark_tmp_path, enable_deletion_vectors):
     gen_list = [("c" + str(i), gen) for i, gen in enumerate(delta_write_gens)]
     data_path = spark_tmp_path + "/DELTA_DATA"
@@ -693,8 +691,7 @@ def do_update_round_trip_managed(spark_tmp_path, mode, enable_deletion_vectors):
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                            enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
+@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_overwrite_round_trip_unmanaged(spark_tmp_path, enable_deletion_vectors):
     do_update_round_trip_managed(spark_tmp_path, "overwrite", enable_deletion_vectors)
 
@@ -702,8 +699,7 @@ def test_delta_overwrite_round_trip_unmanaged(spark_tmp_path, enable_deletion_ve
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                            enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
+@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_append_round_trip_unmanaged(spark_tmp_path, enable_deletion_vectors):
     do_update_round_trip_managed(spark_tmp_path, "append", enable_deletion_vectors)
 
@@ -1024,8 +1020,7 @@ def test_delta_overwrite_mixed_clause(spark_tmp_table_factory, spark_tmp_path, m
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                            enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
+@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_write_round_trip_cdf_write_opt(spark_tmp_path, enable_deletion_vectors):
     gen_list = [("ints", int_gen)]
     data_path = spark_tmp_path + "/DELTA_DATA"
@@ -1473,8 +1468,7 @@ def test_delta_write_multiple_identity_columns_sql(spark_tmp_path):
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(
-                            enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
+@pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_write_aqe_join(spark_tmp_path, enable_deletion_vectors):
     data_path = spark_tmp_path + "/DELTA_DATA"
     confs=copy_and_update(delta_writes_enabled_conf, {"spark.sql.adaptive.enabled": "true"})


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: not measurable locally — DBR 14.3 shim classfiles do not match the Apache shim350 nightly baseline**

Contributes to #12027

## Summary

- Remove the #12027-specific expected-failure reason after the fix in #12451.
- Restore normal CPU/GPU parity execution for five Delta write cases with deletion vectors enabled.
- Remove the redundant #12027 reason from the managed-table case without counting it as recovered; the remaining Databricks xfails are tracked by #13106 and #11169.

## Recovered parameters

- `test_delta_write_round_trip_unmanaged[True]`
- `test_delta_overwrite_round_trip_unmanaged[True]`
- `test_delta_append_round_trip_unmanaged[True]`
- `test_delta_write_round_trip_cdf_write_opt[True]`
- `test_delta_write_aqe_join[True]`

## Relinked, not recovered

`test_delta_write_round_trip_managed[True]` is not counted as recovered. This change only removes its redundant #12027 parameter-level reason; the test remains covered by the open Databricks xfails in #13106 and #11169.

## Validation

Exact source: `7e457724a96a4367cb74e79e8404d1d35122517f` plus this marker-only patch.

- Python syntax: `python3 -m py_compile integration_tests/src/main/python/delta_lake_write_test.py`
- Reduced-IT selector self-test: `python3 integration_tests/src/main/python/reduced_it_selection_test.py` (exit 0; all three single-parameter cases retained)
- DBR 14.3 / Spark 3.5.0 / buildver `350db143`, focused: `5 passed, 2 warnings in 192.12s`
- DBR 17.3 / Spark 4.0.0 / buildver `400db173`, focused: `5 passed, 5 warnings in 93.28s`
- DBR 14.3 full `delta_lake_write_test.py`: 150 unique JUnit cases across 8 isolated Spark processes; `106 passed, 23 skipped, 20 xfailed, 1 xpassed`; 0 failures/errors
- DBR 17.3 full `delta_lake_write_test.py`: 150 unique JUnit cases; `123 passed, 2 skipped, 23 xfailed, 2 xpassed, 5 warnings in 901.01s`; 0 failures/errors
- JaCoCo diagnostic: the nightly merge showed a raw `+107` lines on the matching class subset, but JaCoCo reported 432 runtime/classfile mismatches, so no numeric delta is claimed
- NT local review: 6 reviewers, 0 findings

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
