### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Re-enable JSON partition-pruning tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/prune_partition_column_test.py
+++ b/integration_tests/src/main/python/prune_partition_column_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@ from conftest import spark_jvm
 part1_gen = SetValuesGen(IntegerType(), [-10, -1, 0, 1, 10])
 part2_gen = SetValuesGen(LongType(), [-100, 0, 100])
 
-file_formats = ['parquet', 'orc', 'csv',
-    pytest.param('json', marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7446'))]
+file_formats = ['parquet', 'orc', 'csv', 'json']
 if os.environ.get('INCLUDE_SPARK_AVRO_JAR', 'false') == 'true':
     file_formats = file_formats + ['avro']
 


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350, nightly b14 anchor `4f725f15`; the exercised production path is already covered by the nightly baseline)

Contributes to #7446.

## Summary

- Remove the shared JSON xfail from `prune_partition_column_test.py`.
- Re-enable 28 JSON parameters across six partition-pruning test functions without changing schemas, data, assertions, or fallback allowances.
- Keep NVIDIA/cudf-spark#7616 out of scope: its still-open no-schema/schema-inference `empty.min` path is distinct from these explicit-schema tests.

## Recovered tests

- `test_prune_partition_column_when_project`
- `test_prune_partition_column_when_fallback_project`
- `test_prune_partition_column_when_filter_project`
- `test_prune_partition_column_when_fallback_filter_and_project`
- `test_prune_partition_column_when_fallback_filter_project`
- `test_prune_partition_column_when_filter_fallback_project`

Source: `integration_tests/src/main/python/prune_partition_column_test.py`

## Validation

- Spark 3.3: target matrix `28 passed, 104 deselected`; explicit-schema empty-JSON root regression `1 passed, 1034 deselected`.
- Spark 3.5: target matrix `28 passed, 104 deselected`; root regression `1 passed, 1034 deselected`; enclosing file `128 passed, 4 skipped`.
- Spark 4.1: target matrix `28 passed, 104 deselected`; root regression `1 passed, 1034 deselected`.
- Spark 3.5 event log: all 28 target GPU executions contain `GpuScan json`; no target scan is missing GPU execution.
- Python 3.10 `py_compile`, `git diff --check`, and NT local review: passed.
- JaCoCo: b14 anchor base and merged sql-plugin line coverage are both `56012/69176`; measured net delta `+0 lines`.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
