### PR TITLE
[BUG] Fix SpillablePartialFileHandle host memory leak seen in tests only [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillablePartialFileHandle.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillablePartialFileHandle.scala
@@ -124,7 +124,9 @@ class SpillablePartialFileHandle private (
       case e: Exception =>
         logWarning(s"Failed to allocate initial buffer of $initialCapacity bytes, " +
           s"falling back to file-based storage", e)
-        // Fallback to file-based if allocation fails
+        // Close the buffer if it was allocated before the failure so it isn't leaked.
+        host.foreach(_.close())
+        host = None
         spilledToDisk = true
         currentBufferCapacity = 0L
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -187,9 +187,12 @@ object RapidsShuffleInternalManagerBase extends Logging {
     var terminated = false
     try {
       terminated = pool.awaitTermination(5, TimeUnit.SECONDS)
+    } catch {
+      case e: Throwable =>
+        logWarning(s"Exception during shutdown whiel terminating pool ${poolName}", e)
     } finally {
       if (!terminated) {
-        logWarning(s"Thread pool ${poolName} did not terminate within 30 seconds after shutdown")
+        logWarning(s"Thread pool ${poolName} did not terminate within 5 seconds after shutdown")
       }
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -183,6 +183,17 @@ object RapidsShuffleInternalManagerBase extends Logging {
     }
   }
 
+  private def awaitTermination(poolName: String, pool: ExecutorService): Unit = {
+    var terminated = false
+    try {
+      terminated = pool.awaitTermination(5, TimeUnit.SECONDS)
+    } finally {
+      if (!terminated) {
+        logWarning(s"Thread pool ${poolName} did not terminate within 30 seconds after shutdown")
+      }
+    }
+  }
+
   def startThreadPoolIfNeeded(
       numWriterThreads: Int,
       numReaderThreads: Int): Unit = synchronized {
@@ -209,18 +220,27 @@ object RapidsShuffleInternalManagerBase extends Logging {
 
   def stopThreadPool(): Unit = synchronized {
     mtShuffleInitialized = false
+    // Interrupt all pools first so workers receive the signal concurrently.
     if (writerPool != null) {
       shutdownNow(writerPool)
-      writerPool = null
     }
-
     if (readerPool != null) {
       shutdownNow(readerPool)
-      readerPool = null
     }
-
     if (mergerPool != null) {
       shutdownNow(mergerPool)
+    }
+    // Then wait for each pool to drain before releasing shared resources.
+    if (writerPool != null) {
+      awaitTermination("shuffle writer", writerPool)
+      writerPool = null
+    }
+    if (readerPool != null) {
+      awaitTermination("shuffle reader", readerPool)
+      readerPool = null
+    }
+    if (mergerPool != null) {
+      awaitTermination("shuffle merge", mergerPool)
       mergerPool = null
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -189,7 +189,7 @@ object RapidsShuffleInternalManagerBase extends Logging {
       terminated = pool.awaitTermination(5, TimeUnit.SECONDS)
     } catch {
       case e: Throwable =>
-        logWarning(s"Exception during shutdown whiel terminating pool ${poolName}", e)
+        logWarning(s"Exception during shutdown while terminating pool ${poolName}", e)
     } finally {
       if (!terminated) {
         logWarning(s"Thread pool ${poolName} did not terminate within 5 seconds after shutdown")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -188,6 +188,9 @@ object RapidsShuffleInternalManagerBase extends Logging {
     try {
       terminated = pool.awaitTermination(5, TimeUnit.SECONDS)
     } catch {
+      case ie: InterruptedException =>
+        Thread.currentThread.interrupt()
+        logWarning(s"Interrupted while waiting for thread pool ${poolName} to terminate", ie)
       case e: Throwable =>
         logWarning(s"Exception during shutdown while terminating pool ${poolName}", e)
     } finally {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -499,6 +499,7 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
   override def afterEach(): Unit = {
     TaskContext.unset()
+    RapidsShuffleInternalManagerBase.stopThreadPool()
     SpillFramework.shutdown()
     blockIdToFileMap.clear()
     temporaryFilesCreated.clear()
@@ -507,7 +508,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       try { buf.close() } catch { case NonFatal(_) => }
     }
     slicedBuffersToClean.clear()
-    RapidsShuffleInternalManagerBase.stopThreadPool()
     try { Utils.deleteRecursively(tempDir) } catch { case NonFatal(_) => }
   }
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -59,7 +59,8 @@ import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 import ai.rapids.cudf.HostMemoryBuffer
-import com.nvidia.spark.rapids.SlicedSerializedColumnVector
+import com.nvidia.spark.rapids.{RapidsConf, SlicedSerializedColumnVector}
+import com.nvidia.spark.rapids.spill.SpillFramework
 import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
 import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
@@ -441,6 +442,7 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
   override def beforeEach(): Unit = {
     super.beforeEach()
+    SpillFramework.initialize(new RapidsConf(conf))
     RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(numWriterThreads, 0)
     TaskContext.setTaskContext(taskContext)
     MockitoAnnotations.openMocks(this).close()
@@ -497,6 +499,7 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
   override def afterEach(): Unit = {
     TaskContext.unset()
+    SpillFramework.shutdown()
     blockIdToFileMap.clear()
     temporaryFilesCreated.clear()
     // Close sliced buffers to release the refCount added by incRefCountAndGetSize


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark/issues/15499

### Description

Fixes a leak mostly exercised in tests. If this happens in prod, we have way bigger problems. 

I think the leak has been around for a long time, since the spillable file handle was introduced, but some unit tests are making it more likely to fail.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
