### PR TITLE
Combine expression integration tests to reduce premerge time

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -505,9 +505,10 @@ def test_pmod_mixed_decimal(lhs, rhs):
         "Pmod")
 
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_signum(data_gen):
+def test_basic_math_unary_ops(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('signum(a)'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'signum(a)', 'sqrt(a)', 'rint(a)'))
 
 @pytest.mark.parametrize('data_gen', numeric_gens + _arith_decimal_gens_low_precision, ids=idfn)
 @disable_ansi_mode
@@ -578,11 +579,6 @@ def test_abs_ansi_overflow(data_type, value):
         conf=ansi_enabled_conf,
         error_message=_arithmetic_exception_string)
 
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_sqrt(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('sqrt(a)'))
-
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9744')
 @approximate_float
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
@@ -621,11 +617,6 @@ def test_floor_ceil_overflow(data_gen):
         lambda spark: unary_op_df(spark, data_gen).selectExpr('ceil(a)').collect(),
         conf={},
         error_message=exception_type)
-
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_rint(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('rint(a)'))
 
 @pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
 def test_shift_ops(data_gen):
@@ -817,12 +808,6 @@ def test_bit_count(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('bit_count(a)'))
 
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_radians(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('radians(a)'))
-
 # Spark's degrees will overflow on large values in jdk 8 or below
 @approximate_float
 @pytest.mark.skipif(get_java_major_version() <= 8, reason="requires jdk 9 or higher")
@@ -854,9 +839,9 @@ def test_hex(data_gen):
 # Because spark will overflow on large exponents drop to something well below
 # what it fails at, note this is binary exponent, not base 10
 @pytest.mark.parametrize('data_gen', [DoubleGen(min_exp=-20, max_exp=20)], ids=idfn)
-def test_columnar_acosh_improved(data_gen):
+def test_columnar_inverse_hyperbolic_improved(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('acosh(a)'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('acosh(a)', 'asinh(a)'),
             {'spark.rapids.sql.improvedFloatOps.enabled': 'true'})
 
 @approximate_float
@@ -868,22 +853,13 @@ def test_math_unary_ops(data_gen):
                 'sin(a)', 'sinh(a)', 'asin(a)',
                 'tan(a)', 'atan(a)', 'tanh(a)', 'cot(a)',
                 'exp(a)', 'expm1(a)',
-                'log(a)', 'log1p(a)', 'log2(a)', 'log10(a)'))
-
-# The default approximate is 1e-6 or 1 in a million
-# in some cases we need to adjust this because the algorithm is different
-@approximate_float(rel=1e-4, abs=1e-12)
-# Because spark will overflow on large exponents drop to something well below
-# what it fails at, note this is binary exponent, not base 10
-@pytest.mark.parametrize('data_gen', [DoubleGen(min_exp=-20, max_exp=20)], ids=idfn)
-def test_columnar_asinh_improved(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('asinh(a)'),
-            {'spark.rapids.sql.improvedFloatOps.enabled': 'true'})
+                'log(a)', 'log1p(a)', 'log2(a)', 'log10(a)',
+                'radians(a)'))
 
 @approximate_float
-def test_logarithm():
-    # For the 'b' field include a lot more values that we would expect customers to use as a part of a log
+def test_logarithm_and_scalar_pow():
+    # For the 'b' field include a lot more values that we would expect customers to use as
+    # a part of a log or pow.
     data_gen = [('a', DoubleGen()),('b', DoubleGen().with_special_case(lambda rand: float(rand.randint(-16, 16)), weight=100.0))]
     string_type = 'DOUBLE'
     assert_gpu_and_cpu_are_equal_collect(
@@ -892,15 +868,7 @@ def test_logarithm():
                 'log(cast(-12 as {}), b)'.format(string_type),
                 'log(cast(null as {}), b)'.format(string_type),
                 'log(a, cast(null as {}))'.format(string_type),
-                'log(a, b)'))
-
-@approximate_float
-def test_scalar_pow():
-    # For the 'b' field include a lot more values that we would expect customers to use as a part of a pow
-    data_gen = [('a', DoubleGen()),('b', DoubleGen().with_special_case(lambda rand: float(rand.randint(-16, 16)), weight=100.0))]
-    string_type = 'DOUBLE'
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : gen_df(spark, data_gen).selectExpr(
+                'log(a, b)',
                 'pow(a, cast(7 as {}))'.format(string_type),
                 'pow(cast(-12 as {}), b)'.format(string_type),
                 'pow(cast(null as {}), a)'.format(string_type),
@@ -914,7 +882,7 @@ def test_columnar_pow(data_gen):
             lambda spark : binary_op_df(spark, data_gen).selectExpr('pow(a, b)'))
 
 @pytest.mark.parametrize('data_gen', all_basic_gens + _arith_decimal_gens, ids=idfn)
