### PR TITLE
Avoid shell command injection in databricks CI scripts [fast-ut][reduced-it][databricks]

### DIFF
--- a/jenkins/databricks/run-build.py
+++ b/jenkins/databricks/run-build.py
@@ -17,9 +17,14 @@ import sys
 import getopt
 import time
 import os
+import shlex
 import subprocess
 from clusterutils import ClusterUtils
 import params
+
+def shell_join(args):
+  """Return shell-escaped command arguments."""
+  return ' '.join(shlex.quote(arg) for arg in args)
 
 def main():
   master_addr = ClusterUtils.cluster_get_master_addr(params.workspace, params.clusterid, params.token)
@@ -29,29 +34,44 @@ def main():
   print("Master node address is: %s" % master_addr)
 
   print("Copying script")
-  ssh_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2200 -i %s" % params.private_key_file
-  rsync_command = "rsync -I -Pave \"ssh %s\" %s ubuntu@%s:%s" % (ssh_args, params.local_script, master_addr, params.script_dest)
-  print("rsync command: %s" % rsync_command)
-  subprocess.check_call(rsync_command, shell = True)
+  ssh_args = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+              "-p", "2200", "-i", params.private_key_file]
+  rsync_ssh = shell_join(["ssh"] + ssh_args)
+  rsync_command = ["rsync", "-I", "-Pave", rsync_ssh, "--", params.local_script,
+                   "ubuntu@%s:%s" % (master_addr, params.script_dest)]
+  print("rsync command: %s" % shell_join(rsync_command))
+  subprocess.check_call(rsync_command)
 
   print("Copying source")
-  rsync_command = "rsync -I -Pave \"ssh %s\" %s ubuntu@%s:%s" % (ssh_args, params.source_tgz, master_addr, params.tgz_dest)
-  print("rsync command: %s" % rsync_command)
-  subprocess.check_call(rsync_command, shell = True)
+  rsync_command = ["rsync", "-I", "-Pave", rsync_ssh, "--", params.source_tgz,
+                   "ubuntu@%s:%s" % (master_addr, params.tgz_dest)]
+  print("rsync command: %s" % shell_join(rsync_command))
+  subprocess.check_call(rsync_command)
 
-  ssh_command = "ssh %s ubuntu@%s " % (ssh_args, master_addr) + \
-        "'SPARKSRCTGZ=%s BASE_SPARK_VERSION=%s BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS=%s MVN_OPT=%s EXTRA_ENVS=%s \
-        bash %s %s 2>&1 | tee buildout; if [ `echo ${PIPESTATUS[0]}` -ne 0 ]; then false; else true; fi'" % \
-        (params.tgz_dest, params.base_spark_pom_version, params.base_spark_version_to_install_databricks_jars, params.mvn_opt, params.extra_envs, params.script_dest, ' '.join(params.script_args))
-  print("ssh command: %s" % ssh_command)
-  subprocess.check_call(ssh_command, shell = True)
+  build_command = shell_join([
+      "env",
+      "SPARKSRCTGZ=%s" % params.tgz_dest,
+      "BASE_SPARK_VERSION=%s" % params.base_spark_pom_version,
+      "BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS=%s" %
+      params.base_spark_version_to_install_databricks_jars,
+      "MVN_OPT=%s" % params.mvn_opt,
+      "EXTRA_ENVS=%s" % params.extra_envs,
+      "bash",
+      params.script_dest,
+  ] + params.script_args)
+  remote_command = "%s 2>&1 | tee buildout; exit ${PIPESTATUS[0]}" % build_command
+  ssh_command = ["ssh"] + ssh_args + ["ubuntu@%s" % master_addr,
+                                       "bash -c %s" % shlex.quote(remote_command)]
+  print("ssh command: %s" % shell_join(ssh_command))
+  subprocess.check_call(ssh_command)
 
   # Only the nightly build needs to copy the spark-rapids-built.tgz back
   if params.test_type == 'nightly':
       print("Copying built tarball back")
-      rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:/home/ubuntu/spark-rapids-built.tgz ./" % (ssh_args, master_addr)
-      print("rsync command to get built tarball: %s" % rsync_command)
-      subprocess.check_call(rsync_command, shell = True)
+      rsync_command = ["rsync", "-I", "-Pave", rsync_ssh, "--",
+                       "ubuntu@%s:/home/ubuntu/spark-rapids-built.tgz" % master_addr, "./"]
+      print("rsync command to get built tarball: %s" % shell_join(rsync_command))
+      subprocess.check_call(rsync_command)
 
 if __name__ == '__main__':
   main()

--- a/jenkins/databricks/run-build.py
+++ b/jenkins/databricks/run-build.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 """Upload & run test script on Databricks cluster."""
 
+import glob
+import shlex
 import subprocess
 import sys
 
 from clusterutils import ClusterUtils
 
 import params
+
+
+def shell_join(args):
+    """Return shell-escaped command arguments."""
+    return ' '.join(shlex.quote(arg) for arg in args)
 
 
 def get_test_report_path_prefix():
@@ -52,40 +59,57 @@ def main():
     print("Master node address is: %s" % master_addr)
 
     print("Copying script")
