### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Restore Delta REORG coverage on Spark 4.1.1+ [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -21,9 +21,8 @@ from delta_lake_utils import delta_meta_allow, setup_delta_dest_table, deletion_
 from marks import allow_non_gpu, delta_lake, ignore_order
 from parquet_test import reader_opt_confs_no_native
 from parquet_test_utils import parquet_row_group_midpoints
-from spark_session import is_spark_411_or_later
 from spark_session import with_cpu_session, with_gpu_session, is_databricks_runtime, \
-    is_spark_320_or_later, is_spark_340_or_later, supports_delta_lake_deletion_vectors, is_spark_401_or_later, \
+    is_spark_320_or_later, is_spark_340_or_later, is_spark_40x, supports_delta_lake_deletion_vectors, is_spark_401_or_later, \
     is_before_spark_353, is_databricks173_or_later
 
 _conf = {'spark.rapids.sql.explain': 'ALL'}
@@ -824,7 +823,7 @@ def test_delta_scan_split_with_DV_disabled_with_DVs(spark_tmp_path, pushdown_dv_
                     reason="Deletion vector scan is not supported on Databricks")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
-@pytest.mark.skipif(is_spark_401_or_later() and not is_spark_411_or_later(),
+@pytest.mark.skipif(is_spark_40x() and is_spark_401_or_later(),
                     reason="REORG requires Delta 4.1.0, available in "
                            "supported Spark 4.1.1+ profiles "
                            "(https://github.com/delta-io/delta/issues/5690)")

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -854,9 +854,8 @@ def test_delta_scan_split_with_DV_disabled_with_DVs(spark_tmp_path, pushdown_dv_
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
 @pytest.mark.skipif(is_spark_40x() and is_spark_401_or_later(),
-                    reason="REORG requires Delta 4.1.0, available in "
-                           "supported Spark 4.1.1+ profiles "
-                           "(https://github.com/delta-io/delta/issues/5690)")
+                    reason="Delta 4.0.0 REORG is incompatible with Spark 4.0.1+ in Spark 4.0.x "
+                           "profiles (https://github.com/delta-io/delta/issues/5690)")
 def test_delta_scan_split_with_DV_enabled_after_DVs_materialized(spark_tmp_path):
     def do_delete_and_reorg(spark, data_path):
         num_deleted = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a = 0").collect()[0][0]

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -21,6 +21,7 @@ from delta_lake_utils import delta_meta_allow, setup_delta_dest_table, deletion_
 from marks import allow_non_gpu, delta_lake, ignore_order
 from parquet_test import reader_opt_confs_no_native
 from parquet_test_utils import parquet_row_group_midpoints
+from spark_session import is_spark_411_or_later
 from spark_session import with_cpu_session, with_gpu_session, is_databricks_runtime, \
     is_spark_320_or_later, is_spark_340_or_later, supports_delta_lake_deletion_vectors, is_spark_401_or_later, \
     is_before_spark_353, is_databricks173_or_later
@@ -823,8 +824,10 @@ def test_delta_scan_split_with_DV_disabled_with_DVs(spark_tmp_path, pushdown_dv_
                     reason="Deletion vector scan is not supported on Databricks")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
-@pytest.mark.skipif(is_spark_401_or_later(),
-                    reason="REORG is not supported in Spark 4.0.1+ (https://github.com/delta-io/delta/issues/5690)")
+@pytest.mark.skipif(is_spark_401_or_later() and not is_spark_411_or_later(),
+                    reason="REORG requires Delta 4.1.0, available in "
+                           "supported Spark 4.1.1+ profiles "
+                           "(https://github.com/delta-io/delta/issues/5690)")
 def test_delta_scan_split_with_DV_enabled_after_DVs_materialized(spark_tmp_path):
     def do_delete_and_reorg(spark, data_path):
         num_deleted = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a = 0").collect()[0][0]


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: not measurable locally — the recovered Spark 4.0/4.1 classfiles do not match the shim350 nightly aggregate**

Contributes to delta-io/delta#5690.

### Description

Narrow the Delta REORG regression guard from every Spark 4.0.1+ runtime to
Spark 4.0.1 through 4.0.x. This restores the existing deletion-vector
materialization scan-split test on supported Spark 4.1.1+ profiles, where
Delta 4.1.0 contains the upstream fix.

The guard is intentionally retained for Spark 4.0.1 through 4.0.x because
Delta 4.0.0 still reproduces the upstream binary incompatibility during CPU
table setup. The target remains independently skipped on Databricks, so no
Databricks execution claim is made.

### Validation

- Static gates: `py_compile`, `git diff --check`, and current exemption scan passed.
- Spark 4.0.1 / Delta 4.0.0:
  - committed guard: `1 skipped, 250 deselected`;
  - temporary unmask: CPU setup reproduces `ParquetToSparkSchemaConverter` five-argument `NoSuchMethodError`.
- Spark 4.0.0 / Delta 4.0.0:
  - build: `BUILD SUCCESS`, 14/14 reactor modules;
  - final target: `1 passed, 250 deselected`;
  - plan diagnostics: `FileSourceScanExec will run on GPU`.
- Spark 4.1.1 / Delta 4.1.0:
  - build: `BUILD SUCCESS`, 14/14 reactor modules;
  - final target: `1 passed, 250 deselected`;
  - full `delta_lake_test.py`: `248 passed, 3 skipped, 0 failed`;
  - JUnit: `tests=251, errors=0, failures=0, skipped=3`; target passed;
  - plan diagnostics: `FileSourceScanExec will run on GPU` in exact and full-file runs.
- NT local review: 6 independent reviewers; one duplicated line-length finding was fixed and validator-confirmed; final result `0 must-fix, 0 should-fix, 0 suggestions`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
