### PR TITLE
[fast-ut] [SkipRecovery] Narrow CSV timestamp inference exemptions [databricks]

### DIFF
--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -582,38 +582,39 @@ spark_350_timestamp_inference_xfail_formats = {
     ('yyyy-MM-dd', "'T'HH:mm:ss"),
     ('yyyy-MM-dd', "'T'HH:mm"),
 }
-spark_350_timestamp_inference_xfail = is_spark_350()
 
-csv_infer_schema_timestamp_params = [
-    pytest.param(
-        timestamp_type,
-        ts_part,
-        date_format,
-        marks=pytest.mark.xfail(
-            spark_350_timestamp_inference_xfail
-            and timestamp_type == 'TIMESTAMP_LTZ'
-            and (date_format, ts_part) in spark_350_timestamp_inference_xfail_formats,
-            reason="https://github.com/NVIDIA/spark-rapids/issues/9325"))
-    for timestamp_type in ['TIMESTAMP_LTZ', 'TIMESTAMP_NTZ']
-    for ts_part in csv_supported_ts_parts
-    for date_format in csv_supported_date_formats
-]
+def run_csv_infer_schema_timestamp_ntz(
+        spark_tmp_path, date_format, ts_part, timestamp_type, v1_enabled_list, cpu_scan_class):
+    try:
+        csv_infer_schema_timestamp_ntz(
+            spark_tmp_path, date_format, ts_part, timestamp_type, v1_enabled_list,
+            cpu_scan_class)
+    except Exception:
+        if (is_spark_350()
+                and timestamp_type == 'TIMESTAMP_LTZ'
+                and (date_format, ts_part) in spark_350_timestamp_inference_xfail_formats):
+            pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/9325")
+        raise
 
 @allow_non_gpu('FileSourceScanExec', 'ProjectExec', 'CollectLimitExec', 'DeserializeToObjectExec')
 @pytest.mark.skipif(is_before_spark_341(), reason='`TIMESTAMP_NTZ` is only supported in PySpark 341+')
-@pytest.mark.parametrize(
-    "timestamp_type,ts_part,date_format", csv_infer_schema_timestamp_params)
+@pytest.mark.parametrize('date_format', csv_supported_date_formats)
+@pytest.mark.parametrize('ts_part', csv_supported_ts_parts)
+@pytest.mark.parametrize('timestamp_type', ['TIMESTAMP_LTZ', 'TIMESTAMP_NTZ'])
 def test_csv_infer_schema_timestamp_ntz_v1(spark_tmp_path, date_format, ts_part, timestamp_type):
-    csv_infer_schema_timestamp_ntz(spark_tmp_path, date_format, ts_part, timestamp_type, 'csv', 'FileSourceScanExec')
+    run_csv_infer_schema_timestamp_ntz(
+        spark_tmp_path, date_format, ts_part, timestamp_type, 'csv', 'FileSourceScanExec')
 
 @allow_non_gpu('BatchScanExec', 'FileSourceScanExec', 'ProjectExec', 'CollectLimitExec', 'DeserializeToObjectExec')
 @pytest.mark.skipif(is_databricks_runtime(),
     reason="https://github.com/NVIDIA/spark-rapids/issues/9325")
 @pytest.mark.skipif(is_before_spark_341(), reason='`TIMESTAMP_NTZ` is only supported in PySpark 341+')
-@pytest.mark.parametrize(
-    "timestamp_type,ts_part,date_format", csv_infer_schema_timestamp_params)
+@pytest.mark.parametrize('date_format', csv_supported_date_formats)
+@pytest.mark.parametrize('ts_part', csv_supported_ts_parts)
+@pytest.mark.parametrize('timestamp_type', ['TIMESTAMP_LTZ', 'TIMESTAMP_NTZ'])
 def test_csv_infer_schema_timestamp_ntz_v2(spark_tmp_path, date_format, ts_part, timestamp_type):
-    csv_infer_schema_timestamp_ntz(spark_tmp_path, date_format, ts_part, timestamp_type, '', 'BatchScanExec')
+    run_csv_infer_schema_timestamp_ntz(
+        spark_tmp_path, date_format, ts_part, timestamp_type, '', 'BatchScanExec')
 
 def csv_infer_schema_timestamp_ntz(spark_tmp_path, date_format, ts_part, timestamp_type, v1_enabled_list, cpu_scan_class):
     full_format = date_format + ts_part

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -576,24 +576,42 @@ def test_csv_read_count(spark_tmp_path):
     assert_gpu_and_cpu_row_counts_equal(lambda spark: spark.read.csv(data_path),
         conf = {'spark.rapids.sql.explain': 'ALL'})
 