-def test_least(data_gen):
+def test_least_greatest(data_gen):
     num_cols = 20
     s1 = with_cpu_session(
         lambda spark: gen_scalar(data_gen, force_no_nulls=not isinstance(data_gen, NullGen)))
@@ -924,24 +892,9 @@ def test_least(data_gen):
 
     command_args = [f.col('_c' + str(x)) for x in range(0, num_cols)]
     command_args.append(s1)
-    data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gen).select(
-                f.least(*command_args)))
-
-@pytest.mark.parametrize('data_gen', all_basic_gens + _arith_decimal_gens, ids=idfn)
-def test_greatest(data_gen):
-    num_cols = 20
-    s1 = with_cpu_session(
-        lambda spark: gen_scalar(data_gen, force_no_nulls=not isinstance(data_gen, NullGen)))
-    # we want lots of nulls
-    gen = StructGen([('_c' + str(x), data_gen.copy_special_case(None, weight=100.0))
-        for x in range(0, num_cols)], nullable=False)
-    command_args = [f.col('_c' + str(x)) for x in range(0, num_cols)]
-    command_args.append(s1)
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : gen_df(spark, gen).select(
+                f.least(*command_args),
                 f.greatest(*command_args)))
 
 
@@ -1098,10 +1051,10 @@ def test_subtraction_overflow_with_ansi_enabled(data, tp, expr):
 
 
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
-def test_unary_minus_day_time_interval(ansi_enabled):
+def test_unary_ops_day_time_interval(ansi_enabled):
     DAY_TIME_GEN_NO_OVER_FLOW = DayTimeIntervalGen(min_value=timedelta(days=-2000*365), max_value=timedelta(days=3000*365))
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, DAY_TIME_GEN_NO_OVER_FLOW).selectExpr('-a'),
+        lambda spark: unary_op_df(spark, DAY_TIME_GEN_NO_OVER_FLOW).selectExpr('-a', 'abs(a)'),
         conf={'spark.sql.ansi.enabled': ansi_enabled})
 
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
@@ -1115,13 +1068,6 @@ def test_unary_minus_ansi_overflow_day_time_interval(ansi_enabled):
         df_fun=lambda spark: _get_overflow_df(spark, [timedelta(microseconds=LONG_MIN)], DayTimeIntervalType(), '-a').collect(),
         conf={'spark.sql.ansi.enabled': ansi_enabled},
         error_message='SparkArithmeticException' if is_before_spark_400() else "ArithmeticException")
-
-@pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
-def test_abs_ansi_no_overflow_day_time_interval(ansi_enabled):
-    DAY_TIME_GEN_NO_OVER_FLOW = DayTimeIntervalGen(min_value=timedelta(days=-2000*365), max_value=timedelta(days=3000*365))
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, DAY_TIME_GEN_NO_OVER_FLOW).selectExpr('abs(a)'),
-        conf={'spark.sql.ansi.enabled': ansi_enabled})
 
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
 def test_abs_ansi_overflow_day_time_interval(ansi_enabled):

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -526,28 +526,28 @@ def test_signum(data_gen):
 
 @pytest.mark.parametrize('data_gen', numeric_gens + _arith_decimal_gens_low_precision, ids=idfn)
 @disable_ansi_mode