-    ssh_args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2200 -i %s" % params.private_key_file
-    rsync_command = "rsync -I -Pave \"ssh %s\" %s ubuntu@%s:%s" % \
-        (ssh_args, params.local_script, master_addr, params.script_dest)
-    print("rsync command: %s" % rsync_command)
-    subprocess.check_call(rsync_command, shell=True)
+    ssh_args = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+                "-p", "2200", "-i", params.private_key_file]
+    rsync_ssh = shell_join(["ssh"] + ssh_args)
+    rsync_command = ["rsync", "-I", "-Pave", rsync_ssh, "--", params.local_script,
+                     "ubuntu@%s:%s" % (master_addr, params.script_dest)]
+    print("rsync command: %s" % shell_join(rsync_command))
+    subprocess.check_call(rsync_command)
 
-    ssh_command = "ssh %s ubuntu@%s " % (ssh_args, master_addr) + \
-        "'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VERSION=%s EXTRA_ENVS=%s TEST_TYPE=%s bash %s %s 2>&1 | tee testout; " \
-        "if [ ${PIPESTATUS[0]} -ne 0 ]; then false; else true; fi'" % \
-        (params.jar_path, params.spark_conf, params.base_spark_pom_version, params.extra_envs, params.test_type,
-         params.script_dest, ' '.join(params.script_args))
-    print("ssh command: %s" % ssh_command)
+    test_command = shell_join([
+        "env",
+        "LOCAL_JAR_PATH=%s" % params.jar_path,
+        "SPARK_CONF=%s" % params.spark_conf,
+        "BASE_SPARK_VERSION=%s" % params.base_spark_pom_version,
+        "EXTRA_ENVS=%s" % params.extra_envs,
+        "TEST_TYPE=%s" % params.test_type,
+        "bash",
+        params.script_dest,
+    ] + params.script_args)
+    remote_command = "%s 2>&1 | tee testout; exit ${PIPESTATUS[0]}" % test_command
+    ssh_command = ["ssh"] + ssh_args + ["ubuntu@%s" % master_addr,
+                                         "bash -c %s" % shlex.quote(remote_command)]
+    print("ssh command: %s" % shell_join(ssh_command))
     try:
-        subprocess.check_call(ssh_command, shell=True)
+        subprocess.check_call(ssh_command)
     finally:
         print("Copying test reports back")
         try:
             report_target_path = "%s/integration_tests/target" % get_test_report_path_prefix()
-            subprocess.check_call("mkdir -p integration_tests/target", shell=True)
+            subprocess.check_call(["mkdir", "-p", "integration_tests/target"])
             # Copy the diagnostics needed by Jenkins while avoiding unrelated run_dir contents.
-            rsync_command = "rsync -I -Pave \"ssh %s\" --prune-empty-dirs " \
-                "--include='run_dir*/' " \
-                "--include='run_dir*/TEST-pytest-*.xml' " \
-                "--include='run_dir*/eventlog_*/***' " \
-                "--include='run_dir*/*_worker_logs.log' " \
-                "--exclude='*' ubuntu@%s:%s/ integration_tests/target/" % \
-                (ssh_args, master_addr, report_target_path)
-            print("rsync command: %s" % rsync_command)
-            subprocess.check_call(rsync_command, shell=True)
+            rsync_command = [
+                "rsync", "-I", "-Pave", rsync_ssh,
+                "--prune-empty-dirs",
+                "--include=run_dir*/",
+                "--include=run_dir*/TEST-pytest-*.xml",
+                "--include=run_dir*/eventlog_*/***",
+                "--include=run_dir*/*_worker_logs.log",
+                "--exclude=*",
+                "--",
+                "ubuntu@%s:%s/" % (master_addr, report_target_path),
+                "integration_tests/target/",
+            ]
+            print("rsync command: %s" % shell_join(rsync_command))
+            subprocess.check_call(rsync_command)
             # Keep the existing Jenkins JUnit publishing flow, which expects XML files in this
             # directory.
-            copy_xml_command = "cp integration_tests/target/run_dir*/TEST-pytest-*.xml ./ || true"
-            print("copy xml command: %s" % copy_xml_command)
-            subprocess.check_call(copy_xml_command, shell=True)
+            xml_files = glob.glob("integration_tests/target/run_dir*/TEST-pytest-*.xml")
+            if xml_files:
+                copy_xml_command = ["cp"] + xml_files + ["./"]
+                print("copy xml command: %s" % shell_join(copy_xml_command))
+                subprocess.call(copy_xml_command)
         except subprocess.CalledProcessError as e:
             print("WARNING: test report collection failed: %s" % e)
 


### PR DESCRIPTION
### Description
This PR hardens the Databricks Jenkins build and test launchers against shell command injection. Commands previously assembled as strings and executed with shell=True could allow command-line values to be interpreted by the local shell.

The launchers now pass argument lists directly to subprocess, terminate rsync option parsing before path operands, and shell-quote arguments that must be interpreted by the remote Bash process. The remote tee pipelines are retained, and their original build or test exit status is still propagated through SSH so Jenkins fails when the underlying script fails.
 
Optional XML report copying now expands matching files in Python instead of relying on a local shell, while report collection remains best-effort as before.

### Verification:
- Verified the updated default-mode build and test workflow succeeds: rapids_databricks-for-dev/286.
<img width="3146" height="310" alt="image" src="https://github.com/user-attachments/assets/64e4a095-b807-444d-ae3b-b383d9303372" />
<img width="3112" height="270" alt="image" src="https://github.com/user-attachments/assets/026d9e00-b6cc-446a-9f9a-45c17bd8f6dd" />

- Verified an expected test failure remains non-zero and causes the Jenkins stage to fail: rapids_databricks-for-dev/287.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
