### PR TITLE
[AutoSparkUT] Migrate ten Spark SQL suites [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDisableUnnecessaryBucketedScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDisableUnnecessaryBucketedScanSuite.scala
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+import org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+import org.apache.spark.sql.sources.{
+  DisableUnnecessaryBucketedScanSuite,
+  DisableUnnecessaryBucketedScanWithoutHiveSupportSuite,
+  DisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE
+}
+
+private[suites] trait RapidsDisableUnnecessaryBucketedScanTests {
+  self: DisableUnnecessaryBucketedScanSuite with RapidsSQLTestsTrait =>
+
+  import testImplicits._
+
+  private lazy val rapidsDf1 =
+    (0 until 50).map(i => (i % 5, i % 13, i.toString)).toDF("i", "j", "k").as("df1")
+  private lazy val rapidsDf2 =
+    (0 until 50).map(i => (i % 7, i % 11, i.toString)).toDF("i", "j", "k").as("df2")
+
+  private def checkDisableBucketedScanRapids(
+      query: String,
+      expectedNumScanWithAutoScanEnabled: Int,
+      expectedNumScanWithAutoScanDisabled: Int): Unit = {
+
+    def checkNumBucketedScan(expectedNumBucketedScans: Int): Unit = {
+      val plan = sql(query).queryExecution.executedPlan
+      val bucketedScans = collect(plan) {
+        case scan: GpuFileSourceScanExec if scan.bucketedScan => scan
+        case scan: FileSourceScanExec if scan.bucketedScan => scan
+      }
+      assert(bucketedScans.length == expectedNumBucketedScans,
+        s"Expected $expectedNumBucketedScans bucketed scans, found " +
+          s"${bucketedScans.length}:\n$plan")
+    }
+
+    withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "true") {
+      checkNumBucketedScan(expectedNumScanWithAutoScanEnabled)
+      val result = sql(query).collect()
+
+      withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "false") {
+        checkNumBucketedScan(expectedNumScanWithAutoScanDisabled)
+        checkAnswer(sql(query), result)
+      }
+    }
+  }
+
+  testRapids("SPARK-32859: disable unnecessary bucketed table scan - basic test") {
+    withTable("t1", "t2", "t3") {
+      rapidsDf1.write.format("parquet").bucketBy(8, "i").saveAsTable("t1")
+      rapidsDf2.write.format("parquet").bucketBy(8, "i").saveAsTable("t2")
+      rapidsDf2.write.format("parquet").bucketBy(4, "i").saveAsTable("t3")
+
+      Seq(
+        // Read bucketed table
+        ("SELECT * FROM t1", 0, 1),
+        ("SELECT i FROM t1", 0, 1),
+        ("SELECT j FROM t1", 0, 0),
+        // Filter on bucketed column
+        ("SELECT * FROM t1 WHERE i = 1", 0, 1),
+        // Filter on non-bucketed column
+        ("SELECT * FROM t1 WHERE j = 1", 0, 1),
+        // Join with same buckets
+        ("SELECT /*+ broadcast(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.i", 0, 2),
+        ("SELECT /*+ shuffle_hash(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.i", 2, 2),
+        ("SELECT /*+ merge(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.i", 2, 2),
+        // Join with different buckets
+        ("SELECT /*+ broadcast(t1)*/ * FROM t1 JOIN t3 ON t1.i = t3.i", 0, 2),
+        ("SELECT /*+ shuffle_hash(t1)*/ * FROM t1 JOIN t3 ON t1.i = t3.i", 1, 2),
+        ("SELECT /*+ merge(t1)*/ * FROM t1 JOIN t3 ON t1.i = t3.i", 1, 2),
+        // Join on non-bucketed column
+        ("SELECT /*+ broadcast(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.j", 0, 2),
+        ("SELECT /*+ shuffle_hash(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.j", 1, 2),
+        ("SELECT /*+ merge(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.j", 1, 2),
+        ("SELECT /*+ broadcast(t1)*/ * FROM t1 JOIN t2 ON t1.j = t2.j", 0, 2),
+        ("SELECT /*+ shuffle_hash(t1)*/ * FROM t1 JOIN t2 ON t1.j = t2.j", 0, 2),
+        ("SELECT /*+ merge(t1)*/ * FROM t1 JOIN t2 ON t1.j = t2.j", 0, 2),
+        // Aggregate on bucketed column
+        ("SELECT SUM(i) FROM t1 GROUP BY i", 1, 1),
+        // Aggregate on non-bucketed column
+        ("SELECT SUM(i) FROM t1 GROUP BY j", 0, 1),
+        ("SELECT j, SUM(i), COUNT(j) FROM t1 GROUP BY j", 0, 1)
+      ).foreach { case (query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled) =>
+        checkDisableBucketedScanRapids(
+          query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled)
+      }
+    }
+  }
+
+  testRapids("SPARK-32859: disable unnecessary bucketed table scan - multiple joins test") {
+    withTable("t1", "t2", "t3") {
+      rapidsDf1.write.format("parquet").bucketBy(8, "i").saveAsTable("t1")
+      rapidsDf2.write.format("parquet").bucketBy(8, "i").saveAsTable("t2")
+      rapidsDf2.write.format("parquet").bucketBy(4, "i").saveAsTable("t3")
+
+      Seq(
+        // Multiple joins on bucketed columns
+        ("""
+           |SELECT /*+ broadcast(t1, t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.i = t2.i AND t2.i = t3.i
+           |""".stripMargin, 0, 3),
+        ("""
+           |SELECT /*+ broadcast(t1) merge(t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.i = t2.i AND t2.i = t3.i
+           |""".stripMargin, 2, 3),
+        ("""
+           |SELECT /*+ merge(t1) broadcast(t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.i = t2.i AND t2.i = t3.i
+           |""".stripMargin, 2, 3),
+        ("""
+           |SELECT /*+ merge(t1, t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.i = t2.i AND t2.i = t3.i
+           |""".stripMargin, 2, 3),
+        // Multiple joins on non-bucketed columns
+        ("""
+           |SELECT /*+ broadcast(t1, t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.i = t2.j AND t2.j = t3.i
+           |""".stripMargin, 0, 3),
+        ("""
+           |SELECT /*+ merge(t1, t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.i = t2.j AND t2.j = t3.i
+           |""".stripMargin, 1, 3),
+        ("""
+           |SELECT /*+ merge(t1, t3)*/ * FROM t1 JOIN t2 JOIN t3
+           |ON t1.j = t2.j AND t2.j = t3.j
+           |""".stripMargin, 0, 3)
+      ).foreach { case (query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled) =>
+        checkDisableBucketedScanRapids(
+          query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled)
+      }
+    }
+  }
+
+  testRapids(
+    "SPARK-32859: disable unnecessary bucketed table scan - multiple bucketed columns test") {
+    withTable("t1", "t2", "t3") {
+      rapidsDf1.write.format("parquet").bucketBy(8, "i", "j").saveAsTable("t1")
+      rapidsDf2.write.format("parquet").bucketBy(8, "i", "j").saveAsTable("t2")
+      rapidsDf2.write.format("parquet").bucketBy(4, "i", "j").saveAsTable("t3")
+
+      Seq(
+        // Filter on bucketed columns
+        ("SELECT * FROM t1 WHERE i = 1", 0, 1),
+        ("SELECT * FROM t1 WHERE i = 1 AND j = 1", 0, 1),
+        // Join on bucketed columns
+        ("""
+           |SELECT /*+ broadcast(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.i AND t1.j = t2.j
+           |""".stripMargin, 0, 2),
+        ("""
+           |SELECT /*+ merge(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.i AND t1.j = t2.j
+           |""".stripMargin, 2, 2),
+        ("""
+           |SELECT /*+ merge(t1)*/ * FROM t1 JOIN t3 ON t1.i = t3.i AND t1.j = t3.j
+           |""".stripMargin, 1, 2),
+        ("SELECT /*+ merge(t1)*/ * FROM t1 JOIN t2 ON t1.i = t2.i", 0, 2),
+        // Aggregate on bucketed columns
+        ("SELECT i, j, COUNT(*) FROM t1 GROUP BY i, j", 1, 1),
+        ("SELECT i, COUNT(i) FROM t1 GROUP BY i", 0, 0),
+        ("SELECT i, COUNT(j) FROM t1 GROUP BY i", 0, 1)
+      ).foreach { case (query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled) =>
+        checkDisableBucketedScanRapids(
+          query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled)
+      }
+    }
+  }
+
+  testRapids("SPARK-32859: disable unnecessary bucketed table scan - other operators test") {
+    withTable("t1", "t2", "t3") {
+      rapidsDf1.write.format("parquet").bucketBy(8, "i").saveAsTable("t1")
+      rapidsDf2.write.format("parquet").bucketBy(8, "i").saveAsTable("t2")
+      rapidsDf1.write.format("parquet").saveAsTable("t3")
+
+      Seq(
+        // Operator with interesting partition not in sub-plan
+        ("""
+           |SELECT t1.i FROM t1
+           |UNION ALL
+           |(SELECT t2.i FROM t2 GROUP BY t2.i)
+           |""".stripMargin, 1, 2),
+        // Non-allowed operator in sub-plan
+        ("""
+           |SELECT COUNT(*)
+           |FROM (SELECT t1.i FROM t1 UNION ALL SELECT t2.i FROM t2)
+           |GROUP BY i
+           |""".stripMargin, 2, 2),
+        // Multiple Exchange operators in sub-plan
+        ("""
+           |SELECT j, SUM(i), COUNT(*) FROM t1 GROUP BY j
+           |DISTRIBUTE BY j
+           |""".stripMargin, 0, 1),
+        ("""
+           |SELECT j, COUNT(*)
+           |FROM (SELECT i, j FROM t1 DISTRIBUTE BY i, j)
+           |GROUP BY j
+           |""".stripMargin, 0, 1),
+        // No bucketed table scan in plan
+        ("""
+           |SELECT j, COUNT(*)
+           |FROM (SELECT t1.j FROM t1 JOIN t3 ON t1.j = t3.j)
+           |GROUP BY j
+           |""".stripMargin, 0, 0)
+      ).foreach { case (query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled) =>
+        checkDisableBucketedScanRapids(
+          query, numScanWithAutoScanEnabled, numScanWithAutoScanDisabled)
+      }
+    }
+  }
+
+  testRapids("SPARK-33075: not disable bucketed table scan for cached query") {
+    withTable("t1") {
+      withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "true") {
+        rapidsDf1.write.format("parquet").bucketBy(8, "i").saveAsTable("t1")
+        spark.catalog.cacheTable("t1")
+        assertCached(spark.table("t1"))
+
+        val partitioning = stripAQEPlan(spark.table("t1").queryExecution.executedPlan)
+          .outputPartitioning
+        assert(partitioning match {
+          case HashPartitioning(Seq(column: AttributeReference), 8) if column.name == "i" => true
+          case _ => false
+        })
+
+        val aggregateQuery = sql("SELECT SUM(i) FROM t1 GROUP BY i")
+        checkAnswer(aggregateQuery, Seq(Row(0L), Row(10L), Row(20L), Row(30L), Row(40L)))
+        val aggregateQueryPlan = aggregateQuery.queryExecution.executedPlan
+        val shuffles = collect(aggregateQueryPlan) {
+          case shuffle: GpuShuffleExchangeExecBase => shuffle
+          case shuffle: ShuffleExchangeExec => shuffle
+        }
+        assert(shuffles.isEmpty,
+          s"Expected no CPU or GPU shuffle exchange for cached bucketed data:\n$aggregateQueryPlan")
+      }
+    }
+  }
+
+  testRapids("Aggregates with no groupby over tables having 1 BUCKET, return multiple rows") {
+    withTable("t1") {
+      withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "true") {
+        sql(
+          """
+            |CREATE TABLE t1 (id BIGINT, event_date DATE)
+            |USING PARQUET
+            |CLUSTERED BY (id)
+            |INTO 1 BUCKETS
+            |""".stripMargin)
+        sql(
+          """
+            |INSERT INTO TABLE t1 VALUES(1.23, cast("2021-07-07" as date))
+            |""".stripMargin)
+        sql(
+          """
+            |INSERT INTO TABLE t1 VALUES(2.28, cast("2021-08-08" as date))
+            |""".stripMargin)
+        val df = spark.sql("select sum(id) from t1 where id is not null")
+        assert(df.count == 1)
+        checkDisableBucketedScanRapids(
+          query = "SELECT SUM(id) FROM t1 WHERE id is not null",
+          expectedNumScanWithAutoScanEnabled = 1,
+          expectedNumScanWithAutoScanDisabled = 1)
+      }
+    }
+  }
+}
+
+class RapidsDisableUnnecessaryBucketedScanWithoutHiveSupportSuite
+  extends DisableUnnecessaryBucketedScanWithoutHiveSupportSuite
+  with RapidsSQLTestsTrait
+  with RapidsDisableUnnecessaryBucketedScanTests
+
+class RapidsDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE
+  extends DisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE
+  with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDisableUnnecessaryBucketedScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDisableUnnecessaryBucketedScanSuite.scala
@@ -19,7 +19,7 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.FileSourceScanExec
@@ -49,9 +49,9 @@ private[suites] trait RapidsDisableUnnecessaryBucketedScanTests {
       expectedNumScanWithAutoScanEnabled: Int,
       expectedNumScanWithAutoScanDisabled: Int): Unit = {
 
-    def checkNumBucketedScan(expectedNumBucketedScans: Int): Unit = {
-      val plan = sql(query).queryExecution.executedPlan
-      val bucketedScans = collect(plan) {
+    def checkNumBucketedScan(df: DataFrame, expectedNumBucketedScans: Int): Unit = {
+      val plan = df.queryExecution.executedPlan
+      val bucketedScans = plan.collect {
         case scan: GpuFileSourceScanExec if scan.bucketedScan => scan
         case scan: FileSourceScanExec if scan.bucketedScan => scan
       }
@@ -61,12 +61,14 @@ private[suites] trait RapidsDisableUnnecessaryBucketedScanTests {
     }
 
     withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "true") {
-      checkNumBucketedScan(expectedNumScanWithAutoScanEnabled)
-      val result = sql(query).collect()
+      val autoScanEnabledQuery = sql(query)
+      checkNumBucketedScan(autoScanEnabledQuery, expectedNumScanWithAutoScanEnabled)
+      val result = autoScanEnabledQuery.collect()
 
       withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "false") {
-        checkNumBucketedScan(expectedNumScanWithAutoScanDisabled)
-        checkAnswer(sql(query), result)
+        val autoScanDisabledQuery = sql(query)
+        checkNumBucketedScan(autoScanDisabledQuery, expectedNumScanWithAutoScanDisabled)
+        checkAnswer(autoScanDisabledQuery, result)
       }
     }
   }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileFormatWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileFormatWriterSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.execution.datasources.FileFormatWriterSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsFileFormatWriterSuite
+  extends FileFormatWriterSuite
+  with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileMetadataStructSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileMetadataStructSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.execution.datasources.FileMetadataStructSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsFileMetadataStructSuite extends FileMetadataStructSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsMetadataCacheSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsMetadataCacheSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.{MetadataCacheV1Suite, MetadataCacheV2Suite}
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsMetadataCacheV1Suite extends MetadataCacheV1Suite with RapidsSQLTestsTrait
+
+class RapidsMetadataCacheV2Suite extends MetadataCacheV2Suite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcPartitionDiscoverySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcPartitionDiscoverySuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.execution.datasources.orc.{
+  OrcPartitionDiscoverySuite,
+  OrcV1PartitionDiscoverySuite}
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsOrcPartitionDiscoverySuite
+    extends OrcPartitionDiscoverySuite with RapidsSQLTestsTrait
+
+class RapidsOrcV1PartitionDiscoverySuite
+    extends OrcV1PartitionDiscoverySuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSQLInsertTestSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSQLInsertTestSuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.{DSV2SQLInsertTestSuite, FileSourceSQLInsertTestSuite}
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsFileSourceSQLInsertTestSuite
+    extends FileSourceSQLInsertTestSuite with RapidsSQLTestsTrait
+
+class RapidsDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -238,6 +238,53 @@ class RapidsTestSettings extends BackendTestSettings {
         "Recovery trigger: the Spark test accepts the GPU V1 scan node; P2."))
   enableSuite[RapidsV1ReadFallbackWithDataFrameReaderSuite]
   enableSuite[RapidsV1ReadFallbackWithCatalogSuite]
