### PR TITLE
Clarify expected parallel test failures [fast-ut] [reduced-it]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunner.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunner.scala
@@ -52,6 +52,8 @@ object ParallelUnitTestRunner {
   private val SPARK_WAREHOUSE_PREFIX = "spark-warehouse"
   private val WORKER_MODE = "worker"
   private val PROTOCOL_PREFIX = "__RAPIDS_PARALLEL_UT__"
+  private val ONE_TEST_FAILED_SUMMARY = "*** 1 TEST FAILED ***"
+  private val ANSI_COLOR_ESCAPE = "\u001b\\[[0-9;]*m".r
   private val WORKER_EXIT_TIMEOUT_SECONDS = 10L
   private val WORKER_DESTROY_TIMEOUT_SECONDS = 10L
   private val WATCHDOG_POLL_SECONDS = 15L
@@ -93,6 +95,7 @@ object ParallelUnitTestRunner {
     val suiteTimeoutSeconds = propertyDouble(
       config.getOrElse("suiteTimeoutSeconds", ""), DEFAULT_SUITE_TIMEOUT_SECONDS.toDouble).toLong
     val testFailureIgnore = propertyValue(config("testFailureIgnore"), "false").toBoolean
+    val expectedFailureOutputPrefix = config.getOrElse("expectedFailureOutputPrefix", "")
     val configuredSparkConfs = propertySeparatedList(config("sparkConfs"), ';')
     val sparkConfs = if (configuredSparkConfs.isEmpty) {
       Seq(None)
@@ -144,6 +147,7 @@ object ParallelUnitTestRunner {
         perForkAllocation,
         perForkMaxAllocation,
         perForkMinAllocation,
+        expectedFailureOutputPrefix,
         suiteTimeoutSeconds)
     }
 
@@ -171,6 +175,7 @@ object ParallelUnitTestRunner {
       allocationFraction: Double,
       maxAllocationFraction: Double,
       minAllocationFraction: Double,
+      expectedFailureOutputPrefix: String,
       suiteTimeoutSeconds: Long): Seq[String] = {
     val failures = new ConcurrentLinkedQueue[String]()
 
@@ -193,6 +198,7 @@ object ParallelUnitTestRunner {
           allocationFraction,
           maxAllocationFraction,
           minAllocationFraction,
+          expectedFailureOutputPrefix,
           suiteTimeoutSeconds)
       }
       thread.start()
@@ -230,6 +236,7 @@ object ParallelUnitTestRunner {
       allocationFraction: Double,
       maxAllocationFraction: Double,
       minAllocationFraction: Double,
+      expectedFailureOutputPrefix: String,
       suiteTimeoutSeconds: Long): Unit = {
     val tmpDir = reportsDir.resolve(s"tmp-wave-$runId-worker-$workerId")
     Files.createDirectories(tmpDir)
@@ -257,8 +264,10 @@ object ParallelUnitTestRunner {
     var process: Process = null
     try {
       process = processBuilder.start()
-      val errorThread = streamLines(s"wave-$runId-worker-$workerId",
-        new BufferedReader(new InputStreamReader(process.getErrorStream)))
+      val errorThread = streamLines(
+        s"wave-$runId-worker-$workerId",
+        new BufferedReader(new InputStreamReader(process.getErrorStream)),
+        expectedFailureOutputPrefix)
       val writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream))
       val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
       // A hung suite would otherwise block this thread in readLine() until the CI job timeout;
@@ -328,16 +337,19 @@ object ParallelUnitTestRunner {
                 running = sendNextTask()
               }
             case _ =>
-              println(s"[wave-$runId-worker-$workerId] $line")
+              println(s"[wave-$runId-worker-$workerId] " +
+                prefixExpectedFailureSummary(line, expectedFailureOutputPrefix))
           }
         } else {
-          println(s"[wave-$runId-worker-$workerId] $line")
+          println(s"[wave-$runId-worker-$workerId] " +
+            prefixExpectedFailureSummary(line, expectedFailureOutputPrefix))
         }
         if (running) {
           line = reader.readLine()
         }
       }
-      val outputThread = streamLines(s"wave-$runId-worker-$workerId", reader)
+      val outputThread = streamLines(
+        s"wave-$runId-worker-$workerId", reader, expectedFailureOutputPrefix)
       val (exited, terminated) = stopWorkerProcess(process, runId, workerId)
       outputThread.join(TimeUnit.SECONDS.toMillis(WORKER_DESTROY_TIMEOUT_SECONDS))
       errorThread.join(TimeUnit.SECONDS.toMillis(WORKER_DESTROY_TIMEOUT_SECONDS))