-def test_unary_minus(data_gen):
+def test_unary_ops(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a', 'abs(a)'))
 
 @pytest.mark.parametrize('data_gen', _arith_decimal_gens_high_precision, ids=idfn)
 @pytest.mark.skipif(is_scala213(), reason="Apache Spark built with Scala 2.13 produces inconsistent results at high precision (SPARK-45438)")
-def test_unary_minus_decimal128(data_gen):
+def test_unary_ops_decimal128(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a', 'abs(a)'))
 
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens + [float_gen, double_gen] +
     _arith_decimal_gens_low_precision, ids=idfn)
-def test_unary_minus_ansi_no_overflow(data_gen):
+def test_unary_ops_ansi_no_overflow(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a', 'abs(a)'),
             conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', _arith_decimal_gens_high_precision, ids=idfn)
 @pytest.mark.skipif(is_scala213(), reason="Apache Spark built with Scala 2.13 produces inconsistent results at high precision (SPARK-45438)")
-def test_unary_minus_ansi_no_overflow_decimal128(data_gen):
+def test_unary_ops_ansi_no_overflow_decimal128(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a', 'a', 'abs(a)'),
             conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_type,value', [
@@ -573,33 +573,6 @@ def test_unary_minus_ansi_overflow(data_type, value):
 def test_unary_positive(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr('+a'))
-
-@pytest.mark.parametrize('data_gen', numeric_gens + _arith_decimal_gens_low_precision, ids=idfn)
-@disable_ansi_mode
-def test_abs(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('abs(a)'))
-
-@pytest.mark.parametrize('data_gen', _arith_decimal_gens_high_precision, ids=idfn)
-@pytest.mark.skipif(is_scala213(), reason="Apache Spark built with Scala 2.13 produces inconsistent results at high precision (SPARK-45438)")
-def test_abs_decimal128(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('abs(a)'))
-
-# ANSI is ignored for abs prior to 3.2.0, but still okay to test it a little more.
-@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens + [float_gen, double_gen] +
-    _arith_decimal_gens_low_precision, ids=idfn)
-def test_abs_ansi_no_overflow(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('abs(a)'),
-            conf=ansi_enabled_conf)
-
-@pytest.mark.parametrize('data_gen', _arith_decimal_gens_high_precision, ids=idfn)
-@pytest.mark.skipif(is_scala213(), reason="Apache Spark built with Scala 2.13 produces inconsistent results at high precision")
-def test_abs_ansi_no_overflow_decimal128(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('a','abs(a)'),
-            conf=ansi_enabled_conf)
 
 # Only run this test for Spark v3.2.0 and later to verify abs will
 # throw exceptions for overflow when ANSI mode is enabled.

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -108,7 +108,7 @@ def _get_overflow_df(spark, data, data_type, expr):
 
 @pytest.mark.parametrize('data_gen', _arith_data_gens, ids=idfn)
 @disable_ansi_mode
-def test_addition(data_gen):
+def test_addition_subtraction(data_gen):
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -116,27 +116,7 @@ def test_addition(data_gen):
                 f.lit(-12).cast(data_type) + f.col('b'),
                 f.lit(None).cast(data_type) + f.col('a'),
                 f.col('b') + f.lit(None).cast(data_type),
-                f.col('a') + f.col('b')))
-
-# If it will not overflow for multiply it is good for add too
-@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
-def test_addition_ansi_no_overflow(data_gen):
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') + f.lit(100).cast(data_type),
-                f.lit(-12).cast(data_type) + f.col('b'),
-                f.lit(None).cast(data_type) + f.col('a'),
-                f.col('b') + f.lit(None).cast(data_type),
-                f.col('a') + f.col('b')),
-            conf=ansi_enabled_conf)
-
-@pytest.mark.parametrize('data_gen', _arith_data_gens, ids=idfn)
-@disable_ansi_mode
-def test_subtraction(data_gen):
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
+                f.col('a') + f.col('b'),
                 f.col('a') - f.lit(100).cast(data_type),
                 f.lit(-12).cast(data_type) - f.col('b'),
                 f.lit(None).cast(data_type) - f.col('a'),
@@ -156,12 +136,17 @@ def test_addition_subtraction_mixed(lhs, rhs, addOrSub):
         lambda spark : two_col_df(spark, lhs, rhs).selectExpr(f"a {addOrSub} b")
     )
 
-# If it will not overflow for multiply it is good for subtract too
+# If it will not overflow for multiply it is good for add and subtract too.
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
-def test_subtraction_ansi_no_overflow(data_gen):
+def test_addition_subtraction_ansi_no_overflow(data_gen):
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
+                f.col('a') + f.lit(100).cast(data_type),
+                f.lit(-12).cast(data_type) + f.col('b'),
+                f.lit(None).cast(data_type) + f.col('a'),
+                f.col('b') + f.lit(None).cast(data_type),
+                f.col('a') + f.col('b'),
                 f.col('a') - f.lit(100).cast(data_type),
                 f.lit(-12).cast(data_type) - f.col('b'),
                 f.lit(None).cast(data_type) - f.col('a'),
@@ -593,12 +578,6 @@ def test_abs_ansi_overflow(data_type, value):
         conf=ansi_enabled_conf,
         error_message=_arithmetic_exception_string)
 
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_asin(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('asin(a)'))
-
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
 def test_sqrt(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -614,30 +593,21 @@ def test_hypot(data_gen):
         ))
 
 @pytest.mark.parametrize('data_gen', double_n_long_gens + _arith_decimal_gens_no_neg_scale + [DecimalGen(30, 15)], ids=idfn)
-def test_floor(data_gen):
+def test_floor_ceil(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('floor(a)'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('floor(a)', 'ceil(a)'))
 
 @pytest.mark.parametrize('data_gen', [long_gen] + _arith_decimal_gens_no_neg_scale, ids=idfn)
-def test_floor_scale_zero(data_gen):
+def test_floor_ceil_scale_zero(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('floor(a, 0)'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'floor(a, 0)', 'ceil(a, 0)'))
 
 @allow_non_gpu('RoundFloor', 'Cast')
 @pytest.mark.parametrize('data_gen', [long_gen] + _arith_decimal_gens_no_neg_scale_38_0_overflow, ids=idfn)
 def test_floor_scale_nonzero(data_gen):
     assert_gpu_fallback_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr('floor(a, -1)'), 'RoundFloor')
-
-@pytest.mark.parametrize('data_gen', double_n_long_gens + _arith_decimal_gens_no_neg_scale + [DecimalGen(30, 15)], ids=idfn)
-def test_ceil(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('ceil(a)'))
-
-@pytest.mark.parametrize('data_gen', [long_gen] + _arith_decimal_gens_no_neg_scale, ids=idfn)
-def test_ceil_scale_zero(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('ceil(a, 0)'))
 
 @pytest.mark.parametrize('data_gen', [_decimal_gen_36_neg5, _decimal_gen_38_neg10], ids=idfn)
 def test_floor_ceil_overflow(data_gen):
