### PR TITLE
Run premerge tests in 12 parallel paths [fast-ut] [reduced-it]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -626,7 +626,7 @@ manually trigger it by commenting `build`. It includes the following steps,
 1. Mergeable check
 2. Blackduck vulnerability scan
 3. Fetch merged code (merge the pull request HEAD into BASE branch, e.g. fea-001 into branch-x)
-4. Run `mvn verify` and unit tests for multiple Spark versions in parallel.
+4. Run six unit-test configurations and six integration-test shards in parallel.
 Ref: [spark-premerge-build.sh](jenkins/spark-premerge-build.sh)
 
 If it fails, you can click the `Details` link of this check, and go to `Upload log -> Jenkins log for pull request xxx (click here)` to
@@ -635,6 +635,9 @@ find the uploaded log.
 Options:
 1. Skip tests run by adding `[skip ci]` to title, this should only be used for doc-only change
 2. Run build and tests in databricks runtimes by adding `[databricks]` to title, this would add around 30-40 minutes
+3. Run each unit-test configuration with the parallel runner by adding `[fast-ut]` to the title
+4. Reduce multi-parameter integration-test combinations with deterministic each-choice selection
+   by adding `[reduced-it]` to the title
 
 
 ### Code Review Guidelines

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -378,6 +378,21 @@ unaffected unless `RANDOM_SELECT` is explicitly configured. `RANDOM_SELECT` is n
 reduced IT mode because a second random selection could remove the only selected occurrence of a
 parameter value.
 
+### Sharding tests
+
+Set `TEST_SHARD_INDEX` and `TEST_SHARD_COUNT` together to split the collected tests into stable,
+disjoint shards. `TEST_SHARD_INDEX` is zero-based. The shard is selected from the Java
+`String.hashCode` of the complete pytest node id, so parametrized cases are distributed
+independently and repeated runs select the same cases.
+
+Selection such as `[reduced-it]`, `RANDOM_SELECT`, `TESTS`, `-k`, and `-m` is applied before
+sharding. For example, these commands cover the selected test set exactly once:
+
+```shell
+TEST_SHARD_INDEX=0 TEST_SHARD_COUNT=2 ./integration_tests/run_pyspark_from_build.sh
+TEST_SHARD_INDEX=1 TEST_SHARD_COUNT=2 ./integration_tests/run_pyspark_from_build.sh
+```
+
 ### Randomly selecting tests
 
 To shorten feedback cycles, you can ask the harness to execute only a random subset of the collected

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -608,12 +608,66 @@ def _select_precommit_cases(config, items):
                 f"each-choice tests={each_choice_test_count}.")
 
 
+def _java_string_hashcode(value):
+    """Return Java's deterministic String.hashCode for a pytest node id."""
+    result = 0
+    encoded = value.encode('utf-16-be', errors='surrogatepass')
+    for offset in range(0, len(encoded), 2):
+        code_unit = int.from_bytes(encoded[offset:offset + 2], byteorder='big')
+        result = (31 * result + code_unit) & 0xffffffff
+    return result if result < 0x80000000 else result - 0x100000000
+
+
+def _test_shard_config():
+    shard_index = os.environ.get('TEST_SHARD_INDEX')
+    shard_count = os.environ.get('TEST_SHARD_COUNT')
+    if shard_index is None and shard_count is None:
+        return None
+    if shard_index is None or shard_count is None:
+        raise pytest.UsageError(
+            "TEST_SHARD_INDEX and TEST_SHARD_COUNT must be set together")
+    try:
+        shard_index = int(shard_index)
+        shard_count = int(shard_count)
+    except ValueError as error:
+        raise pytest.UsageError(
+            "TEST_SHARD_INDEX and TEST_SHARD_COUNT must be integers") from error
+    if shard_count < 2:
+        raise pytest.UsageError("TEST_SHARD_COUNT must be at least 2")
+    if shard_index < 0 or shard_index >= shard_count:
+        raise pytest.UsageError(
+            f"TEST_SHARD_INDEX must be between 0 and {shard_count - 1}")
+    return shard_index, shard_count
+
+
+def _apply_test_shard(config, items):
+    shard_config = _test_shard_config()
+    if shard_config is None:
+        return
+
+    shard_index, shard_count = shard_config
+    original_items = list(items)
+    items[:] = [
+        item for item in original_items
+        if _java_string_hashcode(item.nodeid) % shard_count == shard_index
+    ]
+    deselected = [item for item in original_items if item not in items]
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+    reporter = config.pluginmanager.get_plugin('terminalreporter')
+    if reporter:
+        reporter.write_line(
+            f"TEST_SHARD active: shard {shard_index + 1}/{shard_count} "
+            f"running {len(items)} of {len(original_items)} tests.")
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
     if is_precommit_run() and is_reduced_it_run():
         _select_precommit_cases(config, items)
     else:
         _maybe_apply_random_select(config, items)
