### PR TITLE
Group comprehensive timezone test cases

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -472,25 +472,39 @@ def test_to_utc_timestamp_fixed_offset(time_zone):
 # If `end_timestamp` is 2200 year, then generated timestamps are < 2200 year, will use GPU to compute both DST and non-DST timezones.
 # If it has any generated timestamp is > 2200 year and timezone is DST, then `fallback` to CPU.
 # The `fallback` means GPU operator invokes CPU to compute, not really fallback to CPU.
-@pytest.mark.parametrize('time_zone', all_timezones, ids=idfn)
+timezone_group_size = 16
+all_timezone_groups = [
+    tuple(all_timezones[start:start + timezone_group_size])
+    for start in range(0, len(all_timezones), timezone_group_size)]
+
+
+def timezone_group_id(time_zones):
+    return f'{time_zones[0]}...{time_zones[-1]}'
+
+
+@pytest.mark.parametrize('time_zones', all_timezone_groups, ids=timezone_group_id)
 @pytest.mark.parametrize('end_timestamp', [last_supported_tz_time, None], ids=idfn)
-def test_comprehensive_from_utc_timestamp(time_zone, end_timestamp):
+def test_comprehensive_from_utc_timestamp(time_zones, end_timestamp):
     # if end = None, will use the default value
     tz_timestamp_gen = TimestampGen(end = end_timestamp, tzinfo=timezone.utc)
+    expressions = [f'from_utc_timestamp(a, "{time_zone}")' for time_zone in time_zones]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, tz_timestamp_gen).selectExpr(f'from_utc_timestamp(a, "{time_zone}")'))
+        lambda spark: unary_op_df(spark, tz_timestamp_gen).selectExpr(*expressions))
 
 # test to_utc_timestamp
 # If `end_timestamp` is 2200 year, then generated timestamps are < 2200 year, will use GPU to compute both DST and non-DST timezones.
 # If it has any generated timestamp is > 2200 year and timezone is DST, then `fallback` to CPU.
 # The `fallback` means GPU operator invokes CPU to compute, not really fallback to CPU.
-@pytest.mark.parametrize('time_zone', all_timezones, ids=idfn)
+@pytest.mark.parametrize('time_zones', all_timezone_groups, ids=timezone_group_id)
 @pytest.mark.parametrize('end_timestamp', [last_supported_tz_time, None], ids=idfn)
-def test_comprehensive_to_utc_timestamp(time_zone, end_timestamp):
+def test_comprehensive_to_utc_timestamp(time_zones, end_timestamp):
     # if end = None, will use the default value
-    tz_timestamp_gen = TimestampGen(end=end_timestamp, tzinfo=tz.gettz(time_zone))
+    timestamp_gens = [(f'ts_{index}', TimestampGen(end=end_timestamp, tzinfo=tz.gettz(time_zone)))
+                      for index, time_zone in enumerate(time_zones)]
+    expressions = [f'to_utc_timestamp(ts_{index}, "{time_zone}")'
+                   for index, time_zone in enumerate(time_zones)]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, tz_timestamp_gen).selectExpr(f'to_utc_timestamp(a, "{time_zone}")'))
+        lambda spark: gen_df(spark, timestamp_gens).selectExpr(*expressions))
 
 @allow_non_gpu('ToUTCTimestamp')
 def test_unsupported_fallback_to_utc_timestamp():


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

### Description

Group comprehensive timezone expressions in `date_time_test.py` to shorten premerge testing.

The comprehensive `from_utc_timestamp` and `to_utc_timestamp` tests previously started a separate
Spark action for every timezone. This change partitions the complete runtime-provided timezone list
into groups of at most 16 and evaluates one expression per timezone in the same projection.

Every original `(operator, timezone, timestamp range)` combination is preserved exactly once. The
bounded range ending in year 2200 and the default unbounded range remain separate pytest cases, so
the normal GPU path and the runtime CPU bridge path remain independently exercised. For
`from_utc_timestamp`, grouped expressions share the same UTC input column. For `to_utc_timestamp`,
each timezone retains its own input column generated with that timezone's `tzinfo`, preserving the
original local-time data semantics.

Groups are constructed by losslessly slicing `all_timezones`; no timezone ID, alias, fixed-offset
zone, variable-offset zone, or DST rule is sampled or removed. Focused DST-transition,
fixed-offset, parser-policy, ANSI, unsupported-expression, fallback, and error tests remain
unchanged. Exception tests are deliberately not grouped because the first failure could mask later
expressions.

Spark 3.3.0 collection changed from 3,007 to 743 cases, a reduction of 2,264 cases (75.3%). In a
four-worker local run with the same seed, wall time decreased from 7m09s to 2m35s (63.9%). Both
runs completed without unexpected test failures.

JaCoCo was collected from the full baseline and reduced Spark 3.3.0 runs against the same JVM
classes. Global covered lines remained 16,977 -> 16,977 and covered branches increased from 5,649
to 5,660. No datetime or timezone-related class lost a covered line or branch. Covered branches in
`GpuFromUTCTimestamp` increased from 16 to 19; `GpuToUTCTimestamp` remained 16, and
`GpuTimeZoneDB` retained identical counters.

Validation:

- `python -m py_compile integration_tests/src/main/python/date_time_test.py`
- Spark 3.3.0 full `date_time_test.py` baseline: 2,994 passed, 5 skipped, 4 xfailed, 4 xpassed
- Spark 3.3.0 reduced `date_time_test.py`: 730 passed, 5 skipped, 4 xfailed, 4 xpassed
- JaCoCo datetime/timezone class-level covered-line and covered-branch comparison: no regressions

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
