### PR TITLE
[AutoSparkUT] Add Spark version metadata to GPU ORC files [fast-ut][reduced-it] [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -28,8 +28,9 @@ import org.apache.orc.OrcConf
 import org.apache.orc.OrcConf._
 import org.apache.orc.mapred.OrcStruct
 
+import org.apache.spark.SPARK_VERSION_SHORT
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SPARK_VERSION_METADATA_KEY, SparkSession}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.orc.{OrcFileFormat, OrcOptions, OrcUtils}
@@ -232,6 +233,7 @@ class GpuOrcWriter(
   override val tableWriter: TableWriter = {
     val builder = SchemaUtils
       .writerOptionsFromSchema(ORCWriterOptions.builder(), dataSchema, nullable = false)
+      .withMetadata(SPARK_VERSION_METADATA_KEY, SPARK_VERSION_SHORT)
       .withCompressionType(CompressionType.valueOf(OrcConf.COMPRESS.getString(conf)))
     orcStripeSizeRows.foreach { ss =>
       builder.withStripeSizeRows(ss)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcQuerySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcQuerySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.mutable.ListBuffer
 
@@ -27,7 +28,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.orc.{OrcFile, StripeInformation}
 import org.apache.orc.impl.RecordReaderImpl
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkContext}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.rapids.{ExecutionPlanCaptureCallback, MyDenseVector, MyDenseVectorUDT}
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
@@ -69,6 +70,33 @@ class OrcQuerySuite extends SparkQueryCompareTestSuite {
       } finally {
         fullyDelete(tempFile)
       }
+    }
+  }
+
+  Seq("orc", "").foreach { v1List =>
+    val sparkConf = new SparkConf().set("spark.sql.sources.useV1SourceList", v1List)
+    test(s"Write Spark version into ORC file metadata, source list is ($v1List)") {
+      withGpuSparkSession({ spark =>
+        withTempPath { path =>
+          ExecutionPlanCaptureCallback.startCapture()
+          spark.range(1).repartition(1).write.orc(path.getCanonicalPath)
+          val plans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
+          assert(plans.nonEmpty, "Did not capture GPU write plan")
+          ExecutionPlanCaptureCallback.assertContains(plans(0), "GpuDataWritingCommandExec")
+
+          val partFiles = path.listFiles()
+            .filter(f => f.isFile && !f.getName.startsWith(".") && !f.getName.startsWith("_"))
+          assert(partFiles.length === 1)
+
+          val orcFilePath = new Path(partFiles.head.getAbsolutePath)
+          val readerOptions = OrcFile.readerOptions(new Configuration())
+          withResourceIfAllowed(OrcFile.createReader(orcFilePath, readerOptions)) { reader =>
+            val version = UTF_8.decode(
+              reader.getMetadataValue("org.apache.spark.version")).toString
+            assert(version === SPARK_VERSION_SHORT)
+          }
+        }
+      }, sparkConf)
     }
   }
 


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +1 line** (`GpuOrcFileFormat.scala`; fix-line coverage, Spark 330)

Closes #15468.

## Summary

- Add `org.apache.spark.version=SPARK_VERSION_SHORT` to GPU-written ORC file metadata, matching Spark CPU output.
- Use Spark's `SPARK_VERSION_METADATA_KEY` and `SPARK_VERSION_SHORT` constants when configuring the libcudf ORC writer.
- Add focused regression coverage for both ORC data-source selection configurations:
  - Data Source V1 forced with `spark.sql.sources.useV1SourceList=orc`.
  - Data Source V2 enabled with `spark.sql.sources.useV1SourceList=""`.
- Assert that the write reaches `GpuDataWritingCommandExec` before checking the generated ORC metadata.

## Root cause

Spark CPU calls `OrcUtils.addSparkVersionMetadata` when creating an ORC writer. `GpuOrcWriter` configured schema and compression options but omitted the Spark-version user-metadata entry.

Both data-source selection paths ultimately use the shared GPU ORC writer, so both produced files without `org.apache.spark.version`.

## Spark test traceability

- RAPIDS tests:
  - `OrcQuerySuite: Write Spark version into ORC file metadata, source list is (orc)` — forced ORC V1 selection.
  - `OrcQuerySuite: Write Spark version into ORC file metadata, source list is ()` — ORC V2 provider selection.
- Original Spark test:
  - `OrcSourceSuite: Write Spark version into ORC file metadata`
  - [Spark 3.3.0 source, lines 370–385](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala#L370-L385)

## Validation

Spark 330 focused GPU Maven package run:

```text
Tests: succeeded 9, failed 0, canceled 1, ignored 0, pending 0
All tests passed.
```

The canceled case is the pre-existing `orc dictionary encoding with lots of rows for nested types` scale-test TODO.

Integration validation on the exact head of migration PR #15466, with only the #15468 and #15469 exclusions removed from both migrated suites:

```text
Tests: succeeded 56, failed 0, canceled 0, ignored 12, pending 0
All tests passed.
BUILD SUCCESS
```

`Write Spark version into ORC file metadata` executed and passed in both `RapidsOrcSourceV1Suite` and `RapidsOrcSourceV2Suite`.

Spark 340 and Spark 400 compile-only gates both completed with `BUILD SUCCESS`. The Spark 400 gate used `scala2.13/pom.xml`.

Scalastyle processed 1,731 files with 0 errors and 0 warnings. The shim coverage check and `git diff --check` also passed.

JaCoCo fix-line intersection:

```text
sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala: added=3 covered_by_test=1
FIXLINE_COVERED=1 (of 3 added prod lines)
```

The two uncovered added text lines are imports and do not have executable JaCoCo probes.

## Performance impact

This adds one fixed key/value metadata entry when each `GpuOrcWriter` is constructed. It adds no per-row or per-batch processing, GPU kernels, device transfers, or additional data columns. The only file-size impact is the small constant ORC user-metadata entry.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