+    _apply_test_shard(config, items)
     r = random.Random(oom_random_injection_seed)
     for item in items:
         extras = []

--- a/integration_tests/src/main/python/reduced_it_selection_test.py
+++ b/integration_tests/src/main/python/reduced_it_selection_test.py
@@ -278,10 +278,13 @@ def test_reduced_it_activation(monkeypatch, precommit, reduced_it, expected_path
     monkeypatch.setattr(
         conftest, "_maybe_apply_random_select",
         lambda config, items: selected_paths.append("random"))
+    monkeypatch.setattr(
+        conftest, "_apply_test_shard",
+        lambda config, items: selected_paths.append("shard"))
 
     conftest.pytest_collection_modifyitems(None, [])
 
-    assert selected_paths == [expected_path]
+    assert selected_paths == [expected_path, "shard"]
 
 
 def test_reduced_it_each_choice_selection():

--- a/integration_tests/src/main/python/test_shard_selection_test.py
+++ b/integration_tests/src/main/python/test_shard_selection_test.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+import conftest
+
+
+class _Hook:
+    def __init__(self):
+        self.deselected = []
+
+    def pytest_deselected(self, items):
+        self.deselected.extend(items)
+
+
+class _PluginManager:
+    @staticmethod
+    def get_plugin(_name):
+        return None
+
+
+def _config():
+    return SimpleNamespace(hook=_Hook(), pluginmanager=_PluginManager())
+
+
+def _items(count=20):
+    return [SimpleNamespace(nodeid=f"file_test.py::test_case[{index}]")
+            for index in range(count)]
+
+
+def test_java_string_hashcode_is_stable():
+    assert conftest._java_string_hashcode("abc") == 96354
+    assert conftest._java_string_hashcode("file.py::test_case[0]") == 152671142
+    assert conftest._java_string_hashcode("😀") == 1772899
+    assert conftest._java_string_hashcode("zzzzzz") == -685785664
+
+
+def test_two_shards_are_disjoint_and_complete(monkeypatch):
+    original = _items()
+    selected = []
+
+    for shard_index in range(2):
+        items = list(original)
+        config = _config()
+        monkeypatch.setenv("TEST_SHARD_INDEX", str(shard_index))
+        monkeypatch.setenv("TEST_SHARD_COUNT", "2")
+        conftest._apply_test_shard(config, items)
+
+        assert set(item.nodeid for item in items).isdisjoint(selected)
+        assert {item.nodeid for item in config.hook.deselected} == (
+            {item.nodeid for item in original} - {item.nodeid for item in items})
+        selected.extend(item.nodeid for item in items)
+
+    assert set(selected) == {item.nodeid for item in original}
+
+
+@pytest.mark.parametrize(
+    "shard_index,shard_count,error",
+    [
+        (None, "2", "must be set together"),
+        ("0", None, "must be set together"),
+        ("zero", "2", "must be integers"),
+        ("0", "one", "must be integers"),
+        ("0", "1", "must be at least 2"),
+        ("-1", "2", "must be between"),
+        ("2", "2", "must be between"),
+    ])
+def test_invalid_shard_config(monkeypatch, shard_index, shard_count, error):
+    if shard_index is None:
+        monkeypatch.delenv("TEST_SHARD_INDEX", raising=False)
+    else:
+        monkeypatch.setenv("TEST_SHARD_INDEX", shard_index)
+    if shard_count is None:
+        monkeypatch.delenv("TEST_SHARD_COUNT", raising=False)
+    else:
+        monkeypatch.setenv("TEST_SHARD_COUNT", shard_count)
+
+    with pytest.raises(pytest.UsageError, match=error):
+        conftest._test_shard_config()

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -229,8 +229,9 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     !skipped && (normal_build || skills_build)
                 }
             }