+spark_350_timestamp_inference_xfail_formats = {
+    ('yyyy-MM-dd', ''),
+    ('yyyy-MM', ''),
+    ('yyyy-MM-dd', "'T'HH:mm:ss"),
+    ('yyyy-MM-dd', "'T'HH:mm"),
+}
+spark_350_timestamp_inference_xfail = is_spark_350()
+
+csv_infer_schema_timestamp_params = [
+    pytest.param(
+        timestamp_type,
+        ts_part,
+        date_format,
+        marks=pytest.mark.xfail(
+            spark_350_timestamp_inference_xfail
+            and timestamp_type == 'TIMESTAMP_LTZ'
+            and (date_format, ts_part) in spark_350_timestamp_inference_xfail_formats,
+            reason="https://github.com/NVIDIA/spark-rapids/issues/9325"))
+    for timestamp_type in ['TIMESTAMP_LTZ', 'TIMESTAMP_NTZ']
+    for ts_part in csv_supported_ts_parts
+    for date_format in csv_supported_date_formats
+]
+
 @allow_non_gpu('FileSourceScanExec', 'ProjectExec', 'CollectLimitExec', 'DeserializeToObjectExec')
 @pytest.mark.skipif(is_before_spark_341(), reason='`TIMESTAMP_NTZ` is only supported in PySpark 341+')
-@pytest.mark.parametrize('date_format', csv_supported_date_formats)
-@pytest.mark.parametrize('ts_part', csv_supported_ts_parts)
-@pytest.mark.parametrize("timestamp_type", [
-    pytest.param('TIMESTAMP_LTZ', marks=pytest.mark.xfail(is_spark_350_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/9325")),
-    "TIMESTAMP_NTZ"])
+@pytest.mark.parametrize(
+    "timestamp_type,ts_part,date_format", csv_infer_schema_timestamp_params)
 def test_csv_infer_schema_timestamp_ntz_v1(spark_tmp_path, date_format, ts_part, timestamp_type):
     csv_infer_schema_timestamp_ntz(spark_tmp_path, date_format, ts_part, timestamp_type, 'csv', 'FileSourceScanExec')
 
 @allow_non_gpu('BatchScanExec', 'FileSourceScanExec', 'ProjectExec', 'CollectLimitExec', 'DeserializeToObjectExec')
-@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/9325")
+@pytest.mark.skipif(is_databricks_runtime(),
+    reason="https://github.com/NVIDIA/spark-rapids/issues/9325")
 @pytest.mark.skipif(is_before_spark_341(), reason='`TIMESTAMP_NTZ` is only supported in PySpark 341+')
-@pytest.mark.parametrize('date_format', csv_supported_date_formats)
-@pytest.mark.parametrize('ts_part', csv_supported_ts_parts)
-@pytest.mark.parametrize("timestamp_type", [
-    pytest.param('TIMESTAMP_LTZ', marks=pytest.mark.xfail(is_spark_350_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/9325")),
-    "TIMESTAMP_NTZ"])
+@pytest.mark.parametrize(
+    "timestamp_type,ts_part,date_format", csv_infer_schema_timestamp_params)
 def test_csv_infer_schema_timestamp_ntz_v2(spark_tmp_path, date_format, ts_part, timestamp_type):
     csv_infer_schema_timestamp_ntz(spark_tmp_path, date_format, ts_part, timestamp_type, '', 'BatchScanExec')
 


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (26.08 b14 shim-350 nightly; 56012/69176 -> 56012/69176)

## Summary

- Recover CSV V2 timestamp inference coverage on Apache Spark by replacing the unconditional skip with a Databricks-only guard.
- Narrow the V1/V2 LTZ xfail from Spark 3.5+ to the four affected format/time tuples on exact Spark 3.5.0.
- Keep expected values, generated data, and CPU/GPU parity assertions unchanged.
- Retain the Databricks V2 guard because no authorized DBR runtime evidence was available.

Contributes to #9325

## Validation

- Spark 3.4.1 V2 matrix: 160 passed, 966 deselected, 4 warnings in 81.05s.
- Spark 3.5.0 negative boundary with --runxfail: expected PARSE_DATETIME_BY_NEW_PARSER failure, 1 failed in 5.71s.
- Spark 3.5.0 final V1/V2 matrix: 312 passed, 806 deselected, 8 xfailed, 2 warnings in 159.55s.
- Exact nightly-anchor JaCoCo run: 312 passed, 39444 deselected, 8 xfailed, 14 warnings in 168.50s.
- Spark 3.5.5 V1/V2 matrix: 320 passed, 806 deselected, 2 warnings in 159.19s.
- Spark 3.5.5 complete csv_test.py: 1078 passed, 40 xfailed, 8 xpassed, 698 warnings in 281.07s.
- Spark 4.1.1 V1/V2 matrix: 320 passed, 806 deselected, 4 warnings in 156.34s.
- Spark 3.5.5 America/Los_Angeles exact spot check: 4 passed, 2 warnings in 8.69s.
- Final rebased-head Spark 3.5.5 exact GPU gate: 4 passed, 2 warnings in 9.05s.
- Python syntax and git diff checks passed.
- NT local review: 0 must-fix, 0 should-fix; one caching suggestion applied before final validation.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

