### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Restore Delta liquid-clustering RTAS coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -142,6 +142,29 @@ def setup_clustered_table_sql(spark, path, table_name, view_name,
     optimize_liquid_clustered_table(spark, table_name)
 
 
+def assert_db173_gpu_liquid_rtas(spark, replace_sql):
+    callback = spark._sc._jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+    callback.startCapture()
+    try:
+        spark.sql(replace_sql).collect()
+        captured_plans = callback.getResultsWithTimeout(10000)
+        assert len(captured_plans) > 0, "No execution plans captured for liquid RTAS"
+        for gpu_class in [
+                "GpuAtomicReplaceTableAsSelectExec",
+                "GpuDataWritingCommandExec",
+                "GpuWriteFilesExec"]:
+            assert any(callback.contains(plan, gpu_class) for plan in captured_plans), \
+                f"{gpu_class} is not found in the captured liquid RTAS plans"
+        for cpu_class in [
+                "AtomicReplaceTableAsSelectExec",
+                "DataWritingCommandExec",
+                "WriteFilesExec"]:
+            assert not any(callback.didFallBack(plan, cpu_class) for plan in captured_plans), \
+                f"Captured liquid RTAS plan contains CPU {cpu_class}"
+    finally:
+        callback.endCapture()
+
+
 @allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @allow_non_gpu_conditional(is_databricks173_or_later(),
                            f"{delta_write_fallback_allow},AtomicReplaceTableAsSelectExec,"
@@ -162,13 +185,19 @@ def test_delta_rtas_sql_liquid_clustering(spark_tmp_path, spark_tmp_table_factor
 
         create_clustered_table_sql(spark, table_name, path)
         gen_df_and_replace_view(spark, view_name)
-        spark.sql(f"""
+        replace_sql = f"""
             REPLACE TABLE {table_name}
             USING DELTA
             LOCATION '{path}'
             CLUSTER BY (a)
             AS SELECT * FROM {view_name}
-        """)
+        """
+        gpu_enabled = str(spark.conf.get(
+            "spark.rapids.sql.enabled", "false")).lower() == "true"
+        if is_databricks173_or_later() and gpu_enabled:
+            assert_db173_gpu_liquid_rtas(spark, replace_sql)
+        else:
+            spark.sql(replace_sql).collect()
         optimize_liquid_clustered_table(spark, table_name)
 
     data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"

--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -143,11 +143,17 @@ def setup_clustered_table_sql(spark, path, table_name, view_name,
 
 
 @allow_non_gpu(*delta_meta_allow, "CreateTableExec")
+@allow_non_gpu_conditional(is_databricks173_or_later(),
+                           f"{delta_write_fallback_allow},AtomicReplaceTableAsSelectExec,"
+                           "AppendDataExecV1")
+@allow_non_gpu_delta_write_if(
+    is_databricks173_or_later(),
+    reason="DBR 17.3 plans Delta liquid RTAS through V2 AtomicReplaceTableAsSelectExec")
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="RTAS with cluster by is only supported on delta 3.3+")
-@pytest.mark.skipif(is_spark_356_or_later(),
+@pytest.mark.skipif(is_spark_356_or_later() and not is_spark_400_or_later(),
                     reason="https://github.com/delta-io/delta/issues/4671")
 def test_delta_rtas_sql_liquid_clustering(spark_tmp_path, spark_tmp_table_factory):
     def write_func(spark, path):


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: not measurable locally — the recovered Spark 4.0/4.1 and DBR 17.3 classfiles do not match the shim350 nightly aggregate**

Contributes to delta-io/delta#4671.

### Description

Narrow the Delta 3.3.0 regression guard to Spark 3.5.6–3.x so the existing
liquid-clustering RTAS CPU/GPU parity test runs again on Spark 4.0 and 4.1.

DBR 17.3 plans the same operation through its V2 atomic control layer. Mirror
the existing liquid-clustering CTAS allowances for those control nodes while
retaining the test's CPU/GPU data comparison. A separate plan-capture probe
verified that the actual Delta data-file writer remains on GPU.

The guard is intentionally retained for Spark 3.5.6–3.x because the current
Delta 3.3.0 dependency still reproduces the upstream truncate-capability
failure before GPU execution.

### Validation

- Spark 3.5.5 / Delta 3.3.0: target `1 passed, 12 deselected`.
- Spark 3.5.6 / Delta 3.3.0:
  - committed guard: `1 skipped, 12 deselected`;
  - temporary unmask: CPU setup reproduces `AnalysisException: Table ... does not support truncate in batch mode`.
- Spark 4.0.0 / Delta 4.0.0:
  - target `1 passed, 12 deselected`;
  - full `delta_lake_liquid_clustering_test.py`: `13 passed`;
  - all three delta-io/delta#4671 children: `3 passed`.
- Spark 4.1.1 / Delta 4.1.0:
  - target `1 passed, 12 deselected`;
  - full `delta_lake_liquid_clustering_test.py`: `13 passed`;
  - all three delta-io/delta#4671 children: `3 passed`.
- DBR 17.3 / `400db173`:
  - checksum-verified Maven build: `BUILD SUCCESS` in 09:57;
  - target: `1 passed, 6 warnings in 80.17s`;
  - full file: collect=13, `11 passed, 2 skipped, 9 warnings in 301.17s`,
    JUnit=13, no deselection, target passed;
  - plan probe: `1 passed, 6 warnings in 77.27s`; captured
    `GpuAtomicReplaceTableAsSelectExec` and a write plan containing both
    `GpuDataWritingCommandExec` and `GpuWriteFilesExec`, with no CPU data
    writer, `WriteFilesExec`, or atomic RTAS fallback.
- NT local review: 6 independent reviewers, 0 findings.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