-            // Parallel run mvn verify (build and integration tests) and unit tests (for multiple Spark versions)
-            // If any one is failed will abort another if not finish yet and will upload failure log to Github
+            // Run six UT configurations and six independent IT shards in parallel.
+            // The IT paths are two deterministic shards for each of three logical configurations.
+            // If any path fails, abort the unfinished paths and upload its failure log to GitHub.
             failFast true
             parallel {
                 stage('Skills Premerge Test') {
@@ -280,7 +281,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     }
                 } // end of Skills Premerge Test
 
-                stage('mvn verify') {
+                stage('Premerge UT 1: Spark 330 / Scala 2.12') {
                     when {
                         beforeAgent true
                         beforeOptions true
@@ -290,16 +291,14 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     }
 
                     options {
-                        // We have to use params to pass the resource label in options block,
-                        // this is a limitation of declarative pipeline. And we need to lock resource before agent start
                         lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
                     }
                     agent {
                         kubernetes {
-                            label "premerge-ci-1-${BUILD_TAG}"
+                            label "premerge-ut-1-${BUILD_TAG}"
                             cloud "${common.CLOUD_NAME}"
                             yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
-                            customWorkspace "${CUSTOM_WORKSPACE}"
+                            customWorkspace "${CUSTOM_WORKSPACE}-ut-1"
                         }
                     }
 
@@ -307,12 +306,100 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             unstash "source_tree"
                             container('gpu') {
-                                timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
+                                timeout(time: 6, unit: 'HOURS') {
                                     try {
                                         common.resolveIncompatibleDriverIssue(this)
                                         common.restoreM2Cache(this)
                                         common.prepareArtNetrc(this)
-                                        sh "$PREMERGE_SCRIPT mvn_verify"
+                                        sh "$PREMERGE_SCRIPT premerge_ut_1"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-ut-1')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge UT 2: Spark 340 / Scala 2.12') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-ut-2-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-ut-2"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_ut_2"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-ut-2')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge UT 3: base Spark 330 / Scala 2.12') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-ut-3-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-ut-3"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_ut_3"
                                         step([$class                : 'JacocoPublisher',
                                               execPattern           : '**/target/jacoco.exec',
                                               classPattern          : 'target/jacoco_classes/',
@@ -321,7 +408,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         ])
                                     } catch(e) {
                                         common.printJVMCoreDumps(this)
-                                        common.uploadDebugBundle(this, 'spark-rapids', 'mvn-verify')
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-ut-3')
                                         throw e
                                     } finally {
                                         common.publishPytestResult(this, "${STAGE_NAME}")
@@ -330,9 +417,9 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             }
                         }
                     }
-                } // end of mvn verify stage
+                }
 
-                stage('Premerge CI 2') {
+                stage('Premerge UT 4: Spark 356 / Scala 2.12') {
                     when {
                         beforeAgent true
                         beforeOptions true
@@ -346,10 +433,10 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     }
                     agent {
                         kubernetes {
-                            label "premerge-ci-2-${BUILD_TAG}"
+                            label "premerge-ut-4-${BUILD_TAG}"
                             cloud "${common.CLOUD_NAME}"
                             yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
-                            customWorkspace "${CUSTOM_WORKSPACE}-ci-2" // Use different workspace to avoid conflict with IT
+                            customWorkspace "${CUSTOM_WORKSPACE}-ut-4"
                         }
                     }
 
@@ -362,10 +449,10 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         common.resolveIncompatibleDriverIssue(this)
                                         common.restoreM2Cache(this)
                                         common.prepareArtNetrc(this)
-                                        sh "$PREMERGE_SCRIPT ci_2"
+                                        sh "$PREMERGE_SCRIPT premerge_ut_4"
                                     } catch(e) {
                                         common.printJVMCoreDumps(this)
-                                        common.uploadDebugBundle(this, 'spark-rapids', 'ci-2')
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-ut-4')
                                         throw e
                                     } finally {
                                         common.publishPytestResult(this, "${STAGE_NAME}")
@@ -374,9 +461,9 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             }
                         }
                     }
