### PR TITLE
Reduce redundant join integration test cases

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -448,16 +448,12 @@ def test_broadcast_join_right_table_ridealong(data_gen, join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-# Not all join types can be translated to a broadcast join, but this tests them to be sure we
-# can handle what spark is doing
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_right_table_with_job_group(data_gen, join_type):
+def test_broadcast_join_right_table_with_job_group():
     with_cpu_session(lambda spark : spark.sparkContext.setJobGroup("testjob1", "test", False))
     def do_join(spark):
-        left, right = create_df(spark, data_gen, 500, 250)
-        return left.join(broadcast(right), left.a == right.r_a, join_type)
+        left, right = create_df(spark, int_gen, 500, 250)
+        return left.join(broadcast(right), left.a == right.r_a, 'Inner')
 
     conf = {'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
             }
@@ -739,23 +735,21 @@ def test_left_broadcast_nested_loop_join_condition_missing(data_gen, join_type):
         return broadcast(left).join(right, how=join_type).distinct()
     assert_gpu_and_cpu_are_equal_collect(do_join)
 
-@pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + [binary_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type):
+def test_right_broadcast_nested_loop_join_condition_missing_count(join_type):
     def do_join(spark):
-        left, right = create_df(spark, data_gen, 50, 25)
+        left, right = create_df(spark, int_gen, 50, 25)
         return left.join(broadcast(right), how=join_type).selectExpr('COUNT(*)')
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
     assert_gpu_and_cpu_are_equal_collect(do_join, conf = {'spark.sql.adaptive.enabled': 'false'
                                                           })
 
-@pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + [binary_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Right'], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_left_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type):
+def test_left_broadcast_nested_loop_join_condition_missing_count(join_type):
     def do_join(spark):
-        left, right = create_df(spark, data_gen, 50, 25)
+        left, right = create_df(spark, int_gen, 50, 25)
         return broadcast(left).join(right, how=join_type).selectExpr('COUNT(*)')
     assert_gpu_and_cpu_are_equal_collect(do_join)
 
@@ -781,24 +775,34 @@ def test_broadcast_nested_loop_with_conditionals_build_right_fallback(data_gen, 
         return left.join(broadcast(right), (left.b >= right.r_b), join_type)
     assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec')
 
-# local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-# Not all join types can be translated to a broadcast join, but this tests them to be sure we
-# can handle what spark is doing
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-# Specify 200 shuffle partitions to test cases where streaming side is empty
-# as in https://github.com/NVIDIA/spark-rapids/issues/7516
-@pytest.mark.parametrize('shuffle_conf', [{}, {'spark.sql.shuffle.partitions': 200}], ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_left_table(data_gen, join_type, shuffle_conf):
+def _assert_broadcast_join_left_table(data_gen, join_type, shuffle_conf):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 250, 500)
         return broadcast(left).join(right, left.a == right.r_a, join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
     conf = copy_and_update(shuffle_conf, {'spark.sql.adaptive.enabled': 'false'})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
+# Not all join types can be translated to a broadcast join, but this tests them to be sure we
+# can handle what spark is doing.
+# local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
+# After 3.1.0 is the min spark version we can drop this
+@ignore_order(local=True)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
+@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@allow_non_gpu(*non_utc_allow)
+def test_broadcast_join_left_table(data_gen, join_type):
+    _assert_broadcast_join_left_table(data_gen, join_type, {})
+
+# Specify 200 shuffle partitions to test cases where streaming side is empty
+# as in https://github.com/NVIDIA/spark-rapids/issues/7516. The empty-partition behavior is
+# independent of the join key type, so retain every join type with one representative key type.
+@ignore_order(local=True)
+@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@allow_non_gpu(*non_utc_allow)
+def test_broadcast_join_left_table_many_shuffle_partitions(join_type):
+    _assert_broadcast_join_left_table(
+        int_gen, join_type, {'spark.sql.shuffle.partitions': 200})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -128,6 +128,25 @@ def join_batch_size_test_params(*args):
                 params += [ pytest.param(obj, batch_size) ]
     return params
 
+
+def _representative_cross_product(primary_values, secondary_values):
+    """Cover every value on both axes with two representatives for their interaction."""
+    params = []
+    for primary in primary_values:
+        primary_values_and_marks = (primary.values, primary.marks) \
+            if isinstance(primary, ParameterSet) else ((primary,), ())
+        params.append(pytest.param(
+            *primary_values_and_marks[0], *secondary_values[0],
+            marks=primary_values_and_marks[1]))
+    for primary in primary_values[:2]:
+        primary_values_and_marks = (primary.values, primary.marks) \
+            if isinstance(primary, ParameterSet) else ((primary,), ())
+        for secondary in secondary_values[1:]:
+            params.append(pytest.param(
+                *primary_values_and_marks[0], *secondary,
+                marks=primary_values_and_marks[1]))
+    return params
+
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
@@ -207,10 +226,13 @@ def test_broadcast_hash_join_constant_keys(join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen,batch_size', join_batch_size_test_params(
-    (all_gen, '1g'),
-    (join_small_batch_gens, '1000')), ids=idfn)
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,batch_size,join_type', _representative_cross_product(
+    join_batch_size_test_params((all_gen, '1g'), (join_small_batch_gens, '1000')),
+    [(join_type,) for join_type in all_join_types]) + [
+        pytest.param(data_gen, '1000', join_type)
+        for data_gen in join_small_batch_gens
+        for join_type in all_join_types[1:]
+    ], ids=idfn)
 def test_sortmerge_join(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
@@ -222,8 +244,9 @@ def test_sortmerge_join(data_gen, join_type, batch_size):
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    basic_nested_gens + [decimal_gen_128bit],
+    [(join_type,) for join_type in all_join_types]), ids=idfn)
 def test_sortmerge_join_ridealong(data_gen, join_type):
     def do_join(spark):
         left, right = create_ridealong_df(spark, short_gen, data_gen, 500, 500)
