### PR TITLE
  Use ICEBERG_EXTRA_CLASSPATH for Iceberg REST and S3 Tables tests

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -32,6 +32,26 @@ ARTF_ROOT="$WORKSPACE/jars"
 WGET_CMD="wget -q -P $ARTF_ROOT -t 3"
 PROJECT_REPO_HOST=$(sed -E 's#^(.*://)?([^/@]*@)?([^/:]+).*#\3#' <<< "$PROJECT_REPO")
 
+download_maven_jars() {
+  local coordinates=$1
+  local classpath=""
+  local coordinate
+  local group_id
+  local artifact_id
+  local version
+  local jar_name
+  local -a coordinates_array
+
+  IFS=',' read -ra coordinates_array <<< "$coordinates"
+  for coordinate in "${coordinates_array[@]}"; do
+    IFS=':' read -r group_id artifact_id version <<< "$coordinate"
+    jar_name="${artifact_id}-${version}.jar"
+    $WGET_CMD "$SPARK_REPO/${group_id//.//}/$artifact_id/$version/$jar_name" || return 1
+    classpath="${classpath:+${classpath}:}$ARTF_ROOT/$jar_name"
+  done
+  echo "$classpath"
+}
+
 rm -rf $ARTF_ROOT && mkdir -p $ARTF_ROOT
 $WGET_CMD $PROJECT_TEST_REPO/com/nvidia/rapids-4-spark-integration-tests_$SCALA_BINARY_VER/$PROJECT_TEST_VER/rapids-4-spark-integration-tests_$SCALA_BINARY_VER-$PROJECT_TEST_VER-${SHUFFLE_SPARK_SHIM}.jar
 
@@ -347,19 +367,19 @@ run_iceberg_tests() {
       echo "!!! Running iceberg tests with rest catalog"
       ICEBERG_REST_JARS="org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_${SCALA_BINARY_VER}:${ICEBERG_VERSION},\
 org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
+      ICEBERG_REST_EXTRA_CLASSPATH=$(download_maven_jars "$ICEBERG_REST_JARS")
           # filecache.enabled and perfio.s3.enabled are startup-only configs, so they must
           # be set here via PYSP_TEST_ env vars rather than as session-level Spark configs.
           env \
             HOST_NAME=$PROJECT_REPO_HOST \
             EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
+            ICEBERG_EXTRA_CLASSPATH="${ICEBERG_REST_EXTRA_CLASSPATH}" \
             ICEBERG_TEST_CATALOG_TYPE="rest" \
             ICEBERG_TEST_REMOTE_CATALOG=1 \
             PYSP_TEST_spark_driver_memory=1G \
             PYSP_TEST_spark_executor_memory=2G \
             PYSP_TEST_spark_rapids_filecache_enabled=true \
             PYSP_TEST_spark_rapids_perfio_s3_enabled=true \
-            PYSP_TEST_spark_jars_packages="${ICEBERG_REST_JARS}" \
-            PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
             PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
             PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
             "PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl=org.apache.iceberg.rest.RESTCatalog" \
@@ -392,6 +412,7 @@ software.amazon.awssdk:url-connection-client:${AWS_SDK_VERSION},\
 software.amazon.awssdk:s3tables:${AWS_SDK_VERSION},\
 org.apache.hadoop:hadoop-aws:${HADOOP_AWS_VERSION},\
 com.amazonaws:aws-java-sdk-bundle:${AWS_SDK_BUNDLE_VERSION}"
+      ICEBERG_S3TABLES_EXTRA_CLASSPATH=$(download_maven_jars "$ICEBERG_S3TABLES_JARS")
 
       # Requires to setup s3 buckets and namespaces to run iceberg s3tables tests.
       # These steps are included in the test pipeline.
@@ -402,12 +423,11 @@ com.amazonaws:aws-java-sdk-bundle:${AWS_SDK_BUNDLE_VERSION}"
       env \
         HOST_NAME=$PROJECT_REPO_HOST \
         EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
+        ICEBERG_EXTRA_CLASSPATH="${ICEBERG_S3TABLES_EXTRA_CLASSPATH}" \
         ICEBERG_TEST_REMOTE_CATALOG=1 \
         PYSP_TEST_spark_driver_memory=1G \
         PYSP_TEST_spark_executor_memory=2G \
         PYSP_TEST_spark_rapids_filecache_enabled=true \
-        PYSP_TEST_spark_jars_packages="${ICEBERG_S3TABLES_JARS}" \
-        PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
         PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
         PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
         "PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl=software.amazon.s3tables.iceberg.S3TablesCatalog" \


### PR DESCRIPTION
  Fixes #15508.

  ### Description

  Update the Iceberg REST catalog and S3 Tables test modes to exercise the split-classloader path provided by `ICEBERG_EXTRA_CLASSPATH`.

  This change:

  - Adds a helper to download the existing Maven dependency coordinates as local jars.
  - Passes those local jars through `ICEBERG_EXTRA_CLASSPATH`.
  - Removes `PYSP_TEST_spark_jars_packages` and the associated Ivy settings from the REST and S3 Tables test invocations.
  - Leaves the default Iceberg test mode unchanged.

  ### Checklists

  Documentation

  - [ ] Updated for new or modified user-facing features or behaviors
  - [x] No user-facing change

  Testing

  - [x] Added or modified tests to cover new code paths
  - [ ] Covered by existing tests
  - [ ] Not required

  Validation:

  - `bash -n jenkins/spark-tests.sh`

  Performance

  - [ ] Tests ran and results are added in the PR description
  - [ ] Issue filed with a link in the PR description
  - [x] Not required