-                } // end of Unit Test stage
+                }
 
-                stage('CI scala 2.13') {
+                stage('Premerge UT 5: Spark 350 / Scala 2.13') {
                     when {
                         beforeAgent true
                         beforeOptions true
@@ -385,15 +472,15 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         }
                     }
 
-                     options {
+                    options {
                         lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
                     }
                     agent {
                         kubernetes {
-                            label "ci-scala213-${BUILD_TAG}"
+                            label "premerge-ut-5-${BUILD_TAG}"
                             cloud "${common.CLOUD_NAME}"
                             yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
-                            customWorkspace "${CUSTOM_WORKSPACE}-scala-213" // Use different workspace to avoid conflict with IT
+                            customWorkspace "${CUSTOM_WORKSPACE}-ut-5"
                         }
                     }
 
@@ -406,10 +493,10 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         common.resolveIncompatibleDriverIssue(this)
                                         common.restoreM2Cache(this)
                                         common.prepareArtNetrc(this)
-                                        sh "$PREMERGE_SCRIPT ci_scala213"
+                                        sh "$PREMERGE_SCRIPT premerge_ut_5"
                                     } catch(e) {
                                         common.printJVMCoreDumps(this)
-                                        common.uploadDebugBundle(this, 'spark-rapids', 'scala-213')
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-ut-5')
                                         throw e
                                     } finally {
                                         common.publishPytestResult(this, "${STAGE_NAME}")
@@ -418,7 +505,315 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             }
                         }
                     }