@@ -658,35 +628,21 @@ def test_rint(data_gen):
             lambda spark : unary_op_df(spark, data_gen).selectExpr('rint(a)'))
 
 @pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
-def test_shift_left(data_gen):
+def test_shift_ops(data_gen):
     string_type = to_cast_string(data_gen.data_type)
     assert_gpu_and_cpu_are_equal_collect(
-            # The version of shiftLeft exposed to dataFrame does not take a column for num bits
+            # The DataFrame shift functions do not take a column for the number of bits.
             lambda spark : two_col_df(spark, data_gen, IntegerGen()).selectExpr(
                 'shiftleft(a, cast(12 as INT))',
                 'shiftleft(cast(-12 as {}), b)'.format(string_type),
                 'shiftleft(cast(null as {}), b)'.format(string_type),
                 'shiftleft(a, cast(null as INT))',
-                'shiftleft(a, b)'))
-
-@pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
-def test_shift_right(data_gen):
-    string_type = to_cast_string(data_gen.data_type)
-    assert_gpu_and_cpu_are_equal_collect(
-            # The version of shiftRight exposed to dataFrame does not take a column for num bits
-            lambda spark : two_col_df(spark, data_gen, IntegerGen()).selectExpr(
+                'shiftleft(a, b)',
                 'shiftright(a, cast(12 as INT))',
                 'shiftright(cast(-12 as {}), b)'.format(string_type),
                 'shiftright(cast(null as {}), b)'.format(string_type),
                 'shiftright(a, cast(null as INT))',
-                'shiftright(a, b)'))
-
-@pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
-def test_shift_right_unsigned(data_gen):
-    string_type = to_cast_string(data_gen.data_type)
-    assert_gpu_and_cpu_are_equal_collect(
-            # The version of shiftRightUnsigned exposed to dataFrame does not take a column for num bits
-            lambda spark : two_col_df(spark, data_gen, IntegerGen()).selectExpr(
+                'shiftright(a, b)',
                 'shiftrightunsigned(a, cast(12 as INT))',
                 'shiftrightunsigned(cast(-12 as {}), b)'.format(string_type),
                 'shiftrightunsigned(cast(null as {}), b)'.format(string_type),
@@ -705,10 +661,11 @@ _arith_data_gens_for_round = numeric_gens + _arith_decimal_gens_no_neg_scale_38_
 
 @incompat
 @approximate_float
-@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/9350")
+@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/9350 "
+    "and https://github.com/NVIDIA/spark-rapids/issues/9847")
 @pytest.mark.parametrize('data_gen', _arith_data_gens_for_round, ids=idfn)
 @disable_ansi_mode
-def test_decimal_bround(data_gen):
+def test_decimal_rounding(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'bround(a)',
@@ -716,16 +673,7 @@ def test_decimal_bround(data_gen):
                 'bround(a, -1)',
                 'bround(a, 1)',
                 'bround(a, 2)',
-                'bround(a, 10)'))
-
-@incompat
-@approximate_float
-@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/9847")
-@pytest.mark.parametrize('data_gen', _arith_data_gens_for_round, ids=idfn)
-@disable_ansi_mode
-def test_decimal_round(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, data_gen).selectExpr(
+                'bround(a, 10)',
                 'round(a)',
                 'round(1.234, 2)',
                 'round(a, -1)',
@@ -788,22 +736,11 @@ def test_non_decimal_round_overflow():
     IntegerGen(min_val=-2000000000, max_val=2000000000, special_cases=[]),
     LongGen(min_val=-9000000000000000000, max_val=9000000000000000000, special_cases=[])
 ], ids=idfn)
-def test_round_ansi_no_overflow_integral(data_gen):
+def test_rounding_ansi_no_overflow_integral(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr(
             'round(a, -1)',
-            'round(a, -2)'),
-        conf=ansi_enabled_conf)
-
-@pytest.mark.parametrize('data_gen', [
-    ByteGen(min_val=-120, max_val=120, special_cases=[]),
-    ShortGen(min_val=-30000, max_val=30000, special_cases=[]),
-    IntegerGen(min_val=-2000000000, max_val=2000000000, special_cases=[]),
-    LongGen(min_val=-9000000000000000000, max_val=9000000000000000000, special_cases=[])
-], ids=idfn)
-def test_bround_ansi_no_overflow_integral(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, data_gen).selectExpr(
+            'round(a, -2)',
             'bround(a, -1)',
             'bround(a, -2)'),
         conf=ansi_enabled_conf)
@@ -837,13 +774,14 @@ def test_bround_ansi_overflow_integral(data_gen, scale):
 
 @approximate_float
 @pytest.mark.parametrize('data_gen', _math_unary_input_gens, ids=idfn)
