### PR TITLE
Separate JSON floating-point and boolean test patterns [fast-ut] [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1072,7 +1072,7 @@ def test_from_json_struct_decimal():
     # integral
     pytest.param("[0-9]{1,5}", marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/9664")),
     # floating-point
-    "[0-9]{0,2}\\.[0-9]{1,2}"
+    "[0-9]{0,2}\\.[0-9]{1,2}",
     # boolean
     "(true|false)"
 ])
@@ -1146,7 +1146,7 @@ def test_from_json_struct_date_fallback_non_default_format(date_gen, date_format
     pytest.param("[0-9]{1,5}", marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/4940")),
     pytest.param("[1-9]{1,8}", marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/4940")),
     # floating-point
-    r"[0-9]{0,2}\.[0-9]{1,2}"
+    r"[0-9]{0,2}\.[0-9]{1,2}",
     # boolean
     "(true|false)"
 ])


### PR DESCRIPTION
### Description

This fixes a bug in the `from_json` date and timestamp tests. These tests are intended to exercise floating-point and boolean JSON inputs as separate parameter cases.

The missing commas caused Python to concatenate each pair of adjacent regex strings into one pattern. As a result, neither input type was tested independently. The fix restores them as separate pytest parameters and adds 18 independently collected test cases.

Validation:

- Spark 3.3.0 collection: 7,923 tests collected, including the 18 new independent nodes.
- Spark 3.3.0 targeted validation of four new date/timestamp floating-point and boolean nodes: 2 passed, 2 expected xfails.
- Spark 4.0.1 / Scala 2.13 package build with JDK 17: `BUILD SUCCESS`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