-                } // end of Unit Test stage
+                }
+
+                stage('Premerge UT 6: Spark 401 / Scala 2.13') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-ut-6-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-ut-6"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_ut_6"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-ut-6')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge IT 1: ci1 shard 1 / Spark 330 Scala 2.12') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-it-1-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-it-1"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_it_1"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-it-1')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge IT 2: ci1 shard 2 / Spark 330 Scala 2.12') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-it-2-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-it-2"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_it_2"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-it-2')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge IT 3: ci2 shard 1 / Spark 330 Scala 2.12') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-it-3-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-it-3"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_it_3"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-it-3')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge IT 4: ci2 shard 2 / Spark 330 Scala 2.12') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-it-4-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-it-4"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_it_4"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-it-4')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge IT 5: shard 1 / Spark 401 Scala 2.13') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-it-5-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-it-5"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_it_5"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-it-5')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Premerge IT 6: shard 2 / Spark 401 Scala 2.13') {
+                    when {
+                        beforeAgent true
+                        beforeOptions true
+                        expression {
+                            normal_build
+                        }
+                    }
+
+                    options {
+                        lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+                    }
+                    agent {
+                        kubernetes {
+                            label "premerge-it-6-${BUILD_TAG}"
+                            cloud "${common.CLOUD_NAME}"
+                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                            customWorkspace "${CUSTOM_WORKSPACE}-it-6"
+                        }
+                    }
+
+                    steps {
+                        script {
+                            unstash "source_tree"
+                            container('gpu') {
+                                timeout(time: 6, unit: 'HOURS') {
+                                    try {
+                                        common.resolveIncompatibleDriverIssue(this)
+                                        common.restoreM2Cache(this)
+                                        common.prepareArtNetrc(this)
+                                        sh "$PREMERGE_SCRIPT premerge_it_6"
+                                    } catch(e) {
+                                        common.printJVMCoreDumps(this)
+                                        common.uploadDebugBundle(this, 'spark-rapids', 'premerge-it-6')
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 stage('Databricks IT part1') {
                     when {

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -303,6 +303,232 @@ ci_scala213() {
 
 }
 
+setup_premerge_java() {
+    export JAVA_HOME=$(echo /usr/lib/jvm/java-1.17.0-*)
+    update-java-alternatives --set $JAVA_HOME
+    java -version
+}
+
+run_filecache_ut() {
+    local pom_args=()
+    local buildver=${1:?'buildver is required'}
+    local scala_ver=${2:-2.12}
+    if [[ "$scala_ver" == "2.13" ]]; then
+        pom_args=(-f scala2.13/)
+    fi
+    env -u SPARK_HOME SPARK_CONF=spark.rapids.filecache.enabled=true \
+        $MVN "${pom_args[@]}" -B $MVN_URM_MIRROR -Dbuildver=$buildver \
+        test -rf tests $MVN_BUILD_ARGS -Dpytest.TEST_TAGS='' \
+        -DwildcardSuites=org.apache.spark.sql.rapids.filecache.FileCacheIntegrationSuite
+}
+
+run_scala212_ut() {
+    local buildver=${1:?'buildver is required'}
+    local phase=${2:-install}
+    env -u SPARK_HOME \
+        $MVN -U -B $MVN_URM_MIRROR -Dbuildver=$buildver clean "$phase" \
+        $MVN_BUILD_ARGS -Dpytest.TEST_TAGS=''
+}
+
+run_scala213_ut() {
+    local buildver=${1:?'buildver is required'}
+    env -u SPARK_HOME \
+        $MVN -f scala2.13/ -U -B $MVN_URM_MIRROR -Dbuildver=$buildver clean install \
+        $MVN_BUILD_ARGS -Dpytest.TEST_TAGS=''
+    run_filecache_ut "$buildver" 2.13
+}
+
+run_base_scala212_ut() {
+    env -u SPARK_HOME \
+        $MVN -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify $MVN_PARALLEL_UT_ARGS \
+        -Dpytest.TEST_TAGS='' -Dpytest.TEST_TYPE="pre-commit" \
+        -Dcuda.version=$CLASSIFIER
+}
+
+build_scala212_it_artifacts() {
+    $MVN -U -B $MVN_URM_MIRROR -Dbuildver=$SPARK_BASE_SHIM_VERSION \
+        clean package $MVN_BUILD_ARGS -DskipTests=true
+}
+
+build_scala213_it_artifacts() {
+    $MVN -f scala2.13/ -U -B $MVN_URM_MIRROR -Dbuildver=401 \
+        clean package $MVN_BUILD_ARGS -DskipTests=true
+}
+
+run_it_shard() {
+    local test_tags=${1:?'test tags are required'}
+    local shard_index=${2:?'shard index is required'}
+    local scala_ver=${3:-2.12}
+
+    export TEST_TAGS="$test_tags"
+    export TEST_TYPE="pre-commit"
+    export TEST_SHARD_INDEX="$shard_index"
+    export TEST_SHARD_COUNT=2
+
+    if [[ "$scala_ver" == "2.13" ]]; then
+        SPARK_HOME=$SPARK_HOME PYTHONPATH=$PYTHONPATH \
+            ./integration_tests/run_pyspark_from_build.sh
+    else
+        ./integration_tests/run_pyspark_from_build.sh
+    fi
+
+    if [[ "$test_tags" == "not premerge_ci_1" ]]; then
+        run_avro_regexp_it_shard
+    fi
+}
+
+run_avro_regexp_it_shard() {
+    INCLUDE_SPARK_AVRO_JAR=true TEST='avro_test.py' \
+        ./integration_tests/run_pyspark_from_build.sh
+    LC_ALL="en_US.UTF-8" TEST="regexp_test.py" \
+        ./integration_tests/run_pyspark_from_build.sh
+}
+
+without_it_shard() {
+    local shard_index=$TEST_SHARD_INDEX
+    local shard_count=$TEST_SHARD_COUNT
+    unset TEST_SHARD_INDEX TEST_SHARD_COUNT
+    "$@"
+    export TEST_SHARD_INDEX=$shard_index
+    export TEST_SHARD_COUNT=$shard_count
+}
+
+run_scala212_ci1_shard() {
+    local shard_index=${1:?'shard index is required'}
+    build_scala212_it_artifacts
+    prepare_spark $SPARK_VER 2.12
+    run_it_shard "premerge_ci_1" "$shard_index" 2.12
+}
+
+run_scala212_ci2_shard() {
+    local shard_index=${1:?'shard index is required'}
+    build_scala212_it_artifacts
+    prepare_spark $SPARK_VER 2.12
+    run_it_shard "not premerge_ci_1" "$shard_index" 2.12
+}
+
+run_scala213_ci_shard() {
+    local shard_index=${1:?'shard index is required'}
+    local SPARK_VER=4.0.1
+    build_scala213_it_artifacts
+    prepare_spark $SPARK_VER 2.13
+    run_it_shard "not premerge_ci_1" "$shard_index" 2.13
+}
+
+run_mvn_verify_special_tests() {
+    unset TEST_TAGS TEST_TYPE
+    rapids_shuffle_smoke_test
+
+    source "$(dirname "$0")"/test-timezones.sh
+    for tz in "${time_zones_test_cases[@]}"
+    do
+        TZ=$tz ./integration_tests/run_pyspark_from_build.sh -m tz_sensitive_test
+    done
+
+    source "${WORKSPACE}/jenkins/hybrid_execution.sh"
+    if hybrid_prepare ; then
+        LOAD_HYBRID_BACKEND=1 ./integration_tests/run_pyspark_from_build.sh -m hybrid_test
+    fi
+}
+
+prepare_jacoco_classes() {
+    local SPK_VER=${JACOCO_SPARK_VER:-"330"}
+    mkdir -p target/jacoco_classes/
+    local FILE
+    FILE=$(ls dist/target/rapids-4-spark_2.12-*.jar | grep -v test | xargs readlink -f)
+    local UDF_JAR
+    UDF_JAR=$(ls ./udf-compiler/target/spark${SPK_VER}/rapids-4-spark-udf_2.12-*-spark${SPK_VER}.jar |
+        grep -v test | xargs readlink -f)
+    pushd target/jacoco_classes/
+    jar xf $FILE com org rapids spark-shared "spark${JACOCO_SPARK_VER:-330}/"
+    jar xf "$UDF_JAR" com/nvidia/spark/udf
+    rm -rf com/nvidia/shaded/ \
+        org/openucx/ spark-shared/com/nvidia/spark/udf/ \
+        spark${SPK_VER}/com/nvidia/spark/udf/ \
+        spark${SPK_VER}/META-INF/versions/*
+    popd
+}
+
+# Twelve Jenkins paths run concurrently: six UT executions and six IT shards.
+premerge_ut_1() {
+    setup_premerge_java
+
+    local BASE_REF
+    BASE_REF=$(git --no-pager log --oneline -1 | awk '{ print $NF }')
+    pre-commit run check-added-large-files --from-ref $BASE_REF --to-ref HEAD
+
+    run_scala212_ut 330 install
+    run_filecache_ut 330
+
+    for version in "${SPARK_SHIM_VERSIONS_PREMERGE_UTF8[@]}"
+    do
+        env -u SPARK_HOME LC_ALL="en_US.UTF-8" \
+            $MVN $MVN_URM_MIRROR -Dbuildver=$version package $MVN_BUILD_ARGS \
+            -Dpytest.TEST_TAGS='' \
+            -DwildcardSuites=com.nvidia.spark.rapids.ConditionalsSuite,com.nvidia.spark.rapids.RegularExpressionSuite,com.nvidia.spark.rapids.RegularExpressionTranspilerSuite
+    done
+}
+
+premerge_ut_2() {
+    setup_premerge_java
+    run_scala212_ut 340 install
+    run_filecache_ut 340
+}
+
+premerge_ut_3() {
+    setup_premerge_java
+    run_base_scala212_ut
+    prepare_jacoco_classes
+}
+
+premerge_ut_4() {
+    setup_premerge_java
+    run_scala212_ut 356 package
+}
+
+premerge_ut_5() {
+    setup_premerge_java
+    run_scala213_ut 350
+}
+
+premerge_ut_6() {
+    setup_premerge_java
+    run_scala213_ut 401
+}
+
+premerge_it_1() {
+    setup_premerge_java
+    run_scala212_ci1_shard 0
+    without_it_shard run_mvn_verify_special_tests
+}
+
+premerge_it_2() {
+    setup_premerge_java
+    run_scala212_ci1_shard 1
+}
+
+premerge_it_3() {
+    setup_premerge_java
+    run_scala212_ci2_shard 0
+}
+
+premerge_it_4() {
+    setup_premerge_java
+    run_scala212_ci2_shard 1
+}
+
+premerge_it_5() {
+    setup_premerge_java
+    run_scala213_ci_shard 0
+}
+
+premerge_it_6() {
+    setup_premerge_java
+    run_scala213_ci_shard 1
+    without_it_shard rapids_shuffle_smoke_test 4.0.1
+    without_it_shard run_iceberg_version_detect_tests 4.0.1 2.13
+}
+
 prepare_spark() {
     spark_version=${1:-'3.3.0'}
     scala_ver=${2:-'2.12'}
@@ -348,6 +574,54 @@ case $BUILD_TYPE in
 
     ci_scala213 )
         ci_scala213
+        ;;
+
+    premerge_ut_1 )
+        premerge_ut_1
+        ;;
+
+    premerge_ut_2 )
+        premerge_ut_2
+        ;;
+
+    premerge_ut_3 )
+        premerge_ut_3
+        ;;
+
+    premerge_ut_4 )
+        premerge_ut_4
+        ;;
+
+    premerge_ut_5 )
+        premerge_ut_5
+        ;;
+
+    premerge_ut_6 )
+        premerge_ut_6
+        ;;
+
+    premerge_it_1 )
+        premerge_it_1
+        ;;
+
+    premerge_it_2 )
+        premerge_it_2
+        ;;
+
+    premerge_it_3 )
+        premerge_it_3
+        ;;
+
+    premerge_it_4 )
+        premerge_it_4
+        ;;
+
+    premerge_it_5 )
+        premerge_it_5
+        ;;
+
+    premerge_it_6 )
+        premerge_it_6
         ;;
 
     *)


### PR DESCRIPTION
## What changed

- split premerge into six independent unit-test paths and six independent integration-test paths
- shard each of the three logical integration-test configurations into two deterministic partitions
- add stable pytest sharding based on the full node ID using Java `String.hashCode` semantics
- apply reduced-IT each-choice selection before sharding and retain the existing fast-UT opt-in
- document and test the new shard controls

## Why

The previous pipeline grouped multiple unit-test configurations and integration-test runs into three long-running paths. This serialized substantial work inside each path and limited premerge throughput. Separating the six unit-test executions from the six integration-test shards allows all twelve paths to be scheduled independently.

## Impact

The default premerge test coverage is preserved while reducing the critical path when enough GPU workers are available. `[fast-ut]` continues to enable the parallel unit-test runner, and `[reduced-it]` continues to use deterministic each-choice parameter selection before the selected cases are divided between shards.

## Validation

- `python3 -m pytest -q -p no:spark_init_internal integration_tests/src/main/python/test_shard_selection_test.py integration_tests/src/main/python/reduced_it_selection_test.py`
- `bash -n jenkins/spark-premerge-build.sh`
- `python3 -m py_compile integration_tests/src/main/python/conftest.py integration_tests/src/main/python/test_shard_selection_test.py integration_tests/src/main/python/reduced_it_selection_test.py`
- `git diff --check`

Full GPU premerge validation is delegated to this draft PR.
