### PR TITLE
Relax compatibility for `from_json` with map output

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -349,7 +349,10 @@ over this the JSON is considered invalid and all values will be returned as null
 the nesting depth goes over the maximum.
 
 Spark 3.5.0 and above have limits on maximum string length 20,000,000 and maximum number length of
-1,000. We do not have any of these limits on the GPU.
+1,000. We do not have the string length limit on the GPU. The number length limit is enforced by
+`from_json` with a map schema, for integer and floating-point tokens alike: a number past the cap
+makes the record a bad record, so the whole row is returned as null, the same as Spark. The digit
+count excludes signs, `.`, `e`/`E`, and leading zeros.
 
 We, like Spark, cannot support an JSON string that is larger than 2 GiB is size.
 
@@ -413,8 +416,11 @@ In versions of Spark prior to 4.0.0 input JSON Strings were parsed to JSON token
 strings. This effectively normalizes the output string. So things like single quotes are transformed into double
 quotes, floating point numbers are parsed and converted back to strings possibly changing the format, and
 escaped characters are converted back to their simplest form. We try to support this on the GPU as well. Single quotes
-will be converted to double quotes. Only `get_json_object` and `json_tuple` attempt to normalize floating point
-numbers. There is no implementation on the GPU right now that tries to normalize escape characters.
+will be converted to double quotes. Only `get_json_object`, `json_tuple`, and the `from_json` map
+value/element path (`MAP<STRING,STRING>` and `MAP<STRING,ARRAY<STRING>>` schemas, see the
+`from_json` Function section below) attempt to normalize floating point numbers. The same
+`from_json` path is the only GPU implementation that normalizes escape characters; general JSON
+Scan still does not.
 
 ### `from_json` Function
 
