### PR TITLE
Combine redundant mixed arithmetic integration tests

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -143,18 +143,41 @@ def test_subtraction(data_gen):
                 f.col('b') - f.lit(None).cast(data_type),
                 f.col('a') - f.col('b')))
 
-@pytest.mark.parametrize('lhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 5),
+_mixed_arithmetic_lhs = [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 5),
     DecimalGen(6, 4), DecimalGen(5, 4), DecimalGen(5, 3), DecimalGen(4, 2), DecimalGen(3, -2),
-    DecimalGen(16, 7), DecimalGen(19, 0), DecimalGen(30, 10)], ids=idfn)
-@pytest.mark.parametrize('rhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 3),
+    DecimalGen(16, 7), DecimalGen(19, 0), DecimalGen(30, 10)]
+_mixed_arithmetic_rhs = [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 3),
     DecimalGen(10, -2), DecimalGen(15, 3), DecimalGen(30, 12), DecimalGen(3, -3),
-    DecimalGen(27, 7), DecimalGen(20, -3)], ids=idfn)
-@pytest.mark.parametrize('addOrSub', ['+', '-'])
+    DecimalGen(27, 7), DecimalGen(20, -3)]
+
+
+@pytest.mark.parametrize('lhs', _mixed_arithmetic_lhs, ids=idfn)
+@pytest.mark.parametrize('rhs', _mixed_arithmetic_rhs, ids=idfn)
 @disable_ansi_mode
-def test_addition_subtraction_mixed(lhs, rhs, addOrSub):
+def test_mixed_arithmetic_ops(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : two_col_df(spark, lhs, rhs).selectExpr(f"a {addOrSub} b")
+        lambda spark : two_col_df(spark, lhs, rhs).selectExpr(
+            "a + b", "a - b", "a * b", "a % b")
     )
+
+
+_mixed_multiplication_plan_pairs = [
+    (byte_gen, byte_gen),
+    (byte_gen, DecimalGen(6, 3)),
+    (DecimalGen(6, 5), byte_gen),
+    (DecimalGen(30, 10), DecimalGen(30, 12)),
+    (DecimalGen(3, -2), DecimalGen(3, -3)),
+]
+
+
+@pytest.mark.parametrize('lhs,rhs', _mixed_multiplication_plan_pairs, ids=idfn)
+@disable_ansi_mode
+def test_mixed_decimal_multiplication_plan(lhs, rhs):
+    # Keep standalone plans for the four type-resolution corners whose
+    # GpuDecimalMultiply canonicalization differs from a combined projection.
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: two_col_df(spark, lhs, rhs).selectExpr("a * b"))
+
 
 # If it will not overflow for multiply it is good for subtract too
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
@@ -247,18 +270,6 @@ def test_multiplication_without_overflow_for_numeric_ansi_on_off(data_gen_lit_pa
             f.col('a') * f.lit(lit).cast(data_type),
             f.col('a') * f.col('b')),
         conf={'spark.sql.ansi.enabled': ansi_enabled})
-
-@pytest.mark.parametrize('lhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 5),
-    DecimalGen(6, 4), DecimalGen(5, 4), DecimalGen(5, 3), DecimalGen(4, 2), DecimalGen(3, -2),
-    DecimalGen(16, 7), DecimalGen(19, 0), DecimalGen(30, 10)], ids=idfn)
-@pytest.mark.parametrize('rhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 3),
-    DecimalGen(10, -2), DecimalGen(15, 3), DecimalGen(30, 12), DecimalGen(3, -3),
-    DecimalGen(27, 7), DecimalGen(20, -3)], ids=idfn)
-@disable_ansi_mode
-def test_multiplication_mixed(lhs, rhs):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, lhs, rhs).select(
-                f.col('a') * f.col('b')))
 
 @approximate_float # we should get the perfectly correct answer for floats except when casting a decimal to a float in some corner cases.
 @pytest.mark.parametrize('lhs', [float_gen, double_gen], ids=idfn)
@@ -452,17 +463,6 @@ def test_mod_pmod_by_zero_not_ansi(data_gen):
             'a % (cast(0 as {}))'.format(string_type),
             'cast(-12 as {}) % cast(0 as {})'.format(string_type, string_type)),
         {'spark.sql.ansi.enabled': 'false'})
-
-@pytest.mark.parametrize('lhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 5),
-    DecimalGen(6, 4), DecimalGen(5, 4), DecimalGen(5, 3), DecimalGen(4, 2), DecimalGen(3, -2),
-    DecimalGen(16, 7), DecimalGen(19, 0), DecimalGen(30, 10)], ids=idfn)
-@pytest.mark.parametrize('rhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 3),
-    DecimalGen(10, -2), DecimalGen(15, 3), DecimalGen(30, 12), DecimalGen(3, -3),
-    DecimalGen(27, 7), DecimalGen(20, -3)], ids=idfn)
-@disable_ansi_mode
-def test_mod_mixed(lhs, rhs):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : two_col_df(spark, lhs, rhs).selectExpr(f"a % b"))
 
 # @pytest.mark.skipif(not is_databricks113_or_later() and not is_spark_340_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/8330")
 @pytest.mark.parametrize('lhs', [DecimalGen(38,0), DecimalGen(37,2), DecimalGen(38,5), DecimalGen(38,-10), DecimalGen(38,7)], ids=idfn)


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

### Description

Combine redundant mixed-type arithmetic queries in `arithmetic_ops_test.py` to shorten premerge
testing without removing any operand pair or arithmetic expression.

Addition, subtraction, multiplication, and modulo previously executed the same 13-by-11
left/right operand matrix in separate Spark queries. The combined test now evaluates all four
expressions in one projection for every original operand pair. CPU/GPU equality is still checked
for every result and every integral/decimal precision and scale combination.

Five standalone multiplication plans remain for the type-resolution categories that differ from a
combined projection: integral/integral, integral/decimal, decimal/integral, wide decimal/decimal,
and negative-scale decimal/decimal. JaCoCo-guided validation showed that the integral/integral plan
is required to retain the last `GpuDecimalMultiply` shim branch; keeping these five focused cases
avoids restoring the full 143-case standalone matrix.

No production code changes. Spark 3.3.0 collection changed from 1,495 to 1,071 cases, a reduction
of 424 cases (28.4%). Four-worker wall time with fixed data and OOM-injection seeds decreased from
9m10s to 6m19s (31.1%). Both runs completed without unexpected failures.

JaCoCo was collected from baseline and reduced runs against identical JVM classes with
`DATAGEN_SEED=0` and `SPARK_RAPIDS_TEST_INJECT_OOM_SEED=424242`. Global covered lines remain
13,306 and covered branches increase from 4,843 to 4,846. The focused standalone-plan run restores
the complete `GpuDecimalMultiply` branch count. One run-order-sensitive branch in the unchanged
`GpuIntegralDivideParent` class varies under OOM sampling; no integral-divide cases were modified
or removed by this change.

Validation:

- `python -m py_compile integration_tests/src/main/python/arithmetic_ops_test.py`
- Spark 3.3.0 baseline: 1,443 passed, 27 skipped, 7 xfailed, 18 xpassed
- Spark 3.3.0 reduced: 1,018 passed, 27 skipped, 7 xfailed, 18 xpassed
- focused standalone multiplication plans: 5 passed
- focused retained integral-division suite: 27 passed
- final collection: 1,071 cases
- JaCoCo global covered lines: 13,306 → 13,306
- JaCoCo global covered branches: 4,843 → 4,846

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