-def test_cbrt(data_gen):
+def test_extended_math_unary_ops(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('cbrt(a)'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'cbrt(a)', 'asinh(a)', 'atanh(a)'),
             conf=_math_unary_conf)
 
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
-def test_bit_and(data_gen):
+def test_bitwise_binary_ops(data_gen):
     string_type = to_cast_string(data_gen.data_type)
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).selectExpr(
@@ -851,24 +789,12 @@ def test_bit_and(data_gen):
                 'cast(-12 as {}) & b'.format(string_type),
                 'cast(null as {}) & a'.format(string_type),
                 'b & cast(null as {})'.format(string_type),
-                'a & b'))
-
-@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
-def test_bit_or(data_gen):
-    string_type = to_cast_string(data_gen.data_type)
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).selectExpr(
+                'a & b',
                 'a | cast(100 as {})'.format(string_type),
                 'cast(-12 as {}) | b'.format(string_type),
                 'cast(null as {}) | a'.format(string_type),
                 'b | cast(null as {})'.format(string_type),
-                'a | b'))
-
-@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
-def test_bit_xor(data_gen):
-    string_type = to_cast_string(data_gen.data_type)
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).selectExpr(
+                'a | b',
                 'a ^ cast(100 as {})'.format(string_type),
                 'cast(-12 as {}) ^ b'.format(string_type),
                 'cast(null as {}) ^ a'.format(string_type),
@@ -922,30 +848,6 @@ def test_hex(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr('hex(a)'))
 
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_cos(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('cos(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_acos(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('acos(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_cosh(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('cosh(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_acosh(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('acosh(a)'))
-
 # The default approximate is 1e-6 or 1 in a million
 # in some cases we need to adjust this because the algorithm is different
 @approximate_float(rel=1e-4, abs=1e-12)
@@ -959,28 +861,14 @@ def test_columnar_acosh_improved(data_gen):
 
 @approximate_float
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_sin(data_gen):
+def test_math_unary_ops(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('sin(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_sinh(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('sinh(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_asin(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('asin(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', _math_unary_input_gens, ids=idfn)
-def test_asinh(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('asinh(a)'),
-            conf=_math_unary_conf)
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'cos(a)', 'acos(a)', 'cosh(a)', 'acosh(a)',
+                'sin(a)', 'sinh(a)', 'asin(a)',
+                'tan(a)', 'atan(a)', 'tanh(a)', 'cot(a)',
+                'exp(a)', 'expm1(a)',
+                'log(a)', 'log1p(a)', 'log2(a)', 'log10(a)'))
 
 # The default approximate is 1e-6 or 1 in a million
 # in some cases we need to adjust this because the algorithm is different
@@ -992,73 +880,6 @@ def test_columnar_asinh_improved(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr('asinh(a)'),
             {'spark.rapids.sql.improvedFloatOps.enabled': 'true'})
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_tan(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('tan(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_atan(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('atan(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', _math_unary_input_gens, ids=idfn)
-def test_atanh(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('atanh(a)'),
-            conf=_math_unary_conf)
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_tanh(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('tanh(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_cot(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('cot(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_exp(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('exp(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_expm1(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('expm1(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_log(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('log(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_log1p(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('log1p(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_log2(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('log2(a)'))
-
-@approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
-def test_log10(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('log10(a)'))
 
 @approximate_float
 def test_logarithm():

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -22,226 +22,71 @@ from pyspark.sql.types import *
 from marks import datagen_overrides, allow_non_gpu
 import pyspark.sql.functions as f
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + struct_gens_sample_with_decimal128_no_list, ids=idfn)
-def test_eq(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
+def _comparison_exprs(data_gen, s1, s2, compare, include_b_scalar=False):
     data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') == s1,
-                s2 == f.col('b'),
-                f.lit(None).cast(data_type) == f.col('a'),
-                f.col('b') == f.lit(None).cast(data_type),
-                f.col('a') == f.col('b')))
+    exprs = [
+        compare(f.col('a'), s1),
+        compare(s2, f.col('b'))]
+    if include_b_scalar:
+        exprs.append(compare(f.col('b'), s2))
+    exprs.extend([
+        compare(f.lit(None).cast(data_type), f.col('a')),
+        compare(f.col('b'), f.lit(None).cast(data_type)),
+        compare(f.col('a'), f.col('b'))])
+    return exprs
 
-def test_eq_for_interval():
-    def test_func(data_gen):
-        (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-        data_type = data_gen.data_type
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') == s1,
-                s2 == f.col('b'),
-                f.lit(None).cast(data_type) == f.col('a'),
-                f.col('b') == f.lit(None).cast(data_type),
-                f.col('a') == f.col('b')))
-    # DayTimeIntervalType not supported inside Structs -- issue #6184
-    # data_gens = [DayTimeIntervalGen(),
-    # StructGen([['child0', StructGen([['child2', DayTimeIntervalGen()]])], ['child1', short_gen]])]
-    data_gens = [DayTimeIntervalGen()]
-    for data_gen in data_gens:
-        test_func(data_gen)
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + struct_gens_sample_with_decimal128_no_list, ids=idfn)
-def test_eq_ns(data_gen):
+_equality_comparisons = [
+    lambda lhs, rhs: lhs == rhs,
+    lambda lhs, rhs: lhs.eqNullSafe(rhs),
+    lambda lhs, rhs: lhs != rhs]
+
+_ordering_comparisons = [
+    (lambda lhs, rhs: lhs < rhs, False),
+    (lambda lhs, rhs: lhs <= rhs, True),
+    (lambda lhs, rhs: lhs > rhs, True),
+    (lambda lhs, rhs: lhs >= rhs, True)]
+
+
+def _assert_comparisons(data_gen, comparisons):
     (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
+        lambda spark: gen_scalars(
+            data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
+    exprs = []
+    for compare, include_b_scalar in comparisons:
+        exprs.extend(_comparison_exprs(
+            data_gen, s1, s2, compare, include_b_scalar=include_b_scalar))
+    exprs = [expr.alias(f'comparison_{index}') for index, expr in enumerate(exprs)]
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a').eqNullSafe(s1),
-                s2.eqNullSafe(f.col('b')),
-                f.lit(None).cast(data_type).eqNullSafe(f.col('a')),
-                f.col('b').eqNullSafe(f.lit(None).cast(data_type)),
-                f.col('a').eqNullSafe(f.col('b'))))
+        lambda spark: binary_op_df(spark, data_gen).select(*exprs))
 
-def test_eq_ns_for_interval():
-    data_gen = DayTimeIntervalGen()
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : binary_op_df(spark, data_gen).select(
-            f.col('a').eqNullSafe(s1),
-            s2.eqNullSafe(f.col('b')),
-            f.lit(None).cast(data_type).eqNullSafe(f.col('a')),
-            f.col('b').eqNullSafe(f.lit(None).cast(data_type)),
-            f.col('a').eqNullSafe(f.col('b'))))
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + struct_gens_sample_with_decimal128_no_list, ids=idfn)
-def test_ne(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') != s1,
-                s2 != f.col('b'),
-                f.lit(None).cast(data_type) != f.col('a'),
-                f.col('b') != f.lit(None).cast(data_type),
-                f.col('a') != f.col('b')))
+@pytest.mark.parametrize(
+    'data_gen',
+    eq_gens_with_decimal_gen + struct_gens_sample_with_decimal128_no_list,
+    ids=idfn)
+def test_equality_comparisons(data_gen):
+    _assert_comparisons(data_gen, [(compare, False) for compare in _equality_comparisons])
 
-def test_ne_for_interval():
-    def test_func(data_gen):
-        (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-        data_type = data_gen.data_type
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') != s1,
-                s2 != f.col('b'),
-                f.lit(None).cast(data_type) != f.col('a'),
-                f.col('b') != f.lit(None).cast(data_type),
-                f.col('a') != f.col('b')))
-    # DayTimeIntervalType not supported inside Structs -- issue #6184
-    # data_gens = [DayTimeIntervalGen(),
-    # StructGen([['child0', StructGen([['child2', DayTimeIntervalGen()]])], ['child1', short_gen]])]
-    data_gens = [DayTimeIntervalGen()]
-    for data_gen in data_gens:
-        test_func(data_gen)
-
-@pytest.mark.parametrize('data_gen', orderable_gens + struct_gens_sample_with_decimal128_no_list, ids=idfn)
-def test_lt(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') < s1,
-                s2 < f.col('b'),
-                f.lit(None).cast(data_type) < f.col('a'),
-                f.col('b') < f.lit(None).cast(data_type),
-                f.col('a') < f.col('b')))
-
-def test_lt_for_interval():
-    def test_func(data_gen):
-        (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-        data_type = data_gen.data_type
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') < s1,
-                s2 < f.col('b'),
-                f.lit(None).cast(data_type) < f.col('a'),
-                f.col('b') < f.lit(None).cast(data_type),
-                f.col('a') < f.col('b')))
-    # DayTimeIntervalType not supported inside Structs -- issue #6184
-    # data_gens = [DayTimeIntervalGen(),
-    # StructGen([['child0', StructGen([['child2', DayTimeIntervalGen()]])], ['child1', short_gen]])]
-    data_gens = [DayTimeIntervalGen()]
-    for data_gen in data_gens:
-        test_func(data_gen)
-
-@pytest.mark.parametrize('data_gen', orderable_gens + struct_gens_sample_with_decimal128_no_list, ids=idfn)
-def test_lte(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') <= s1,
-                s2 <= f.col('b'),
-                f.col('b') <= s2,
-                f.lit(None).cast(data_type) <= f.col('a'),
-                f.col('b') <= f.lit(None).cast(data_type),
-                f.col('a') <= f.col('b')))
-
-def test_lte_for_interval():
-    def test_func(data_gen):
-        (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-        data_type = data_gen.data_type
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') <= s1,
-                s2 <= f.col('b'),
-                f.lit(None).cast(data_type) <= f.col('a'),
-                f.col('b') <= f.lit(None).cast(data_type),
-                f.col('a') <= f.col('b')))
-    # DayTimeIntervalType not supported inside Structs -- issue #6184
-    # data_gens = [DayTimeIntervalGen(),
-    # StructGen([['child0', StructGen([['child2', DayTimeIntervalGen()]])], ['child1', short_gen]])]
-    data_gens = [DayTimeIntervalGen()]
-    for data_gen in data_gens:
-        test_func(data_gen)
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
-def test_gt(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') > s1,
-                s2 > f.col('b'),
-                f.col('b') > s2,
-                f.lit(None).cast(data_type) > f.col('a'),
-                f.col('b') > f.lit(None).cast(data_type),
-                f.col('a') > f.col('b')))
+def test_ordering_comparisons(data_gen):
+    _assert_comparisons(data_gen, _ordering_comparisons)
 
-def test_gt_interval():
-    def test_func(data_gen):
-        (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-        data_type = data_gen.data_type
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') > s1,
-                s2 > f.col('b'),
-                f.lit(None).cast(data_type) > f.col('a'),
-                f.col('b') > f.lit(None).cast(data_type),
-                f.col('a') > f.col('b')))
-    # DayTimeIntervalType not supported inside Structs -- issue #6184
-    # data_gens = [DayTimeIntervalGen(),
-    # StructGen([['child0', StructGen([['child2', DayTimeIntervalGen()]])], ['child1', short_gen]])]
-    data_gens = [DayTimeIntervalGen()]
-    for data_gen in data_gens:
-        test_func(data_gen)
 
-@pytest.mark.parametrize('data_gen', orderable_gens + struct_gens_sample_with_decimal128_no_list, ids=idfn)
-def test_gte(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    data_type = data_gen.data_type
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') >= s1,
-                s2 >= f.col('b'),
-                f.col('b') >= s2,
-                f.lit(None).cast(data_type) >= f.col('a'),
-                f.col('b') >= f.lit(None).cast(data_type),
-                f.col('a') >= f.col('b')))
+@pytest.mark.parametrize('data_gen', struct_gens_sample_with_decimal128_no_list, ids=idfn)
+def test_struct_ordering_comparisons(data_gen):
+    # Greater-than was not supported by the original struct comparison coverage.
+    _assert_comparisons(
+        data_gen,
+        [comparison for index, comparison in enumerate(_ordering_comparisons) if index != 2])
 
-def test_gte_for_interval():
-    def test_func(data_gen):
-        (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-        data_type = data_gen.data_type
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
-                f.col('a') >= s1,
-                s2 >= f.col('b'),
-                f.lit(None).cast(data_type) >= f.col('a'),
-                f.col('b') >= f.lit(None).cast(data_type),
-                f.col('a') >= f.col('b')))
-    # DayTimeIntervalType not supported inside Structs -- issue #6184
-    # data_gens = [DayTimeIntervalGen(),
-    # StructGen([['child0', StructGen([['child2', DayTimeIntervalGen()]])], ['child1', short_gen]])]
-    data_gens = [DayTimeIntervalGen()]
-    for data_gen in data_gens:
-        test_func(data_gen)
+
+def test_interval_comparisons():
+    # DayTimeIntervalType is not supported inside structs -- issue #6184.
+    comparisons = [(compare, False) for compare in _equality_comparisons]
+    comparisons.extend([(compare, False) for compare, _ in _ordering_comparisons])
+    _assert_comparisons(DayTimeIntervalGen(), comparisons)
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + [binary_gen] + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_isnull(data_gen):

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -224,16 +224,10 @@ def test_ifnull(data_gen):
                 'ifnull(a, {})'.format(null_lit)))
 
 @pytest.mark.parametrize('data_gen', [IntegerGen().with_special_case(2147483647)], ids=idfn)
-def test_conditional_with_side_effects_col_col(data_gen):
+def test_conditional_with_side_effects_integral(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(
-                'IF(a < 2147483647, a + 1, a)'),
-            conf = ansi_enabled_conf)
-
-@pytest.mark.parametrize('data_gen', [IntegerGen().with_special_case(2147483647)], ids=idfn)
-def test_conditional_with_side_effects_col_scalar(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'IF(a < 2147483647, a + 1, a)',
                 'IF(a < 2147483647, a + 1, 2147483647)',
                 'IF(a >= 2147483646, 2147483647, a + 1)'),
             conf = ansi_enabled_conf)

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -196,7 +196,7 @@ def test_nvl2(data_gen):
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/12019
 @disable_ansi_mode