@@ -426,22 +432,27 @@ JSON Scan only supports parsing top level structs. The GPU implementation of `fr
 a `MAP<STRING,STRING>` or `MAP<STRING,ARRAY<STRING>>` as a top level schema, but does not currently support
 arrays at the top level.
 
-For map schemas the values (and, for `MAP<STRING,ARRAY<STRING>>`, the array elements) are extracted as raw JSON
-text. Three cases can therefore differ from Spark: (1) escape sequences are not normalized or unescaped (see the
-JSON Normalization section above); (2) array elements that are JSON objects or nested arrays are returned as their
-raw JSON substring rather than Spark's re-serialized form; and (3) numeric elements keep their raw JSON token,
-whereas Spark re-renders numbers, so non-canonical spellings differ (`007` -> `"7"` with `allowNumericLeadingZeros`,
-`1.00000` -> `"1.0"`, `1e2` -> `"100.0"`) and non-numeric numbers stay bare while Spark quotes them (`NaN` ->
-`"NaN"`, `Infinity` -> `"Infinity"` with `allowNonNumericNumbers`); tokens already matching Spark's rendering
-(`1`, `1.5`, `true`) are unaffected. All three cases differ from Spark on ALL versions, including 4.0.0+, because
-`from_json` on a string column parses via a Reader (Spark's `CreateJacksonParser.utf8String`): Spark 4.0.0's
-`spark.sql.json.enableExactStringParsing` (default `true`) preserves raw source text only for `Array[Byte]` / file
-sources (e.g. `spark.read.json`), never a Reader, so its raw path is unreachable here and the CPU always
-re-serializes non-string tokens (cases 2 and 3). Case (1) likewise differs on all versions because JSON string
-tokens are always unescaped by Spark. For `MAP<STRING,ARRAY<STRING>>` a map value that is
-neither a JSON array nor the JSON `null` literal (i.e. a scalar or object) makes the entire row null, matching
-Spark's PERMISSIVE bad-record handling. Duplicate keys are kept in document order, which matches Spark 3.5.x
-`from_json`; later Spark versions may de-duplicate per `spark.sql.mapKeyDedupPolicy`.
+For map schemas the values (and, for `MAP<STRING,ARRAY<STRING>>`, the array elements) are
+normalized to match Spark's rendering rather than returned as raw JSON text. Map keys and string
+values/elements are unescaped (escape sequences resolved to the characters they name), JSON
+objects and nested arrays are re-serialized compactly the way Spark re-serializes them, numbers
+are re-rendered canonically (`007` -> `7` with `allowNumericLeadingZeros`, `1.00000` -> `1.0`,
+`1e2` -> `100.0`), and non-numeric numbers are quoted (`NaN` -> `"NaN"`, `Infinity` ->
+`"Infinity"` with `allowNonNumericNumbers`). Two caveats are known. Invalid UTF-8 input is out of
+scope: Spark decodes input through an `InputStreamReader`, which replaces invalid byte sequences
+with U+FFFD, while the GPU copies the raw bytes through unchanged. Floating-point parse fidelity
+matches the `get_json_object` path: numbers are parsed with a fast integer mantissa plus
+power-of-ten exponent scan that is not correctly rounded once the mantissa exceeds 2^53, so an
+adversarial long-mantissa double can differ from Spark by 1 ULP and re-render to a different
+shortest string (see the `get_json_object` Function section below). A map value that is the JSON
+`null` literal keeps its pair and yields a SQL NULL value -- for `MAP<STRING,ARRAY<STRING>>`, a null
+inner list. For `MAP<STRING,ARRAY<STRING>>` a map value that is neither a JSON array nor the JSON
+`null` literal (i.e. a scalar or object) makes the entire row null, matching Spark's PERMISSIVE
+bad-record handling. A number past the parser's digit cap makes the row null the same way, whether
+it is a value, an array element, or buried inside a nested value (see the Limits section above).
+Duplicate keys are kept in document order on every supported Spark version:
+`JacksonParser.convertMap` builds `ArrayBasedMapData`
+directly, so `spark.sql.mapKeyDedupPolicy` never applies to `from_json`.
 
 ### `to_json` Function
 

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -728,7 +728,7 @@ def test_from_json_map_with_invalid():
 @pytest.mark.parametrize('allow_single_quotes', ['true', 'false'])
 @pytest.mark.parametrize('allow_non_numeric_numbers', ['true', 'false'])
 @pytest.mark.parametrize('allow_unquoted_chars', ['true', 'false'])
-def test_from_json_map_with_options(allow_single_quotes,  
+def test_from_json_map_with_options(allow_single_quotes,
                                     allow_non_numeric_numbers,
                                     allow_unquoted_chars):
     # Test the input with:
@@ -743,14 +743,56 @@ def test_from_json_map_with_options(allow_single_quotes,
         .with_special_pattern(r'{"a": [+-]?(INF|Infinity|NaN)}', weight=50) \
         .with_special_pattern(r'{"(a|a\r\n\tb)": "(xyz|01\r\n\t23)"}', weight=50)
     options = {"allowSingleQuotes": allow_single_quotes,
-                # Cannot test `allowNumericLeadingZeros==true` because the GPU output always has
-                # leading zeros while the CPU output does not, thus test will always fail.
+               # Kept at false instead of crossing the matrix: the flag only gates number-token
+               # acceptance, independent of the other options, so the leading-zero rows here test
+               # both engines rejecting alike; test_from_json_map_numeric covers true.
                "allowNumericLeadingZeros": "false",
                "allowNonNumericNumbers": allow_non_numeric_numbers,
                "allowUnquotedControlChars": allow_unquoted_chars}
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, json_string_gen, length=20) \
             .select(f.from_json(f.col('a'), 'MAP<STRING,STRING>', options)),
+        conf=_enable_all_types_conf)
+
+@allow_non_gpu(*non_utc_allow)
+def test_from_json_map_numeric():
+    # allowNumericLeadingZeros makes 007 parseable; the GPU re-renders number tokens canonically,
+    # matching Spark CPU (007 -> 7, -007 -> -7, 1.00000 -> 1.0, 1e-2 -> 0.01). Mirrors
+    # test_from_json_map_with_arrays_numeric for the MAP<STRING,STRING> value path; compared via
+    # map_entries because the plain-map compare in asserts.py does not check map contents.
+    schema = StructType([StructField("a", StringType())])
+    data = [
+        ['{"a": 007, "b": -007}'],         # leading zeros: both render 7 / -7
+        ['{"a": -0, "b": -0.0}'],          # signed zero: -0 renders 0, -0.0 keeps the sign
+        ['{"a": 1.00000, "b": -1.00000}'], # float re-render: both render 1.0 / -1.0
+        ['{"a": 1e2, "b": 1e-2}'],         # exponents: both render 100.0 / 0.01
+    ]
+    options = {"allowNumericLeadingZeros": "true"}
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : spark.createDataFrame(data, schema=schema) \
+            .select(f.map_entries(f.from_json(f.col('a'), 'MAP<STRING,STRING>', options))),
+        conf=_enable_all_types_conf)
+
+@allow_non_gpu(*non_utc_allow)
+def test_from_json_map_render():
+    # The MAP<STRING,STRING> value path renders every value kind the class doc claims, mirroring
+    # the test_from_json_map_with_arrays_* tests that cover the array-element path: strings
+    # unescaped, non-numeric numbers quoted, nested values re-serialized compactly, a JSON null
+    # value keeping its pair as a SQL NULL, and duplicate keys kept in document order. Numbers:
+    # test_from_json_map_numeric.
+    schema = StructType([StructField("a", StringType())])
+    data = [
+        ['{"a": "x\\"y", "b": "p\\\\q"}'], # escaped quote / backslash resolved
+        ['{"a": "\\u00e9"}'],              # unicode escape resolved
+        ['{"a": NaN, "b": Infinity, "c": -Infinity}'], # non-numeric tokens rendered quoted
+        ['{"a": {"x": 1}, "b": [1, 2]}'],  # nested values re-serialized compactly
+        ['{"a": null, "b": "z"}'],         # JSON null keeps its pair as a SQL NULL value
+        ['{"a": "1", "a": "2"}'],          # duplicate keys: every occurrence kept, document order
+    ]
+    options = {"allowNonNumericNumbers": "true"}
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : spark.createDataFrame(data, schema=schema) \
+            .select(f.map_entries(f.from_json(f.col('a'), 'MAP<STRING,STRING>', options))),
         conf=_enable_all_types_conf)
 
 @allow_non_gpu('ProjectExec', 'JsonToStructs')
@@ -784,8 +826,8 @@ def test_from_json_map_with_arrays_corner_cases():
     # map_entries(...) -- an array of <key,value> structs -- because the map-equality path in
     # asserts.py only checks row-level null-ness, not the keys/values. Entry order is JSON document
     # order on both engines (matching test_map_entries in map_test.py), so no sort is needed. Keys
-    # within a row are kept distinct; duplicate-key, escape, and non-string-element divergences live
-    # in the *_xfail probes below. All cases here are expected to match Spark CPU exactly.
+    # within a row are kept distinct; duplicate-key, escape, and non-string-element cases live in
+    # the dedicated tests below. All cases here are expected to match Spark CPU exactly.
     schema = StructType([StructField("a", StringType())])
     many_keys = '{' + ', '.join('"k{}": ["v{}"]'.format(i, i) for i in range(10)) + '}'
     wide_inner = '{"a": [' + ', '.join('"e{}"'.format(i) for i in range(50)) + ']}'
@@ -821,7 +863,7 @@ def test_from_json_map_with_arrays_corner_cases():
         ['{"a": ["x", "y", "z"]}'],      # basic multi-element
         ['{"a": [null, "x"]}'],          # literal-null element + non-null sibling
         ['{"a": [""]}'],                 # empty-string element
-        ['{"a": [1, 22, 333, 1.5, true, false]}'],   # scalar number/bool/decimal elements: raw text == Spark string coercion (verified xpass)
+        ['{"a": [1, 22, 333, 1.5, true, false]}'],   # scalar elements: canonical spellings match
         ['{"a": ["é", "日本"]}'],  # literal UTF-8 elements (no escape sequences)
         ['{ "a" : [ "x" , "y" ] }'],     # surrounding whitespace
         ['{"": ["x"]}'],                 # empty key
@@ -835,16 +877,9 @@ def test_from_json_map_with_arrays_corner_cases():
         conf=_enable_all_types_conf)
 
 @allow_non_gpu(*non_utc_allow)
-@pytest.mark.xfail(reason="GPU keeps map array string elements as raw JSON (escapes not "
-                          "unescaped) while Spark unescapes them. This differs on all Spark "
-                          "versions: string elements are VALUE_STRING tokens unescaped via "
-                          "getText, so Spark 4.0 enableExactStringParsing does not apply. "
-                          "docs/compatibility.md 'JSON Normalization (String Types)'; "
-                          "https://github.com/NVIDIA/cudf-spark/issues/15240",
-                   strict=False)
-def test_from_json_map_with_arrays_escaped_xfail():
-    # Escaped quote/backslash and \\u escape sequences inside string elements: GPU keeps them
-    # verbatim, Spark unescapes -> documented divergence.
+def test_from_json_map_with_arrays_escaped():
+    # Escaped quote/backslash and \\u escape sequences inside string elements: the GPU unescapes
+    # them, matching Spark CPU.
     schema = StructType([StructField("a", StringType())])
     data = [
         ['{"a": ["x\\"y", "p\\\\q"]}'],
@@ -856,13 +891,9 @@ def test_from_json_map_with_arrays_escaped_xfail():
         conf=_enable_all_types_conf)
 
 @allow_non_gpu(*non_utc_allow)
-@pytest.mark.xfail(reason="Duplicate map keys: GPU keeps every occurrence (dense). On Spark 3.5.x "
-                          "from_json also keeps duplicates so this currently XPASSES under map_entries, "
-                          "but the behavior is mapKeyDedupPolicy/version-sensitive (later Spark may "
-                          "last-wins or raise), so it is left as a non-strict probe rather than a hard "
-                          "assertion. docs/compatibility.md duplicate-key note.",
-                   strict=False)
-def test_from_json_map_with_arrays_duplicate_keys_xfail():
+def test_from_json_map_with_arrays_duplicate_keys():
+    # Duplicate map keys: both the GPU and Spark from_json keep every occurrence in JSON document
+    # order, so the map_entries outputs match. docs/compatibility.md duplicate-key note.
     schema = StructType([StructField("a", StringType())])
     data = [['{"a": ["1"], "a": ["2", "3"]}']]
     assert_gpu_and_cpu_are_equal_collect(
@@ -871,16 +902,9 @@ def test_from_json_map_with_arrays_duplicate_keys_xfail():
         conf=_enable_all_types_conf)
 
 @allow_non_gpu(*non_utc_allow)
-@pytest.mark.xfail(reason="Nested object/array elements: the GPU returns each element's raw JSON "
-                          "substring, while Spark re-serializes them (whitespace and key formatting "
-                          "normalized). This differs on ALL Spark versions: from_json on a string "
-                          "column parses via a Reader (CreateJacksonParser.utf8String), so Spark "
-                          "4.0's enableExactStringParsing raw-bytes path (which requires a "
-                          "byte[]/file source) is unreachable and the CPU always re-serializes "
-                          "non-string tokens. docs/compatibility.md 'from_json Function'; "
-                          "https://github.com/NVIDIA/cudf-spark/issues/15240",
-                   strict=False)
-def test_from_json_map_with_arrays_nested_elements_xfail():
+def test_from_json_map_with_arrays_nested_elements():
+    # Nested object/array elements: the GPU re-serializes them compactly (whitespace and key
+    # formatting normalized), matching Spark CPU's re-serialization.
     schema = StructType([StructField("a", StringType())])
     data = [
         ['{"a": [{"x": 1}]}'],
@@ -894,23 +918,15 @@ def test_from_json_map_with_arrays_nested_elements_xfail():
 @allow_non_gpu(*non_utc_allow)
 @pytest.mark.skipif(is_before_spark_400(),
                     reason="spark.sql.json.enableExactStringParsing exists only in Spark 4.0+")
-@pytest.mark.xfail(reason="Regression guard that enableExactStringParsing is a no-op for from_json "
-                          "on a string column: with the option explicitly false the GPU raw "
-                          "elements diverge from the CPU exactly as they do with the default true, "
-                          "because from_json parses via a Reader (CreateJacksonParser.utf8String) "
-                          "and the option's raw-bytes path only applies to byte[]/file sources. "
-                          "docs/compatibility.md 'from_json Function'; "
-                          "https://github.com/NVIDIA/cudf-spark/issues/15240",
-                   strict=False)
-def test_from_json_map_with_arrays_exact_string_parsing_off_xfail():
+def test_from_json_map_with_arrays_exact_string_parsing_off():
     # Spark 4.0+ only: force enableExactStringParsing=false to confirm the option is a no-op for
-    # from_json on a string column -- the CPU re-serializes non-string tokens (so the GPU raw
-    # elements still diverge) exactly as with the default true, because the option's raw-bytes path
-    # is unreachable for a Reader source.
+    # from_json on a string column -- the GPU normalizes non-string tokens and matches the CPU
+    # exactly as with the default true, because the option's raw-bytes path is unreachable for a
+    # Reader source.
     schema = StructType([StructField("a", StringType())])
     data = [
-        ['{"a": [{"x": 1}]}'],       # nested object: GPU raw vs CPU re-serialized
-        ['{"a": [007, 1.00000]}'],   # numbers: GPU raw token vs CPU re-rendered
+        ['{"a": [{"x": 1}]}'],       # nested object: both re-serialize compactly
+        ['{"a": [007, 1.00000]}'],   # numbers: both re-render canonically
     ]
     options = {"allowNumericLeadingZeros": "true"}
     conf = copy_and_update(_enable_all_types_conf,
@@ -921,21 +937,15 @@ def test_from_json_map_with_arrays_exact_string_parsing_off_xfail():
         conf=conf)
 
 @allow_non_gpu(*non_utc_allow)
-@pytest.mark.xfail(reason="GPU keeps raw JSON number tokens; Spark re-renders them, so "
-                          "non-canonical spellings differ (007->7, 1.00000->1.0, 1e2->100.0). "
-                          "This differs on ALL Spark versions: from_json on a string column parses "
-                          "via a Reader (CreateJacksonParser.utf8String), so Spark 4.0's "
-                          "enableExactStringParsing raw-bytes path (which requires a byte[]/file "
-                          "source) is unreachable and the CPU always re-renders numbers via "
-                          "copyCurrentStructure. docs/compatibility.md 'from_json Function'; "
-                          "https://github.com/NVIDIA/cudf-spark/issues/15240",
-                   strict=False)
-def test_from_json_map_with_arrays_numeric_xfail():
-    # allowNumericLeadingZeros makes 007 parseable; floats diverge under default options.
+def test_from_json_map_with_arrays_numeric():
+    # allowNumericLeadingZeros makes 007 parseable; the GPU re-renders number tokens canonically,
+    # matching Spark CPU (007 -> 7, 1.00000 -> 1.0, 1e2 -> 100.0).
     schema = StructType([StructField("a", StringType())])
     data = [
-        ['{"a": [007]}'],            # leading zeros: GPU "007" vs Spark "7"
-        ['{"a": [1.00000, 1e2]}'],   # float re-render: GPU "1.00000"/"1e2" vs Spark "1.0"/"100.0"
+        ['{"a": [007]}'],            # leading zeros: both render 7
+        ['{"a": [-007]}'],           # negative leading zeros: sign kept, both render -7
+        ['{"a": [1.00000, 1e2]}'],   # float re-render: both render 1.0 / 100.0
+        ['{"a": [-1.00000, 1e-2]}'], # negative float / negative exponent: -1.0 / 0.01
     ]
     options = {"allowNumericLeadingZeros": "true"}
     assert_gpu_and_cpu_are_equal_collect(
@@ -951,9 +961,9 @@ def test_from_json_map_with_arrays_options(allow_single_quotes, allow_unquoted_c
     # MAP<STRING,ARRAY<STRING>> dispatch, proving the parser options reach the array path. Inputs
     # exercise single-quoted strings and literal control chars in elements; when an option is off
     # both engines reject its input alike (bad record -> null), so every combo stays GPU==CPU.
-    # allowNumericLeadingZeros stays false and allowNonNumericNumbers is not toggled here: where
-    # either would accept the token the GPU keeps it raw while Spark re-renders/quotes it -- the
-    # test_from_json_map_with_arrays_numeric_xfail / _nonnumeric_xfail probes cover those.
+    # allowNumericLeadingZeros stays false and allowNonNumericNumbers is not toggled here: the
+    # test_from_json_map_with_arrays_numeric / _nonnumeric tests cover the rendering of tokens
+    # those options accept.
     json_string_gen = StringGen(r'{"a": \["[0-9]{0,5}"\]}') \
         .with_special_pattern(r"""{'a': \['[0-9]{0,5}'\]}""", weight=50) \
         .with_special_pattern(r'{"(a|a\r\n\tb)": \["(xyz|01\r\n\t23)"\]}', weight=50)
@@ -965,19 +975,9 @@ def test_from_json_map_with_arrays_options(allow_single_quotes, allow_unquoted_c
         conf=_enable_all_types_conf)
 
 @allow_non_gpu(*non_utc_allow)
-@pytest.mark.xfail(reason="GPU keeps the bare NaN/Infinity token under allowNonNumericNumbers; "
-                          "Spark re-serializes non-numeric numbers as quoted strings (NaN -> "
-                          "'NaN', Infinity -> 'Infinity'), so the elements differ. This differs on "
-                          "ALL Spark versions: from_json on a string column parses via a Reader "
-                          "(CreateJacksonParser.utf8String), so Spark 4.0's enableExactStringParsing "
-                          "raw-bytes path (which requires a byte[]/file source) is unreachable and "
-                          "the CPU always re-serializes non-string tokens. docs/compatibility.md "
-                          "'from_json Function'; "
-                          "https://github.com/NVIDIA/cudf-spark/issues/15240",
-                   strict=False)
-def test_from_json_map_with_arrays_nonnumeric_xfail():
-    # allowNonNumericNumbers=true makes NaN/Infinity parseable; the GPU emits the bare token whereas
-    # Spark quotes it (verified GPU ['NaN','Infinity'] vs CPU ['"NaN"','"Infinity"']).
+def test_from_json_map_with_arrays_nonnumeric():
+    # allowNonNumericNumbers=true makes NaN/Infinity parseable; the GPU re-serializes the bare
+    # token as a quoted string (NaN -> "NaN", Infinity -> "Infinity"), matching Spark CPU.
     schema = StructType([StructField("a", StringType())])
     data = [
         ['{"a": [NaN, Infinity]}'],   # bare non-numeric tokens

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4076,12 +4076,8 @@ object GpuOverrides extends Logging {
 
         override def tagExprForGpu(): Unit = {
           a.schema match {
-            // from_json to a MAP is a "raw" extraction: values (and, for ARRAY<STRING>, array
-            // elements) are raw JSON text. Verified vs Spark 3.5.5, it diverges on only two cases:
-            // escapes are not unescaped, and object/nested-array elements stay as raw JSON
-            // substrings. Scalar elements, whole-row null on a non-array value, and
-            // document-order duplicate keys all match Spark. See docs/compatibility.md and
-            // GpuJsonToStructs.
+            // Both map schemas render to match Spark's Jackson output, so nothing to flag here.
+            // See `GpuJsonToStructs` and docs/compatibility.md for the contract and its caveats.
             case MapType(StringType, StringType, _) => ()
             case MapType(StringType, ArrayType(StringType, _), _) => ()
             case st: StructType =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -33,28 +33,33 @@ import org.apache.spark.sql.types._
 /**
  * GPU implementation of Spark's `from_json` (`JsonToStructs`).
  *
- * For a `MAP<STRING, ARRAY<STRING>>` (and `MAP<STRING, STRING>`) schema the map is extracted as a
- * "raw" map: keys, values and array elements are raw JSON byte ranges (surrounding quotes stripped
- * but NOT JSON-unescaped). Verified against Spark 3.5.5, the output diverges from Spark CPU on
- * three documented corner cases (see docs/compatibility.md):
- *  - escape sequences (e.g. `\"`, `\\`, `\\uXXXX`) are kept verbatim rather than
- *    unescaped/normalized;
- *  - for `ARRAY<STRING>`, object / nested-array elements are returned as their raw JSON substring
- *    rather than Spark's re-serialized form;
- *  - numeric elements keep their raw JSON token; Spark re-renders numbers, so non-canonical
- *    spellings differ (`007` -> `"7"` with `allowNumericLeadingZeros`, `1.00000` -> `"1.0"`,
- *    `1e2` -> `"100.0"`), and non-numeric numbers stay bare while Spark quotes them (`NaN` ->
- *    `"NaN"`, `Infinity` -> `"Infinity"`).
- * All of these differ from Spark on ALL versions, including 4.0.0+: `from_json` on a string column
- * parses via a Reader (Spark's `CreateJacksonParser.utf8String`), so Spark 4.0.0's
+ * For a `MAP<STRING, STRING>` or `MAP<STRING, ARRAY<STRING>>` schema the map's keys, values and
+ * array elements are rendered to match Spark CPU's Jackson output (see docs/compatibility.md):
+ * string tokens are de-quoted and JSON-unescaped; numbers are re-rendered canonically (integer
+ * leading zeros and `-0` stripped, floats in Java `Double.toString` form); the `NaN`/`Infinity`
+ * spellings accepted with `allowNonNumericNumbers` render as their quoted canonical forms; nested
+ * object/array values and elements are re-serialized compactly in document order. A map value that
+ * is the JSON `null` literal keeps its pair and yields a SQL NULL value (for `ARRAY<STRING>`, a
+ * null inner list), while for `ARRAY<STRING>` a value that is non-null but not a JSON array (a
+ * scalar or object) nulls the whole row (PERMISSIVE bad-record). A number the JSON parser refuses
+ * nulls the whole row the same way: the parser caps a number's digit count (signs, `.`, `e`/`E`,
+ * and leading zeros excluded) and applies that cap to integers and floats alike, so a number past
+ * it makes the record a Spark bad record whether it is a value, an array element, or buried inside
+ * a nested value. Duplicate keys are kept in document order on every supported Spark version:
+ * `JacksonParser.convertMap` builds `ArrayBasedMapData` directly, so `spark.sql.mapKeyDedupPolicy`
+ * never applies to `from_json`.
+ *
+ * The rendering is the same on every Spark version, including 4.0.0+: `from_json` on a string
+ * column parses via a Reader (Spark's `CreateJacksonParser.utf8String`), so Spark 4.0.0's
  * `spark.sql.json.enableExactStringParsing` (default `true`) does not apply. Its raw-source-byte
  * path (`JacksonParser`) fires only for `Array[Byte]` / file sources (e.g. `spark.read.json`),
- * never a Reader, so the CPU always re-serializes non-string tokens (cases 2/3, via
- * `copyCurrentStructure`) and always unescapes string tokens (case 1, via `getText`).
- * The following MATCH Spark and are NOT divergences: canonical elements whose raw text already
- * equals Spark's rendering (e.g. `1`, `1.5`, `true`); a map value that is not a JSON array and not
- * the JSON `null` literal nulls the whole row (PERMISSIVE bad-record); duplicate keys kept in
- * document order (matches Spark 3.5.x; later Spark may de-dup per `spark.sql.mapKeyDedupPolicy`).
+ * never a Reader, so the CPU always re-serializes non-string tokens (via `copyCurrentStructure`)
+ * and always unescapes string tokens (via `getText`) -- the same rendering produced here. Known
+ * caveats (docs/compatibility.md): invalid UTF-8 is out of scope (Spark's `InputStreamReader`
+ * replaces invalid byte sequences with U+FFFD while the GPU copies raw bytes through unchanged),
+ * and float parse fidelity matches the `get_json_object` path (mantissas beyond 2^53 are not
+ * correctly rounded, so an adversarial double can differ by 1 ULP and re-render to a different
+ * shortest string).
  */
 case class GpuJsonToStructs(
     schema: DataType,
@@ -75,8 +80,7 @@ case class GpuJsonToStructs(
   override protected def doColumnar(input: GpuColumnVector): cudf.ColumnVector = {
     NvtxRegistry.JSON_TO_STRUCTS {
       schema match {
-        // Raw extraction (no unescaping, duplicate keys kept, non-string elements as raw text) --
-        // see the class doc and docs/compatibility.md.
+        // The JNI name keeps its historical "Raw"; the output here is Spark-rendered, not raw.
         case MapType(StringType, ArrayType(StringType, _), _) =>
           JSONUtils.extractRawMapFromJsonString(input.getBase, cudfOptions,
             JSONUtils.MapValueType.ARRAY_OF_STRING)


### PR DESCRIPTION
The inconsistency between our `from_json` native kernel and Apache Spark is fixed in cudf-spark-jni, thus this PR:
 * Flip the six `from_json` map integration tests that were marked `xfail`
 * Add coverage for the `MAP<STRING,STRING>` value path
 * Update `docs/compatibility.md` and some code comments describing the new behaviors.
 
No plugin behavior changes here — the fix shipped in cudf-spark-jni.

Example for output of type `MAP<STRING,ARRAY<STRING>>`, at the Spark level:

| Query input | GPU before (wrong) | GPU after (matches CPU) |
|---|---|---|
| `{"a": ["x\"y", "p\\q"]}` | elements `x\"y`, `p\\q` | elements `x"y`, `p\q` |
| `{"a": ["\u00e9"]}` | element `\u00e9` — the escape intact | element `é` |
| `{"a": [{"x": 1}]}` | element `{"x": 1}` — with the space | element `{"x":1}` |
| `{"a": [[1, 2]]}` | element `[1, 2]` — with the space | element `[1,2]` |
| `{"a": [007]}` | element `007` | element `7` |
| `{"a": [NaN]}` | element `NaN` | element `"NaN"` — with the quotes |

The duplicate-key probe is different: it was already passing unexpectedly. Spark's `from_json` builds the map directly and bypasses `mapKeyDedupPolicy`, so `{"a": ["1"], "a": ["2", "3"]}` keeps both keys and our GPU implementation just follows.

Closes https://github.com/NVIDIA/cudf-spark/issues/15240.

Depends on:
 * https://github.com/NVIDIA/cudf-spark-jni/pull/4950