### PR TITLE
[fast-ut] [reduced-it] [BUG] Handle oversized regex quantifier integers [databricks]

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -480,19 +480,6 @@ def test_regexp_replace():
                 'regexp_replace(a, "a|b|c", "A")'),
         conf=_regexp_conf)
 
-# https://github.com/NVIDIA/cudf-spark/issues/15495
-@allow_non_gpu('ProjectExec', 'RegExpReplace')
-def test_regexp_replace_oversized_quantifier():
-    from pyspark.sql.functions import col, regexp_replace
-    pattern = "a{9999999999999999999999999999}"
-    assert_gpu_and_cpu_same_data_or_error(
-        lambda spark: spark.createDataFrame(
-            ["aaaa", pattern], "string").toDF("a").select(
-                regexp_replace(col("a"), pattern, "replacement")).collect(),
-        conf=_regexp_conf,
-        error_message=re.compile(r"Illegal repetition|INVALID_PARAMETER_VALUE\.PATTERN"))
-
-
 # https://github.com/NVIDIA/spark-rapids/issues/14742
 # Replacement-string parser must match java.util.regex.Matcher#appendReplacement.
 # Use the DataFrame API rather than selectExpr because Spark SQL variable substitution

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -490,7 +490,7 @@ def test_regexp_replace_oversized_quantifier():
             ["aaaa", pattern], "string").toDF("a").select(
                 regexp_replace(col("a"), pattern, "replacement")).collect(),
         conf=_regexp_conf,
-        error_message=re.compile("Illegal repetition"))
+        error_message=re.compile(r"Illegal repetition|INVALID_PARAMETER_VALUE\.PATTERN"))
 
 
 # https://github.com/NVIDIA/spark-rapids/issues/14742

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -480,6 +480,19 @@ def test_regexp_replace():
                 'regexp_replace(a, "a|b|c", "A")'),
         conf=_regexp_conf)
 
+# https://github.com/NVIDIA/cudf-spark/issues/15495
+@allow_non_gpu('ProjectExec', 'RegExpReplace')
+def test_regexp_replace_oversized_quantifier():
+    from pyspark.sql.functions import col, regexp_replace
+    pattern = "a{9999999999999999999999999999}"
+    assert_gpu_and_cpu_same_data_or_error(
+        lambda spark: spark.createDataFrame(
+            ["aaaa", pattern], "string").toDF("a").select(
+                regexp_replace(col("a"), pattern, "replacement")).collect(),
+        conf=_regexp_conf,
+        error_message=re.compile("Illegal repetition"))
+
+
 # https://github.com/NVIDIA/spark-rapids/issues/14742
 # Replacement-string parser must match java.util.regex.Matcher#appendReplacement.
 # Use the DataFrame API rather than selectExpr because Spark SQL variable substitution

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -57,10 +57,11 @@ class RegexParser(pattern: String) {
     // Validate if the pattern is compatible with Java, as this would throw an error otherwise
     Pattern.compile(pattern)
 
-    parseWithoutJavaValidation()
+    parseUnchecked()
   }
 