-def test_nullif(data_gen):
+def test_nullif_ifnull(data_gen):
     (s1, s2) = with_cpu_session(
         lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
     null_lit = get_null_lit_string(data_gen.data_type)
@@ -206,17 +206,7 @@ def test_nullif(data_gen):
                 'nullif(a, {})'.format(s2),
                 'nullif({}, b)'.format(s1),
                 'nullif({}, b)'.format(null_lit),
-                'nullif(a, {})'.format(null_lit)))
-
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
-# https://github.com/NVIDIA/spark-rapids/issues/12019
-@disable_ansi_mode
-def test_ifnull(data_gen):
-    (s1, s2) = with_cpu_session(
-        lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
-    null_lit = get_null_lit_string(data_gen.data_type)
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).selectExpr(
+                'nullif(a, {})'.format(null_lit),
                 'ifnull(a, b)',
                 'ifnull(a, {})'.format(s2),
                 'ifnull({}, b)'.format(s1),
@@ -278,17 +268,10 @@ def test_conditional_with_side_effects_sequence_cast(data_gen):
 
 @pytest.mark.parametrize('data_gen', [ArrayGen(mk_str_gen('[a-z]{0,3}'))], ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-def test_conditional_with_side_effects_element_at(data_gen, ansi_enabled):
+def test_conditional_with_side_effects_array_access(data_gen, ansi_enabled):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
-            'CASE WHEN size(a) > 1 THEN element_at(a, 2) ELSE null END'),
-        conf = {'spark.sql.ansi.enabled': ansi_enabled})
-
-@pytest.mark.parametrize('data_gen', [ArrayGen(mk_str_gen('[a-z]{0,3}'))], ids=idfn)
-@pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-def test_conditional_with_side_effects_array_index(data_gen, ansi_enabled):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'CASE WHEN size(a) > 1 THEN element_at(a, 2) ELSE null END',
             'CASE WHEN size(a) > 1 THEN a[1] ELSE null END'),
         conf = {'spark.sql.ansi.enabled': ansi_enabled})
 