@@ -267,9 +290,11 @@ def hash_join_ridealong(data_gen, join_type, confs):
 
 @validate_execs_in_gpu_plan('GpuShuffledHashJoinExec')
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_non_sized_join_types, ids=idfn)
-@pytest.mark.parametrize('sub_part_enabled', ['false', 'true'], ids=['SubPartition_OFF', 'SubPartition_ON'])
+@pytest.mark.parametrize('data_gen,join_type,sub_part_enabled', _representative_cross_product(
+    basic_nested_gens + [decimal_gen_128bit],
+    [(join_type, sub_part_enabled)
+     for join_type in all_non_sized_join_types
+     for sub_part_enabled in ['false', 'true']]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_hash_join_ridealong_non_sized(data_gen, join_type, sub_part_enabled):
     confs = {
@@ -280,8 +305,9 @@ def test_hash_join_ridealong_non_sized(data_gen, join_type, sub_part_enabled):
 
 @validate_execs_in_gpu_plan('GpuShuffledSymmetricHashJoinExec')
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_symmetric_sized_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    basic_nested_gens + [decimal_gen_128bit],
+    [(join_type,) for join_type in all_symmetric_sized_join_types]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_hash_join_ridealong_symmetric(data_gen, join_type):
     confs = {
@@ -292,8 +318,9 @@ def test_hash_join_ridealong_symmetric(data_gen, join_type):
 
 @validate_execs_in_gpu_plan('GpuShuffledAsymmetricHashJoinExec')
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    basic_nested_gens + [decimal_gen_128bit],
+    [(join_type,) for join_type in all_asymmetric_sized_join_types]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_hash_join_ridealong_asymmetric(data_gen, join_type):
     confs = {
@@ -323,8 +350,9 @@ def hash_join_side_is_build_side(data_gen, join_type, confs):
 # test right outer join with right side is build side
 @validate_execs_in_gpu_plan('GpuShuffledAsymmetricHashJoinExec')
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    basic_nested_gens + [decimal_gen_128bit],
+    [(join_type,) for join_type in all_asymmetric_sized_join_types]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_hash_join_side_is_build_side_asymmetric(data_gen, join_type):
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
@@ -368,10 +396,10 @@ def test_hash_join_side_is_build_side_basic(join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    all_gen, [(join_type,) for join_type in all_join_types]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_broadcast_join_right_table(data_gen, join_type):
     def do_join(spark):
@@ -433,10 +461,14 @@ def test_broadcast_nested_loop_join_degen_left_outer_stream_no_columns(a_val):
     assert_gpu_and_cpu_are_equal_collect(degen_join_func)
 
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    basic_nested_gens + [decimal_gen_128bit],
+    [(join_type,) for join_type in all_join_types]) + [
+        pytest.param(data_gen, 'FullOuter')
+        for data_gen in (basic_nested_gens + [decimal_gen_128bit])[2:]
+    ], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_broadcast_join_right_table_ridealong(data_gen, join_type):
     def do_join(spark):
@@ -686,10 +718,11 @@ def test_broadcast_nested_loop_join_with_condition_fallback(data_gen, join_type)
                                         "spark.sql.adaptive.enabled": "false"})
 
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', [byte_gen, short_gen, int_gen, long_gen,
-                                      float_gen, double_gen,
-                                      string_gen, boolean_gen, date_gen, timestamp_gen], ids=idfn)
-@pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
+     string_gen, boolean_gen, date_gen, timestamp_gen],
+    [(join_type,) for join_type in ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti']]),
+    ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_broadcast_nested_loop_join_with_array_contains(data_gen, join_type):
     arr_gen = ArrayGen(data_gen)
@@ -755,8 +788,10 @@ def test_left_broadcast_nested_loop_join_condition_missing_count(join_type):
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'GreaterThanOrEqual', *non_utc_allow)
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-@pytest.mark.parametrize('join_type', ['LeftOuter', 'LeftSemi', 'LeftAnti', 'FullOuter'], ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    all_gen,
+    [(join_type,) for join_type in ['LeftOuter', 'LeftSemi', 'LeftAnti', 'FullOuter']]),
+    ids=idfn)
 def test_broadcast_nested_loop_join_with_conditionals_build_left_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
