### PR TITLE
Reduce redundant JSON premerge cases [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -100,6 +100,14 @@ _decimal_10_3_schema = StructType([
 _date_schema = StructType([
     StructField('number', DateType())])
 
+# dateFormat only affects date parsing. Pair it with the date schema explicitly instead of
+# multiplying every non-date schema by an option that cannot change its execution path.
+_basic_json_schema_date_formats = [
+    (schema, None) for schema in [
+        _bool_schema, _byte_schema, _short_schema, _int_schema, _long_schema,
+        _float_schema, _double_schema, _decimal_10_2_schema, _decimal_10_3_schema]
+] + [(_date_schema, None), (_date_schema, 'yyyy-MM-dd')]
+
 _timestamp_schema = StructType([
     StructField('number', TimestampType())])
 
@@ -346,23 +354,18 @@ def json_ts_formats_round_trip_ntz(spark_tmp_path, timestamp_format, timestamp_t
     'dates.json',
     'dates_invalid.json',
 ])
-@pytest.mark.parametrize('schema', [_bool_schema, _byte_schema, _short_schema, _int_schema, _long_schema, \
-                                    _float_schema, _double_schema, _decimal_10_2_schema, _decimal_10_3_schema, \
-                                    _date_schema], ids=idfn)
+@pytest.mark.parametrize('schema,date_format', _basic_json_schema_date_formats, ids=idfn)
 @pytest.mark.parametrize('read_func', [read_json_df, read_json_sql])
 @pytest.mark.parametrize('allow_non_numeric_numbers', ['true', 'false'])
 @pytest.mark.parametrize('allow_numeric_leading_zeros', [
     'true',
     'false'
 ])
-@pytest.mark.parametrize('ansi_enabled', ["true", "false"])
 @allow_non_gpu(*not_utc_allow_for_test_json_scan)
-@pytest.mark.parametrize('date_format', [None, 'yyyy-MM-dd'])
 def test_basic_json_read(std_input_path, filename, schema, read_func, allow_non_numeric_numbers, \
-        allow_numeric_leading_zeros, ansi_enabled, spark_tmp_table_factory, date_format):
+        allow_numeric_leading_zeros, spark_tmp_table_factory, date_format):
     updated_conf = copy_and_update(_enable_all_types_conf,
-        {'spark.sql.ansi.enabled': ansi_enabled,
-         'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
+        {'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
          'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     options = {"allowNonNumericNumbers": allow_non_numeric_numbers,
            "allowNumericLeadingZeros": allow_numeric_leading_zeros,
@@ -395,22 +398,17 @@ def test_basic_json_read(std_input_path, filename, schema, read_func, allow_non_
     'dates.json',
     'dates_invalid.json',
 ])
-@pytest.mark.parametrize('schema', [_bool_schema, _byte_schema, _short_schema, _int_schema, _long_schema, \
-                                    _float_schema, _double_schema, _decimal_10_2_schema, _decimal_10_3_schema, \
-                                    _date_schema], ids=idfn)
+@pytest.mark.parametrize('schema,date_format', _basic_json_schema_date_formats, ids=idfn)
 @pytest.mark.parametrize('allow_non_numeric_numbers', ['true', 'false'])
 @pytest.mark.parametrize('allow_numeric_leading_zeros', [
     'true',
     'false'
 ])
-@pytest.mark.parametrize('ansi_enabled', ["true", "false"])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_project_allow)
-@pytest.mark.parametrize('date_format', [None, 'yyyy-MM-dd'])
 def test_basic_from_json(std_input_path, filename, schema, allow_non_numeric_numbers, \
-        allow_numeric_leading_zeros, ansi_enabled, date_format):
+        allow_numeric_leading_zeros, date_format):
     updated_conf = copy_and_update(_enable_all_types_conf,
-        {'spark.sql.ansi.enabled': ansi_enabled,
-         'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
+        {'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
          'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     options = {"allowNonNumericNumbers": allow_non_numeric_numbers,
            "allowNumericLeadingZeros": allow_numeric_leading_zeros,
@@ -1162,16 +1160,14 @@ def test_from_json_struct_date_fallback_non_default_format(date_gen, date_format
     pytest.param("LEGACY", marks=pytest.mark.allow_non_gpu('JsonToStructs')),
     pytest.param("CORRECTED", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10535'))
 ])
-@pytest.mark.parametrize('ansi_enabled', [ True, False ])
-def test_from_json_struct_timestamp(timestamp_gen, timestamp_format, time_parser_policy, ansi_enabled):
+def test_from_json_struct_timestamp(timestamp_gen, timestamp_format, time_parser_policy):
     json_string_gen = StringGen(r'{ "a": ' + timestamp_gen + ' }') \
         .with_special_case('{ "a": null }') \
         .with_special_case('{ "a": "6395-12-21T56:86:40.205705Z" }') \
         .with_special_case('null')
     options = { 'timestampFormat': timestamp_format } if timestamp_format else { }
     conf = copy_and_update(_enable_all_types_conf, {
-        'spark.sql.legacy.timeParserPolicy': time_parser_policy, 
-        'spark.sql.ansi.enabled': ansi_enabled})
+        'spark.sql.legacy.timeParserPolicy': time_parser_policy})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, json_string_gen) \
             .select(f.col('a'), f.from_json('a', 'struct<a:timestamp>', options)),

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -100,8 +100,9 @@ _decimal_10_3_schema = StructType([
 _date_schema = StructType([
     StructField('number', DateType())])
 
-# dateFormat only affects date parsing. Pair it with the date schema explicitly instead of
-# multiplying every non-date schema by an option that cannot change its execution path.
+# dateFormat only affects date parsing. Pair it with the date schema
+# explicitly instead of multiplying every non-date schema by an option
+# that cannot change its execution path.
 _basic_json_schema_date_formats = [
     (schema, None) for schema in [
         _bool_schema, _byte_schema, _short_schema, _int_schema, _long_schema,

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -425,6 +425,29 @@ def test_basic_from_json(std_input_path, filename, schema, allow_non_numeric_num
         conf=updated_conf)
 
 
+@approximate_float
+@pytest.mark.parametrize('read_func', [read_json_df, read_json_sql])
+def test_json_read_invalid_float_ansi(
+        std_input_path, read_func, spark_tmp_table_factory):
+    conf = copy_and_update(_enable_all_types_conf, {'spark.sql.ansi.enabled': 'true'})
+    assert_gpu_and_cpu_are_equal_collect(
+        read_func(std_input_path + '/floats_invalid.json',
+                  _float_schema,
+                  spark_tmp_table_factory,
+                  {}),
+        conf=conf)
+
+
+@approximate_float
+@allow_non_gpu(TEXT_INPUT_EXEC)
+def test_from_json_invalid_float_ansi(std_input_path):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.text(std_input_path + '/floats_invalid.json').
+          selectExpr("value as json").
+          select(f.col("json"), f.from_json(f.col("json"), _float_schema)),
+        conf=copy_and_update(_enable_all_types_conf, {'spark.sql.ansi.enabled': 'true'}))
+
+
 @ignore_order
 @pytest.mark.parametrize('filename', [
     'malformed1.ndjson',


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

### Description

Reduce redundant parameter combinations in `json_test.py` to shorten premerge testing.

The basic JSON scan and `from_json` matrices previously crossed every schema with both ANSI
settings and both date-format settings. ANSI mode is not consumed by the GPU JSON scan or
`from_json` implementation, while the ANSI-sensitive date parsing paths remain covered by the
dedicated valid/invalid date tests. Likewise, `dateFormat` cannot affect non-date schemas. This
change pairs both date formats only with the date schema and keeps one configuration for every
non-date schema. The timestamp `from_json` matrix also drops its unrelated ANSI dimension; the
dedicated date/timestamp tests continue to cover both ANSI settings.

The `ansi_enabled` dimension can be removed from these broad matrices because the affected RAPIDS
JSON paths do not branch on it. `from_json` date and timestamp conversion uses non-ANSI parsing
semantics, and JSON scan invalid-date behavior is selected by
`spark.sql.legacy.timeParserPolicy`, not `spark.sql.ansi.enabled`. The non-date schemas have no
ANSI-dependent JSON parsing branch. Focused tests such as `test_json_read_valid_dates`,
`test_json_read_generated_dates`, `test_json_read_invalid_dates`, and
`test_json_read_valid_timestamps` still exercise both ANSI settings where they can affect
fallback or compatibility behavior.

Every filename, schema, V1/V2/SQL read path, numeric parsing option, date format that can affect
the selected schema, parser policy, expected fallback, xfail, and error path remains covered.
This removes repeated executions of identical implementation paths without sampling datatype or
parser branches.

Spark 3.3.0 collection changed from 7,923 to 2,963 cases, a reduction of 4,960 cases (62.6%). In
a four-worker local run with the same seed, wall time decreased from 13m46s to 7m30s (45.5%). Both
runs completed without unexpected test failures.

JaCoCo was collected from the full baseline and reduced Spark 3.3.0 runs against the same JVM
classes. Covered lines remained 15,549 -> 15,549 and covered branches changed from 4,698 -> 4,699.
No class lost a covered line or branch. The JSON reader, scan, `GpuJsonToStructs`,
`GpuStructsToJson`, shim, and JNI JSON classes retained identical line and branch coverage.

Validation:

- `python3 -m py_compile integration_tests/src/main/python/json_test.py`
- Spark 3.3.0 full `json_test.py` baseline: 6,912 passed, 359 skipped, 203 xfailed,
  449 xpassed
- Spark 3.3.0 reduced `json_test.py`: 2,356 passed, 351 skipped, 139 xfailed, 117 xpassed
- JaCoCo class-level covered-line and covered-branch comparison: no regressions
- JDK 17, Spark 4.0.1 / Scala 2.13 clean package: `BUILD SUCCESS`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
