### PR TITLE
Fix ORC numeric-only field name parsing [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -3048,6 +3048,8 @@ case class OrcTableReader(
   private[this] val reader = new ORCChunkedReader(chunkSizeByteLimit,
     maxChunkedReaderMemoryUsageSizeBytes, parseOpts, buffer, offset, bufferSize)
 
+  private[this] lazy val catalystTableSchema = SchemaUtils.toCatalystSchema(tableSchema)
+
   private[this] lazy val splitsString = splits.mkString("; ")
 
   override def hasNext: Boolean = reader.hasNext
@@ -3078,7 +3080,7 @@ case class OrcTableReader(
     }
     metrics(NUM_OUTPUT_BATCHES) += 1
     val rebased = GpuOrcTimezoneUtils.rebaseOrcTimestamps(table, writerTimezone)
-    SchemaUtils.evolveSchemaIfNeededAndClose(rebased, tableSchema,
+    SchemaUtils.evolveSchemaIfNeededAndClose(rebased, catalystTableSchema,
       readDataSchema, isSchemaCaseSensitive, Some(GpuOrcScan.castColumnTo))
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SchemaUtils.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import java.util.Optional
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
@@ -56,10 +57,26 @@ object SchemaUtils {
    * Convert a TypeDescription to a Catalyst StructType.
    */
   implicit def toCatalystSchema(schema: TypeDescription): StructType = {
-    // Here just follows the implementation of Spark3.0.x, so it does not replace the
-    // CharType/VarcharType with StringType. It is OK because GPU does not support
-    // these two char types yet.
-    CatalystSqlParser.parseDataType(schema.toString).asInstanceOf[StructType]
+    // Build complex types directly so ORC field names are preserved verbatim. Parse only
+    // primitive leaves to retain the existing CharType/VarcharType behavior.
+    def toCatalystType(orcType: TypeDescription): DataType = orcType.getCategory match {
+      case TypeDescription.Category.STRUCT => toStructType(orcType)
+      case TypeDescription.Category.LIST =>
+        ArrayType(toCatalystType(orcType.getChildren.get(0)))
+      case TypeDescription.Category.MAP =>
+        val Seq(keyType, valueType) = orcType.getChildren.asScala.toSeq
+        MapType(toCatalystType(keyType), toCatalystType(valueType))
+      case _ => CatalystSqlParser.parseDataType(orcType.toString)
+    }
+
+    def toStructType(orcType: TypeDescription): StructType = {
+      val fields = orcType.getFieldNames.asScala.zip(orcType.getChildren.asScala).map {
+        case (fieldName, fieldType) => StructField(fieldName, toCatalystType(fieldType))
+      }
+      StructType(fields.toSeq)
+    }
+
+    toStructType(schema)
   }
 
   private def getPrecisionsList(dt: DataType): Seq[Int] = dt match {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcQuerySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcQuerySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,35 @@ class OrcQuerySuite extends SparkQueryCompareTestSuite {
     }
   ) {
     frame => frame
+  }
+
+  Seq("orc", "").foreach { v1List =>
+    val sparkConf = new SparkConf().set("spark.sql.sources.useV1SourceList", v1List)
+    testSparkReadResultsAreEqual(
+      s"SPARK-36663 read numeric-only ORC field names, source list is ($v1List)",
+      (file: File) => (spark: SparkSession) => spark.read.orc(file.getCanonicalPath),
+      (spark: SparkSession, file: File) => {
+        spark.sql(
+          """
+            |SELECT
+            |  'a' AS `1`,
+            |  named_struct('20', 'b', '30', named_struct('40', 'c')) AS `50`,
+            |  array(named_struct('123', 'd')) AS `789`,
+            |  map('key', named_struct('456', 'e')) AS `012`
+          """.stripMargin)
+          .coalesce(1)
+          .write
+          .orc(file.getCanonicalPath)
+      },
+      conf = sparkConf,
+      existClasses = if (v1List == "orc") "GpuFileSourceScanExec" else "GpuBatchScan") { frame =>
+      frame.selectExpr(
+        "`1`",
+        "`50`.`20`",
+        "`50`.`30`.`40`",
+        "`789`[0].`123`",
+        "`012`['key'].`456`")
+    }
   }
 
   /**

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SchemaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SchemaUtilsSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.orc.TypeDescription
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.types.{ArrayType, MapType, StringType, StructField, StructType}
+
+class SchemaUtilsSuite extends AnyFunSuite {
+
+  test("convert ORC schemas with numeric-only field names to Catalyst") {
+    val orcSchema = TypeDescription.createStruct()
+      .addField("1", TypeDescription.createString())
+      .addField("50", TypeDescription.createStruct()
+        .addField("20", TypeDescription.createString())
+        .addField("30", TypeDescription.createStruct()
+          .addField("40", TypeDescription.createString())))
+      .addField("789", TypeDescription.createList(
+        TypeDescription.createStruct()
+          .addField("123", TypeDescription.createString())))
+      .addField("012", TypeDescription.createMap(
+        TypeDescription.createStruct()
+          .addField("321", TypeDescription.createString()),
+        TypeDescription.createStruct()
+          .addField("456", TypeDescription.createString())))
+
+    val expected = StructType(Seq(
+      StructField("1", StringType),
+      StructField("50", StructType(Seq(
+        StructField("20", StringType),
+        StructField("30", StructType(Seq(
+          StructField("40", StringType))))))),
+      StructField("789", ArrayType(StructType(Seq(
+        StructField("123", StringType))))),
+      StructField("012", MapType(
+        StructType(Seq(StructField("321", StringType))),
+        StructType(Seq(StructField("456", StringType)))))))
+
+    assert(SchemaUtils.toCatalystSchema(orcSchema) === expected)
+  }
+}


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +14 lines** (`SchemaUtils` +12, `GpuOrcScan` +2; fix-line coverage, Spark 330)

Closes #15472.

## Summary

- Construct Catalyst complex types directly from the ORC type tree so numeric-only field names remain verbatim.
- Parse only primitive leaves, preserving the existing CHAR/VARCHAR behavior.
- Cache the converted table schema once per chunked ORC reader.
- Cover numeric-only names at the top level and inside structs, lists, map keys, and map values; verify both V1 and V2 GPU scans.

## Root cause

`TypeDescription.toString` emits numeric-only field names without SQL identifier quoting. Passing that string to `CatalystSqlParser` therefore fails at the first numeric field name, while Spark CPU constructs the schema programmatically.

## Validation

- Reproduced before the fix: `Tests: succeeded 7, failed 3, canceled 1, ignored 0, pending 0`; all three failures had `ParseException: Syntax error at or near '1'` from `SchemaUtils.toCatalystSchema`.
- Spark 330 focused GPU run after the fix: `Tests: succeeded 10, failed 0, canceled 1, ignored 0, pending 0` and `BUILD SUCCESS`.
- Spark 340 `sql-plugin` compile: `BUILD SUCCESS`.
- Spark 400 / Scala 2.13 `sql-plugin` compile: `BUILD SUCCESS`.
- Scalastyle: 1,732 files processed, 0 errors, 0 warnings.
- Shim coverage check: passed.
- JaCoCo fix-line intersection: 14 of 24 added production lines covered by the focused run.

## Performance impact

This is a schema-metadata cold path with no per-row GPU kernel or data-transfer change. The chunked reader now caches the Catalyst table schema once per reader, avoiding the previous conversion on every output batch.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