-  private[rapids] def parseWithoutJavaValidation(): RegexAST = {
+  // Package-visible so tests can exercise parser-only behavior without host-JDK validation.
+  private[rapids] def parseUnchecked(): RegexAST = {
     val ast = parseUntil(() => eof())
     if (!eof()) {
       throw new RegexUnsupportedException("Failed to parse full regex. Last character parsed was",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -57,6 +57,10 @@ class RegexParser(pattern: String) {
     // Validate if the pattern is compatible with Java, as this would throw an error otherwise
     Pattern.compile(pattern)
 
+    parseWithoutJavaValidation()
+  }
+
+  private[rapids] def parseWithoutJavaValidation(): RegexAST = {
     val ast = parseUntil(() => eof())
     if (!eof()) {
       throw new RegexUnsupportedException("Failed to parse full regex. Last character parsed was",
@@ -655,7 +659,13 @@ class RegexParser(pattern: String) {
     if (start == pos) {
       None
     } else {
-      Some(pattern.substring(start, pos).toInt)
+      try {
+        Some(pattern.substring(start, pos).toInt)
+      } catch {
+        case _: NumberFormatException =>
+          throw new RegexUnsupportedException(
+            "Regex quantifier exceeds supported integer range", Some(start))
+      }
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -53,6 +53,22 @@ class RegularExpressionParserSuite extends AnyFunSuite {
       RegexRepetition(RegexChar('a'), QuantifierFixedLength(1)))))
   }
 
+  test("issue-15495: quantifier integer boundaries") {
+    assert(new RegexParser("a{2147483647}").parseWithoutJavaValidation() ===
+      RegexSequence(ListBuffer(
+        RegexRepetition(RegexChar('a'), QuantifierFixedLength(Int.MaxValue)))))
+
+    Seq(
+      "a{2147483648}" -> 2,
+      "a{1,2147483648}" -> 4).foreach { case (pattern, index) =>
+      val e = intercept[RegexUnsupportedException] {
+        new RegexParser(pattern).parseWithoutJavaValidation()
+      }
+      assert(e.getMessage ===
+        s"Regex quantifier exceeds supported integer range near index $index")
+    }
+  }
+
   test("not a quantifier") {
     assert(parse("{1}") ===
       RegexSequence(ListBuffer(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 import java.util.regex.PatternSyntaxException
 
 import scala.collection.mutable.ListBuffer
+import scala.util.Random
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -53,16 +54,30 @@ class RegularExpressionParserSuite extends AnyFunSuite {
       RegexRepetition(RegexChar('a'), QuantifierFixedLength(1)))))
   }
 
-  test("issue-15495: quantifier integer boundaries") {
-    assert(new RegexParser("a{2147483647}").parseWithoutJavaValidation() ===
-      RegexSequence(ListBuffer(
-        RegexRepetition(RegexChar('a'), QuantifierFixedLength(Int.MaxValue)))))
+  // Regression test for https://github.com/NVIDIA/cudf-spark/issues/15495
+  test("quantifier integer boundaries") {
+    val supportedBoundaries: Seq[(String, RegexQuantifier)] = Seq(
+      s"a{${Int.MaxValue}}" -> QuantifierFixedLength(Int.MaxValue),
+      s"a{${Int.MaxValue},}" -> QuantifierVariableLength(Int.MaxValue, None),
+      s"a{1,${Int.MaxValue}}" -> QuantifierVariableLength(1, Some(Int.MaxValue)))
+    supportedBoundaries.foreach { case (pattern, quantifier) =>
+      assert(new RegexParser(pattern).parseUnchecked() ===
+        RegexSequence(ListBuffer(RegexRepetition(RegexChar('a'), quantifier))))
+    }
 
-    Seq(
-      "a{2147483648}" -> 2,
-      "a{1,2147483648}" -> 4).foreach { case (pattern, index) =>
+    val firstUnsupported = (Int.MaxValue.toLong + 1).toString
+    val random = new Random(15495L)
+    val seededOversized = Seq.fill(8) {
+      (random.nextInt(9) + 1).toString + Seq.fill(31)(random.nextInt(10)).mkString
+    }
+    (firstUnsupported +: seededOversized).flatMap { count =>
+      Seq(
+        s"a{$count}" -> 2,
+        s"a{$count,}" -> 2,
+        s"a{1,$count}" -> 4)
+    }.foreach { case (pattern, index) =>
       val e = intercept[RegexUnsupportedException] {
-        new RegexParser(pattern).parseWithoutJavaValidation()
+        new RegexParser(pattern).parseUnchecked()
       }
       assert(e.getMessage ===
         s"Regex quantifier exceeds supported integer range near index $index")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
@@ -16,6 +16,9 @@
 package com.nvidia.spark.rapids
 
 import java.nio.charset.Charset
+import java.util.regex.Pattern
+
+import scala.util.Try
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
@@ -77,6 +80,17 @@ class RegularExpressionSuite extends SparkQueryCompareTestSuite {
     nullableStringsFromCsv, execsAllowedNonGpu = Seq("ProjectExec", "Alias",
       "RegExpReplace", "AttributeReference"), conf = conf) {
     frame => frame.selectExpr("regexp_replace(strings,'','D')")
+  }
+
+  testGpuFallback("String regexp_replace oversized quantifier cpu fall back",
+    "RegExpReplace",
+    nullableStringsFromCsv, execsAllowedNonGpu = Seq("ProjectExec", "Alias",
+      "RegExpReplace", "AttributeReference"), conf = conf) { frame =>
+    // JDK 11 accepts this pattern while newer JDKs reject it before RAPIDS parsing.
+    val pattern = "a{9999999999999999999999999999}"
+    assume(Try(Pattern.compile(pattern)).isSuccess,
+      "Java regex validation rejects the oversized quantifier")
+    frame.selectExpr(s"regexp_replace(strings, '$pattern', 'replacement')")
   }
 
   testSparkResultsAreEqual("String regexp_replace regex 1",


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +4 lines** (`RegexParser.scala`; fix-line coverage from `RegularExpressionParserSuite`, shim 330)

Closes #15495
Contributes to #14733
Related: #15478 (code-adjacent bounded-quantifier refactor; separate root cause)

## What this fixes

On Spark 3.3 with JDK 11, Java accepts a sufficiently long regex quantifier digit run, after which `RegexParser.consumeInt` can leak a raw `NumberFormatException`. That aborts RAPIDS planning even though the CPU `regexp_replace` query succeeds. This change converts the overflow into the parser's normal unsupported-regex diagnostic so metadata can conservatively use the existing CPU bridge fallback.

## Approach

Catch only `NumberFormatException` around the centralized numeric-token conversion in `consumeInt`, then throw a positioned `RegexUnsupportedException` at the digit token's start. The public parser still validates with `Pattern.compile` first. A package-visible `parseUnchecked` method lets the same-package Scala suite test parser-only boundaries independently of host-JDK validation.

The unit suite covers valid `Int.MaxValue`, the first invalid value, and fixed-seed oversized counts in `{n}`, `{n,}`, and `{1,n}` forms. An end-to-end Scala query test runs the fallback path when the host JDK accepts the pattern (JDK 11) and cancels when Java validation rejects it (JDK 17+).

## Whole-system design assessment

Disposition: `LOCAL_FIX`

An out-of-range repetition count has no representable `Int` AST value, so `consumeInt` is the owning invariant boundary. Translating conversion overflow there prevents an invalid node from being constructed and reuses the established `RegexUnsupportedException` fallback path. No parser AST, regex rewrite, serializer, or GPU kernel change is warranted. The active #15478 refactor is code-adjacent but leaves `consumeInt` unchanged, so the root causes and review scopes remain separate.

## Tests added

- Scala unit: `com.nvidia.spark.rapids.RegularExpressionParserSuite` -> `quantifier integer boundaries`
- Scala end-to-end query: `com.nvidia.spark.rapids.RegularExpressionSuite` -> `String regexp_replace oversized quantifier cpu fall back`

## Local validation

```text
JDK 17: Tests: succeeded 60, failed 0, canceled 2, ignored 0, pending 0
JDK 11: Tests: succeeded 61, failed 0, canceled 1, ignored 0, pending 0
All tests passed.
BUILD SUCCESS (both runs)
```

Fix-line coverage:

```text
RegexParser.scala: added=11 covered_by_test=4
FIXLINE_COVERED=4 (of 11 added prod lines)
```

## Performance impact

Cold planning/error path only. In-range tokens retain the same digit scan and `String.toInt`; the new exception translation runs only after conversion already throws. The review follow-up only renames the parser-only entry point, adds a rationale comment, and strengthens unit coverage. There is no row-processing, GPU-kernel, AST-shape, or rewrite-path change, so no benchmark is required.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required