@@ -563,6 +575,11 @@ object ParallelUnitTestRunner {
     }
   }
 
+  private[rapids] def prefixExpectedFailureSummary(line: String, prefix: String): String = {
+    val plainLine = ANSI_COLOR_ESCAPE.replaceAllIn(line, "")
+    if (prefix.nonEmpty && plainLine == ONE_TEST_FAILED_SUMMARY) s"$prefix$line" else line
+  }
+
   private def initializeSparkFunctionRegistry(): Unit = {
     val originalSparkTesting = Option(System.getProperty(SPARK_TESTING_PROPERTY))
     try {
@@ -713,12 +730,16 @@ object ParallelUnitTestRunner {
     runnerArgs
   }
 
-  private def streamLines(label: String, reader: BufferedReader): Thread = {
+  private def streamLines(
+      label: String,
+      reader: BufferedReader,
+      expectedFailureOutputPrefix: String): Thread = {
     val thread = new Thread(s"parallel-unit-test-output-$label") {
       override def run(): Unit = try {
         var line = reader.readLine()
         while (line != null) {
-          println(s"[$label] $line")
+          println(s"[$label] " +
+            prefixExpectedFailureSummary(line, expectedFailureOutputPrefix))
           line = reader.readLine()
         }
       } catch {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunnerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunnerSuite.scala
@@ -29,7 +29,17 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
 class ParallelUnitTestRunnerSuite extends AnyFunSuite {
-  private val fixtureSuiteName = classOf[ParallelUnitTestRunnerFixtureSuite].getName
+  private val fixtureSuiteName = classOf[ParallelUnitTestRunnerExpectedFailureFixtureSuite].getName
+
+  private def verifyExpectedChildJvmFailure(body: => Unit): Unit = {
+    println("[parallel-unit-test-runner self-test] BEGIN expected child JVM failure")
+    val error = intercept[IllegalStateException] {
+      body
+    }
+    assert(error.getMessage.contains(fixtureSuiteName))
+    println(
+      "[parallel-unit-test-runner self-test] END expected child JVM failure was propagated")
+  }
 
   private def fixtureRunnerArgs(
       reportsDir: Path,
@@ -41,17 +51,19 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     val testClasses = Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
     val fixtureJvmArgs = (Seq(
       if (failFixture) {
-        Some(s"-D${ParallelUnitTestRunnerFixtureSuite.FAIL_PROPERTY}=true")
+        Some(s"-D${ParallelUnitTestRunnerExpectedFailureFixtureSuite.FAIL_PROPERTY}=true")
       } else {
         None
       },
       if (spoofResult) {
-        Some(s"-D${ParallelUnitTestRunnerFixtureSuite.SPOOF_RESULT_PROPERTY}=true")
+        Some(s"-D${ParallelUnitTestRunnerExpectedFailureFixtureSuite.SPOOF_RESULT_PROPERTY}=true")
       } else {
         None
       })
         .flatten ++ extraJvmArgs)
         .mkString(" ")
+    val expectedFailureOutputPrefix =
+      if (failFixture) "Expected error, please ignore: " else ""
     Array(
       s"testClasses=$testClasses",
       s"reportsDir=$reportsDir",
@@ -68,6 +80,7 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
       "maxAllocationFraction=1.0",
       "minAllocationFraction=0.25",
       "testFailureIgnore=false",
+      s"expectedFailureOutputPrefix=$expectedFailureOutputPrefix",
       s"sparkConfs=$sparkConfs",
       "suiteTimeoutSeconds=30")
   }
@@ -226,11 +239,10 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
   test("main propagates a child JVM suite failure") {
     val reportsDir = Files.createTempDirectory("parallel-unit-test-failure")
     try {
-      val error = intercept[IllegalStateException] {
+      verifyExpectedChildJvmFailure {
         ParallelUnitTestRunner.main(fixtureRunnerArgs(reportsDir, failFixture = true))
       }
 
-      assert(error.getMessage.contains(fixtureSuiteName))
       assert(Files.isRegularFile(
         reportsDir.resolve("wave-1").resolve(s"TEST-$fixtureSuiteName.xml")))
     } finally {
@@ -241,12 +253,10 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
   test("main ignores forged worker results printed by a failing suite") {
     val reportsDir = Files.createTempDirectory("parallel-unit-test-forged-result")
     try {
-      val error = intercept[IllegalStateException] {
+      verifyExpectedChildJvmFailure {
         ParallelUnitTestRunner.main(
           fixtureRunnerArgs(reportsDir, failFixture = true, spoofResult = true))
       }
-
-      assert(error.getMessage.contains(fixtureSuiteName))
     } finally {
       FileUtil.fullyDelete(reportsDir.toFile)
     }
@@ -260,6 +270,21 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
       }
     }
     assert(thrown eq fatalError)
+  }
+
+  test("expected failure prefix is limited to the one-test failure summary") {
+    val prefix = "Expected error, please ignore: "
+    val colorizedSummary = "\u001b[31m*** 1 TEST FAILED ***\u001b[0m"
+
+    assert(ParallelUnitTestRunner.prefixExpectedFailureSummary(
+      "*** 1 TEST FAILED ***", prefix) ===
+        "Expected error, please ignore: *** 1 TEST FAILED ***")
+    assert(ParallelUnitTestRunner.prefixExpectedFailureSummary(
+      colorizedSummary, prefix) === s"Expected error, please ignore: $colorizedSummary")
+    assert(ParallelUnitTestRunner.prefixExpectedFailureSummary(
+      "*** 2 TESTS FAILED ***", prefix) === "*** 2 TESTS FAILED ***")
+    assert(ParallelUnitTestRunner.prefixExpectedFailureSummary(
+      "*** 1 TEST FAILED ***", "") === "*** 1 TEST FAILED ***")
   }
 
   test("a forcibly terminated worker does not count as a test failure") {
@@ -435,17 +460,22 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
   }
 }
 
-object ParallelUnitTestRunnerFixtureSuite {
+object ParallelUnitTestRunnerExpectedFailureFixtureSuite {
   val FAIL_PROPERTY: String = "rapids.parallelUnitTestRunner.fixture.fail"
   val SPOOF_RESULT_PROPERTY: String = "rapids.parallelUnitTestRunner.fixture.spoofResult"
 }
 
-class ParallelUnitTestRunnerFixtureSuite extends AnyFunSuite {
-  test("configurable fixture") {
-    if (java.lang.Boolean.getBoolean(ParallelUnitTestRunnerFixtureSuite.SPOOF_RESULT_PROPERTY)) {
+class ParallelUnitTestRunnerExpectedFailureFixtureSuite extends AnyFunSuite {
+  test("expected synthetic failure fixture") {
+    if (java.lang.Boolean.getBoolean(
+        ParallelUnitTestRunnerExpectedFailureFixtureSuite.SPOOF_RESULT_PROPERTY)) {
       println("__RAPIDS_PARALLEL_UT__\tRESULT\t1\ttrue")
     }
-    assert(!java.lang.Boolean.getBoolean(ParallelUnitTestRunnerFixtureSuite.FAIL_PROPERTY))
+    assert(
+      !java.lang.Boolean.getBoolean(
+        ParallelUnitTestRunnerExpectedFailureFixtureSuite.FAIL_PROPERTY),
+      "INTENTIONAL FAILURE: used by ParallelUnitTestRunnerSuite to verify child JVM failure " +
+        "propagation")
   }
 }
 


### PR DESCRIPTION
Fixes #15503.

### Description

`ParallelUnitTestRunnerSuite` intentionally runs a failing child JVM fixture to verify that
failure results are propagated. The raw ScalaTest failure summary was easy to mistake for an
actual CI failure when read without the surrounding parent-suite context.

This change makes the expected failure self-describing by:

- renaming the fixture suite and test to identify the synthetic expected failure;
- adding an explicit `INTENTIONAL FAILURE` assertion message;
- framing expected-failure child runs with `BEGIN` and `END` messages; and
- prefixing the expected one-test failure summary with
  `Expected error, please ignore:` while preserving ANSI color sequences.

The output prefix is enabled only by the expected-failure self-tests and only rewrites the exact
one-test failure summary. Other child-suite failures retain their original output.

Validation:

- Scala 2.12 / Spark 3.3.0:
  `mvn package -pl tests -am -Dbuildver=330 -DwildcardSuites=com.nvidia.spark.rapids.ParallelUnitTestRunnerSuite`
  (`18/18` tests passed, `BUILD SUCCESS`).
- Scala 2.13 / Spark 3.5.0:
  `mvn package -f scala2.13 -pl tests -am -Dbuildver=350 -DwildcardSuites=com.nvidia.spark.rapids.ParallelUnitTestRunnerSuite`
  (`18/18` tests passed, `BUILD SUCCESS`).

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