@@ -788,8 +823,8 @@ def _assert_broadcast_join_left_table(data_gen, join_type, shuffle_conf):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    all_gen, [(join_type,) for join_type in all_join_types]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_broadcast_join_left_table(data_gen, join_type):
     _assert_broadcast_join_left_table(data_gen, join_type, {})
@@ -807,8 +842,8 @@ def test_broadcast_join_left_table_many_shuffle_partitions(join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', join_ast_gen, ids=idfn)
-@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    join_ast_gen, [(join_type,) for join_type in all_join_types]), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_broadcast_join_with_conditionals(data_gen, join_type):
     def do_join(spark):
@@ -868,8 +903,10 @@ def test_broadcast_join_with_condition_post_filter(data_gen, join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', join_ast_gen, ids=idfn)
-@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
+@pytest.mark.parametrize('data_gen,join_type', _representative_cross_product(
+    join_ast_gen,
+    [(join_type,) for join_type in ['Left', 'Right', 'Inner', 'FullOuter', 'LeftSemi', 'LeftAnti']]),
+    ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_sortmerge_join_with_condition_ast(data_gen, join_type):
     def do_join(spark):
@@ -1547,11 +1584,16 @@ def test_distinct_join(join_type, batch_size):
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=join_conf)
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("join_type", ["Inner", "FullOuter", "LeftOuter", "RightOuter"], ids=idfn)
-@pytest.mark.parametrize("is_left_host_shuffle", [False, True], ids=idfn)
-@pytest.mark.parametrize("is_right_host_shuffle", [False, True], ids=idfn)
-@pytest.mark.parametrize("is_left_smaller", [False, True], ids=idfn)
-@pytest.mark.parametrize("batch_size", ["1024", "1g"], ids=idfn)
+@pytest.mark.parametrize(
+    "join_type,is_left_host_shuffle,is_right_host_shuffle,is_left_smaller,batch_size",
+    _representative_cross_product(
+        ["Inner", "FullOuter", "LeftOuter", "RightOuter"],
+        [(is_left_host_shuffle, is_right_host_shuffle, is_left_smaller, batch_size)
+         for is_left_host_shuffle in [False, True]
+         for is_right_host_shuffle in [False, True]
+         for is_left_smaller in [False, True]
+         for batch_size in ["1024", "1g"]]),
+    ids=idfn)
 def test_sized_join(join_type, is_left_host_shuffle, is_right_host_shuffle,
                     is_left_smaller, batch_size):
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

### Description

Remove redundant Cartesian products from `join_test.py` to shorten premerge testing while
retaining every data type, join type, configuration value, and coverage-sensitive interaction.

For orthogonal parameter axes, `_representative_cross_product` keeps every primary value with a
default secondary configuration and runs the complete secondary matrix with two representative
primary values. This preserves the individual behavior dimensions without repeating every pair.

Coverage-guided exceptions retain the interactions that are not orthogonal:

- Small-batch sort-merge inputs retain every join type because the batch-size/join-type interaction
  exercises both `JoinGathererImpl` and `JoinGathererSameTable` paths.
- Wrong-key array fallback retains its complete matrix because different payload/join plan pairs
  exercise distinct higher-order-expression equality branches.
- Broadcast ridealong retains every nested payload with `FullOuter` because null materialization
  exercises additional `GpuScalar` paths.
- Conditional, fallback, build-side, subpartition, host-shuffle, and asymmetric/symmetric join
  dimensions still retain every individual choice, with two representative cross-axis values.

The earlier focused reductions remain unchanged: the job-group test uses one integer inner join,
no-condition `COUNT(*)` tests use one integer payload, and the 200-shuffle-partition regression
retains every join type with one representative key. No production behavior changes.

Spark 3.3.0 collection changes from 2,322 to 1,338 cases, reducing 984 cases (42.38%).

JaCoCo was compared with fixed `DATAGEN_SEED=12345` and
`--test_oom_injection_mode=never`, so changing the number of collected cases cannot change random
OOM assignment. Global covered lines remain 25,894, while covered branches increase from 9,507 to
9,512. Focused matrix experiments were used to retain the smallest interactions needed to preserve
these counts.

Validation:

- `python3 -m py_compile integration_tests/src/main/python/join_test.py`
- `git diff --check`
- Spark 3.3.0 deterministic baseline: 2,005 passed, 17 skipped
- Spark 3.3.0 reduced core run: 1,209 passed, 17 skipped
- Focused retained-interaction runs: 307 passed; 105 passed; 46 passed
- Final Spark 3.3.0 collection: 1,338 cases
- JaCoCo global covered lines: 25,894 → 25,894
- JaCoCo global covered branches: 9,507 → 9,512

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