@@ -305,17 +288,10 @@ def test_conditional_with_side_effects_map_key_not_found(map_gen, data_gen, ansi
 
 @pytest.mark.parametrize('data_gen', [ShortGen().with_special_case(SHORT_MIN)], ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-def test_conditional_with_side_effects_abs(data_gen, ansi_enabled):
+def test_conditional_with_side_effects_unary_ops(data_gen, ansi_enabled):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
-            'CASE WHEN a > -32768 THEN abs(a) ELSE null END'),
-        conf = {'spark.sql.ansi.enabled': ansi_enabled})
-
-@pytest.mark.parametrize('data_gen', [ShortGen().with_special_case(SHORT_MIN)], ids=idfn)
-@pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-def test_conditional_with_side_effects_unary_minus(data_gen, ansi_enabled):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'CASE WHEN a > -32768 THEN abs(a) ELSE null END',
             'CASE WHEN a > -32768 THEN -a ELSE null END'),
         conf = {'spark.sql.ansi.enabled': ansi_enabled})
 

--- a/integration_tests/src/main/python/logic_test.py
+++ b/integration_tests/src/main/python/logic_test.py
@@ -23,7 +23,7 @@ import pyspark.sql.functions as f
 
 @pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
 @pytest.mark.parametrize('data_gen', boolean_gens, ids=idfn)