+  enableSuite[RapidsFileMetadataStructSuite]
+  enableSuite[RapidsDisableUnnecessaryBucketedScanWithoutHiveSupportSuite]
+    .exclude("SPARK-32859: disable unnecessary bucketed table scan - basic test",
+      ADJUST_UT("Replaced by GPU-aware testRapids coverage. See " +
+        "https://github.com/NVIDIA/cudf-spark/issues/15512. Recovery trigger: upstream Spark " +
+        "plan assertions become implementation agnostic; P2."))
+    .exclude("SPARK-32859: disable unnecessary bucketed table scan - multiple joins test",
+      ADJUST_UT("Replaced by GPU-aware testRapids coverage. See " +
+        "https://github.com/NVIDIA/cudf-spark/issues/15512. Recovery trigger: upstream Spark " +
+        "plan assertions become implementation agnostic; P2."))
+    .exclude(
+      "SPARK-32859: disable unnecessary bucketed table scan - multiple bucketed columns test",
+      ADJUST_UT("Replaced by GPU-aware testRapids coverage. See " +
+        "https://github.com/NVIDIA/cudf-spark/issues/15512. Recovery trigger: upstream Spark " +
+        "plan assertions become implementation agnostic; P2."))
+    .exclude("SPARK-32859: disable unnecessary bucketed table scan - other operators test",
+      ADJUST_UT("Replaced by GPU-aware testRapids coverage. See " +
+        "https://github.com/NVIDIA/cudf-spark/issues/15512. Recovery trigger: upstream Spark " +
+        "plan assertions become implementation agnostic; P2."))
+    .exclude("SPARK-33075: not disable bucketed table scan for cached query",
+      ADJUST_UT("Replaced by testRapids coverage that checks CPU and GPU shuffle nodes. " +
+        "See https://github.com/NVIDIA/cudf-spark/issues/15512. Recovery trigger: upstream " +
+        "Spark plan assertions become implementation agnostic; P2."))
+    .exclude("Aggregates with no groupby over tables having 1 BUCKET, return multiple rows",
+      ADJUST_UT("Replaced by GPU-aware testRapids coverage. See " +
+        "https://github.com/NVIDIA/cudf-spark/issues/15512. Recovery trigger: upstream Spark " +
+        "plan assertions become implementation agnostic; P2."))
+  enableSuite[RapidsDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE]
+  enableSuite[RapidsOrcPartitionDiscoverySuite]
+  enableSuite[RapidsOrcV1PartitionDiscoverySuite]
+  enableSuite[RapidsFileFormatWriterSuite]
+  enableSuite[RapidsFileSourceSQLInsertTestSuite]
+  enableSuite[RapidsDSV2SQLInsertTestSuite]
+  enableSuite[RapidsMetadataCacheV1Suite]
+    .exclude("SPARK-16336,SPARK-27961 Suggest fixing FileNotFoundException",
+      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15511. " +
+        "Recovery trigger: GPU ORC V1 missing-file errors include Spark-equivalent recreate " +
+        "guidance; P1."))
+    .exclude("SPARK-16337 temporary view refresh",
+      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15511. " +
+        "Recovery trigger: GPU ORC V1 missing-file errors include Spark-equivalent REFRESH " +
+        "and recreate guidance; P1."))
+  enableSuite[RapidsMetadataCacheV2Suite]
+    .exclude("SPARK-16336,SPARK-27961 Suggest fixing FileNotFoundException",
+      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15511. " +
+        "Recovery trigger: GPU ORC V2 missing-file errors include Spark-equivalent recreate " +
+        "guidance; P1."))
   enableSuite[RapidsFileSourceStrategySuite]
     .exclude("partitioned table - after scan filters", ADJUST_UT("Replaced by testRapids version that checks GpuFilterExec residual filters."))
     .exclude("[SPARK-16818] partition pruned file scans implement sameResult correctly", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15161"))


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: not measurable locally — Spark 3.3-only suites are not selected by the mandatory shim 350 coverage rig**

Closes #15514

## Summary

Migrate ten eligible Spark 3.3 SQL suites in one PR:

- `FileMetadataStructSuite`
- `DisableUnnecessaryBucketedScanWithoutHiveSupportSuite`
- `DisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE`
- `OrcPartitionDiscoverySuite`
- `OrcV1PartitionDiscoverySuite`
- `FileFormatWriterSuite`
- `FileSourceSQLInsertTestSuite`
- `DSV2SQLInsertTestSuite`
- `MetadataCacheV1Suite`
- `MetadataCacheV2Suite`

All wrappers use `RapidsSQLTestsTrait` and are registered in `RapidsTestSettings`.

## Spark source traceability

Spark 3.3.0 commit `f74867bddfbcdd4d08076db36851e88b15e66556` is the authoritative compatibility source. Current Spark master lineage was refreshed at `a519c97a2c02f8760f51526fd31d86411e23183f`.

| RAPIDS suite | Spark 3.3.0 source | Current master lineage | Source registrations | Executed |
|---|---|---|---:|---:|
| `RapidsFileMetadataStructSuite` | [`FileMetadataStructSuite` L31-L567](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala#L31-L567) | [L36-L1230](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala#L36-L1230) | 42 dynamic | 42 |
| `RapidsDisableUnnecessaryBucketedScanWithoutHiveSupportSuite` | [`concrete` L30-L39](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L30-L39), [`shared` L52-L287](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L52-L287) | [L29-L268](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L29-L268) | 6 | 6 |
| `RapidsDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE` | [`concrete` L41-L50](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L41-L50), [`shared` L52-L287](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L52-L287) | [L41-L268](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L41-L268) | 6 | 6 |
| `RapidsOrcPartitionDiscoverySuite` | [`shared` L39-L169](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala#L39-L169), [`concrete` L171-L255](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala#L171-L255) | [L40-L256](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala#L40-L256) | 5 | 5 |
| `RapidsOrcV1PartitionDiscoverySuite` | [`shared` L39-L169](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala#L39-L169), [`concrete` L257-L344](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala#L257-L344) | [L258-L345](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala#L258-L345) | 5 | 5 |
| `RapidsFileFormatWriterSuite` | [`FileFormatWriterSuite` L24-L80](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala#L24-L80) | [L24-L79](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala#L24-L79) | 4 | 8 |
| `RapidsFileSourceSQLInsertTestSuite` | [`shared` L30-L332](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala#L30-L332), [`concrete` L334-L339](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala#L334-L339) | [L35-L624](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala#L35-L624) | 13 | 13 |
| `RapidsDSV2SQLInsertTestSuite` | [`shared` L30-L332](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala#L30-L332), [`concrete` L341-L350](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala#L341-L350) | [L35-L657](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala#L35-L657) | 13 | 13 |
| `RapidsMetadataCacheV1Suite` | [`shared` L29-L62](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala#L29-L62), [`concrete` L64-L120](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala#L64-L120) | [L29-L130](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala#L29-L130) | 3 | 3 |
| `RapidsMetadataCacheV2Suite` | [`shared` L29-L62](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala#L29-L62), [`concrete` L122-L127](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala#L122-L127) | [L29-L137](https://github.com/apache/spark/blob/a519c97a2c02f8760f51526fd31d86411e23183f/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala#L29-L137) | 1 | 1 |
| **Total** |  |  | **98** | **102** |

`FileMetadataStructSuite` dynamically registers 42 cases. `FileFormatWriterSuite` expands four source declarations into codegen and interpreted variants, producing eight executions. Inherited test names remain unchanged.

The six RAPIDS replacements map one-to-one to the same Spark test names and preserve the original query matrices:

- `Rapids - SPARK-32859: disable unnecessary bucketed table scan - basic test` → [Spark L86-L125](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L86-L125)
- `Rapids - SPARK-32859: disable unnecessary bucketed table scan - multiple joins test` → [Spark L127-L168](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L127-L168)
- `Rapids - SPARK-32859: disable unnecessary bucketed table scan - multiple bucketed columns test` → [Spark L170-L199](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L170-L199)
- `Rapids - SPARK-32859: disable unnecessary bucketed table scan - other operators test` → [Spark L201-L240](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L201-L240)
- `Rapids - SPARK-33075: not disable bucketed table scan for cached query` → [Spark L242-L260](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L242-L260)
- `Rapids - Aggregates with no groupby over tables having 1 BUCKET, return multiple rows` → [Spark L262-L286](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala#L262-L286)

## Remediation and deferred cases

- Six non-AQE bucketed originals are replaced by GPU-aware tests that accept both `GpuFileSourceScanExec` and CPU `FileSourceScanExec`, preserve result checks, and check both CPU/GPU shuffle nodes for cached data. Dedicated `ADJUST_UT` issue: #15512.
- Three MetadataCache originals retain their strict Spark recovery-guidance assertions and are deferred without weakening semantics. Dedicated `KNOWN_ISSUE`: #15511.
- The batch tracking issue is not used as exclusion evidence.

## Validation

Focused runs:

```text
RapidsMetadataCacheV1Suite + V2Suite: succeeded 1, failed 0, ignored 3
Bucketed non-AQE selector (including matching AE suite): succeeded 12, failed 0, ignored 6
```

Final combined Spark 3.3 GPU Maven package run:

```text
Tests: succeeded 99, failed 0, canceled 0, ignored 9, pending 0
BUILD SUCCESS
```

Full repository ScalaStyle:

```text
Processed 1746 file(s)
Found 0 errors
Found 0 warnings
BUILD SUCCESS
```

## Coverage measurement

A `buildver=350` Maven package run with the same suite selector completed successfully and reported:

```text
Expected test count is: 0
Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

These wrappers are confined to the `spark330` source set. A Spark 3.3 JaCoCo exec cannot be merged against shim 350 nightly classfiles without invalid probe mappings, so no line delta is reported.

## Scope markers

This PR changes only `tests/src/test/spark330` wrappers and registration. It does not touch production, shared, or Databricks-specific code. Migration-UT PRs do not use the Databricks title marker.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