-def test_and(data_gen, ansi_enabled):
+def test_and_or(data_gen, ansi_enabled):
     ansi_conf = {'spark.sql.ansi.enabled': ansi_enabled}
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -32,16 +32,7 @@ def test_and(data_gen, ansi_enabled):
                 f.lit(False) & f.col('b'),
                 f.lit(None).cast(data_type) & f.col('a'),
                 f.col('b') & f.lit(None).cast(data_type),
-                f.col('a') & f.col('b')),
-                conf=ansi_conf)
-
-@pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-@pytest.mark.parametrize('data_gen', boolean_gens, ids=idfn)
-def test_or(data_gen, ansi_enabled):
-    data_type = data_gen.data_type
-    ansi_conf = {'spark.sql.ansi.enabled': ansi_enabled}
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).select(
+                f.col('a') & f.col('b'),
                 f.col('a') | f.lit(True),
                 f.lit(False) | f.col('b'),
                 f.lit(None).cast(data_type) | f.col('a'),


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346

## Summary

- combine compatible arithmetic, comparison, conditional, and logical expression tests into shared DataFrame projections
- preserve distinct markers, Spark configurations, fallback checks, and error assertions
- reduce repeated CPU/GPU assertion executions in premerge integration testing

## Impact

The additional unary, binary, and ternary-expression combinations in the latest commit reduce the affected parameterized cases from 99 assertion executions to 49. Together with the earlier commits on this branch, this reduces redundant Spark work while retaining the same expression coverage.

## Validation

- `python3 -m py_compile` for the changed Python test files
- `git diff --check`
- Spark 3.3.0 / Scala 2.12 targeted GPU integration tests: 49 passed
