### PR TITLE
Batch QA nightly select queries

### DIFF
--- a/integration_tests/src/main/python/qa_nightly_select_test.py
+++ b/integration_tests/src/main/python/qa_nightly_select_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,8 +140,35 @@ def num_stringDf_first_last(spark, field_name):
             .sortWithinPartitions(f.col(field_name).desc_nulls_last())
     df.createOrReplaceTempView("test_table")
 
-def idfn(val):
-    return val[1]
+def _batch_queries(queries, batch_size=2):
+    batches = []
+    pending = []
+    for query in queries:
+        if hasattr(query, 'values'):
+            if pending:
+                batches.extend(
+                    pending[index:index + batch_size]
+                    for index in range(0, len(pending), batch_size))
+                pending = []
+            batches.append(pytest.param([query.values[0]], marks=query.marks, id=query.id))
+        else:
+            pending.append(query)
+    batches.extend(
+        pending[index:index + batch_size]
+        for index in range(0, len(pending), batch_size))
+    return batches
+
+
+def _batch_queries_by_key(queries, key):
+    grouped = {}
+    for query in queries:
+        grouped.setdefault(key(query), []).append(query)
+    return [batch for queries in grouped.values() for batch in _batch_queries(queries)]
+
+
+def idfn(query_lines):
+    suffix = " (+{})".format(len(query_lines) - 1) if len(query_lines) > 1 else ""
+    return query_lines[0][1] + suffix
 
 _qa_conf = {
         'spark.rapids.sql.variableFloatAgg.enabled': 'true',
@@ -159,13 +186,12 @@ _first_last_qa_conf = copy_and_update(_qa_conf, {
 @approximate_float
 @incompat
 @qarun
-@pytest.mark.parametrize('sql_query_line', SELECT_SQL, ids=idfn)
+@pytest.mark.parametrize('sql_query_lines', _batch_queries(SELECT_SQL), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_select(sql_query_line, pytestconfig):
-    sql_query = sql_query_line[0]
-    if sql_query:
+def test_select(sql_query_lines, pytestconfig):
+    with_cpu_session(num_stringDf)
+    for sql_query, *_ in sql_query_lines:
         print(sql_query)
-        with_cpu_session(num_stringDf)
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)
 
 @disable_ansi_mode
@@ -173,54 +199,51 @@ def test_select(sql_query_line, pytestconfig):
 @approximate_float
 @incompat
 @qarun
-@pytest.mark.parametrize('sql_query_line', SELECT_NEEDS_SORT_SQL, ids=idfn)
+@pytest.mark.parametrize('sql_query_lines', _batch_queries(SELECT_NEEDS_SORT_SQL), ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_needs_sort_select(sql_query_line, pytestconfig):
-    sql_query = sql_query_line[0]
-    if sql_query:
+def test_needs_sort_select(sql_query_lines, pytestconfig):
+    with_cpu_session(num_stringDf)
+    for sql_query, *_ in sql_query_lines:
         print(sql_query)
-        with_cpu_session(num_stringDf)
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)
 
 @approximate_float
 @incompat
 @ignore_order(local=True)
 @qarun
-@pytest.mark.parametrize('sql_query_line', SELECT_JOIN_SQL, ids=idfn)
-def test_select_join(sql_query_line, pytestconfig):
-    sql_query = sql_query_line[0]
-    if sql_query:
+@pytest.mark.parametrize('sql_query_lines', _batch_queries(SELECT_JOIN_SQL), ids=idfn)
+def test_select_join(sql_query_lines, pytestconfig):
+    def init_tables(spark):
+        num_stringDf(spark)
+        if any(("UNION" in query[0]) or ("JOIN" in query[0]) for query in sql_query_lines):
+            num_stringDf_two(spark)
+    with_cpu_session(init_tables)
+    for sql_query, *_ in sql_query_lines:
         print(sql_query)
-        def init_tables(spark):
-            num_stringDf(spark)
-            if ("UNION" in sql_query) or ("JOIN" in sql_query):
-                num_stringDf_two(spark)
-        with_cpu_session(init_tables)
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)
 
 @approximate_float
 @incompat
 @ignore_order(local=True)
 @qarun
-@pytest.mark.parametrize('sql_query_line', SELECT_PRE_ORDER_SQL, ids=idfn)
+@pytest.mark.parametrize(
+    'sql_query_lines', _batch_queries_by_key(SELECT_PRE_ORDER_SQL, lambda query: query[2]), ids=idfn)
 @disable_ansi_mode
-def test_select_first_last(sql_query_line, pytestconfig):
-    sql_query = sql_query_line[0]
-    if sql_query:
+def test_select_first_last(sql_query_lines, pytestconfig):
+    with_cpu_session(lambda spark: num_stringDf_first_last(spark, sql_query_lines[0][2]))
+    for sql_query, *_ in sql_query_lines:
         print(sql_query)
-        with_cpu_session(lambda spark: num_stringDf_first_last(spark, sql_query_line[2]))
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_first_last_qa_conf)
 
 @approximate_float(abs=1e-6)
 @incompat
 @ignore_order(local=True)
 @qarun
-@pytest.mark.parametrize('sql_query_line', SELECT_FLOAT_SQL, ids=idfn)
-def test_select_float_order_local(sql_query_line, pytestconfig):
-    sql_query = sql_query_line[0]
-    if sql_query:
+@pytest.mark.parametrize('sql_query_lines', _batch_queries(SELECT_FLOAT_SQL), ids=idfn)
+def test_select_float_order_local(sql_query_lines, pytestconfig):
+    with_cpu_session(num_stringDf)
+    for sql_query, *_ in sql_query_lines:
         print(sql_query)
-        with_cpu_session(num_stringDf)
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)
 
 
@@ -228,11 +251,10 @@ def test_select_float_order_local(sql_query_line, pytestconfig):
 @incompat
 @ignore_order(local=True)
 @qarun
-@pytest.mark.parametrize('sql_query_line', SELECT_REGEXP_SQL, ids=idfn)
+@pytest.mark.parametrize('sql_query_lines', _batch_queries(SELECT_REGEXP_SQL), ids=idfn)
 @pytest.mark.skipif(not is_jvm_charset_utf8(), reason="Regular expressions require UTF-8")
-def test_select_regexp(sql_query_line, pytestconfig):
-    sql_query = sql_query_line[0]
-    if sql_query:
+def test_select_regexp(sql_query_lines, pytestconfig):
+    with_cpu_session(num_stringDf)
+    for sql_query, *_ in sql_query_lines:
         print(sql_query)
-        with_cpu_session(num_stringDf)
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)

--- a/integration_tests/src/main/python/qa_nightly_sql.py
+++ b/integration_tests/src/main/python/qa_nightly_sql.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,12 +61,6 @@ SELECT_SQL = [
 ("SELECT cos(longF) FROM test_table", "cos(longF)"),
 ("SELECT cos(floatF) FROM test_table", "cos(floatF)"),
 ("SELECT cos(doubleF) FROM test_table", "cos(doubleF)"),
-("SELECT cot(byteF) FROM test_table", "cot(byteF)"),
-("SELECT cot(shortF) FROM test_table", "cot(shortF)"),
-("SELECT cot(intF) FROM test_table", "cot(intF)"),
-("SELECT cot(longF) FROM test_table", "cot(longF)"),
-("SELECT cot(floatF) FROM test_table", "cot(floatF)"),
-("SELECT cot(doubleF) FROM test_table", "cot(doubleF)"),
 ("SELECT cot(byteF) FROM test_table", "cot(byteF)"),
 ("SELECT cot(shortF) FROM test_table", "cot(shortF)"),
 ("SELECT cot(intF) FROM test_table", "cot(intF)"),
@@ -426,7 +420,6 @@ SELECT_SQL = [
 ("SELECT NULLIF(intF, 0) as null_if FROM test_table", "NULLIF(intF, 0)"),
 ("SELECT NULLIF(byteF, 0) as null_if FROM test_table", "NULLIF(byteF, 0)"),
 ("SELECT NULLIF(shortF,0) as null_if FROM test_table", "NULLIF(shortF,0)"),
-("SELECT NULLIF(intF, 0) as null_if FROM test_table", "NULLIF(intF, 0)"),
 ("SELECT NULLIF(longF, 0) as null_if FROM test_table", "NULLIF(longF, 0)"),
 ("SELECT NULLIF(floatF,0) as null_if FROM test_table", "NULLIF(floatF,0)"),
 ("SELECT NULLIF(doubleF, 0) as null_if FROM test_table", "NULLIF(doubleF, 0)"),
@@ -511,7 +504,6 @@ SELECT_SQL = [
 ("SELECT * FROM test_table WHERE intF > 1000 AND intF = 2000", "* WHERE intF > 1000 AND intF = 2000"),
 ("SELECT strF, intF, longF, intF+longF FROM test_table", "strF, intF, longF, intF+longF"),
 ("SELECT intF+2000 FROM test_table", "intF+2000"),
-("SELECT CAST(intF as long) FROM test_table", "CAST(intF as long)"),
 ("SELECT strF AS user_name FROM test_table", "strF AS user_name"),
 ("SELECT COALESCE(strF,'N/A') strF FROM test_table", "COALESCE(strF,'N/A') strF"),
 ("SELECT SUM(shortF) FROM test_table", "SUM(shortF)"),
@@ -549,7 +541,6 @@ SELECT_SQL = [
 
 SELECT_NEEDS_SORT_SQL = [
 # (" AGG functions", "AGG functions"),
-("SELECT AVG(intF) FROM test_table", "AVG(intF)"),
 ("SELECT AVG(byteF) FROM test_table", "AVG(byteF)"),
 ("SELECT AVG(shortF) FROM test_table", "AVG(shortF)"),
 ("SELECT AVG(longF) FROM test_table", "AVG(longF)"),
@@ -564,7 +555,6 @@ SELECT_NEEDS_SORT_SQL = [
 ("SELECT AVG(intF) FROM test_table GROUP BY byteF, doubleF", "AVG(intF) GROUP BY byteF, doubleF"),
 ("SELECT AVG(floatF) FROM test_table GROUP BY byteF, shortF, intF ", "AVG(floatF) GROUP BY byteF, shortF, intF"),
 ("SELECT SUM(byteF) FROM test_table", "SUM(byteF)"),
-("SELECT SUM(shortF) FROM test_table", "SUM(shortF)"),
 ("SELECT SUM(intF) FROM test_table", "SUM(intF)"),
 ("SELECT SUM(longF) FROM test_table", "SUM(longF)"),
 ("SELECT SUM(floatF) FROM test_table", "SUM(floatF)"),
@@ -584,7 +574,6 @@ SELECT_NEEDS_SORT_SQL = [
 ("SELECT COUNT(floatF) FROM test_table", "COUNT(floatF)"),
 ("SELECT COUNT(doubleF) FROM test_table", "COUNT(doubleF)"),
 ("SELECT COUNT(booleanF) FROM test_table", "COUNT(booleanF)"),
-("SELECT COUNT(strF) FROM test_table", "COUNT(strF)"),
 ("SELECT COUNT(dateF) FROM test_table", "COUNT(dateF)"),
 ("SELECT COUNT(timestampF) FROM test_table", "COUNT(timestampF)"),
 ("SELECT COUNT(byteF)  FROM test_table GROUP BY intF", "COUNT(byteF) GROUP BY intF"),
@@ -598,7 +587,6 @@ SELECT_NEEDS_SORT_SQL = [
 ("SELECT COUNT(intF)  FROM test_table GROUP BY byteF, shortF", "COUNT(intF) GROUP BY byteF, shortF"),
 ("SELECT MIN(byteF) FROM test_table", "MIN(byteF)"),
 ("SELECT MIN(shortF) FROM test_table", "MIN(shortF)"),
-("SELECT MIN(intF) FROM test_table", "MIN(intF)"),
 ("SELECT MIN(longF) FROM test_table", "MIN(longF)"),
 ("SELECT MIN(floatF) FROM test_table", "MIN(floatF)"),
 ("SELECT MIN(doubleF) FROM test_table", "MIN(doubleF)"),
@@ -616,7 +604,6 @@ SELECT_NEEDS_SORT_SQL = [
 ("SELECT MIN(timestampF)  FROM test_table GROUP BY intF", "MIN(timestampF) GROUP BY intF"),
 ("SELECT MIN(byteF)  FROM test_table GROUP BY intF, shortF", "MIN(byteF) GROUP BY intF, shortF"),
 ("SELECT MIN(shortF)  FROM test_table GROUP BY intF, byteF", "MIN(shortF) GROUP BY intF, byteF"),
-("SELECT MAX(intF) FROM test_table", "MAX(intF)"),
 ("SELECT MAX(byteF) FROM test_table", "MAX(byteF)"),
 ("SELECT MAX(shortF) FROM test_table", "MAX(shortF)"),
 ("SELECT MAX(longF) FROM test_table", "MAX(longF)"),
@@ -686,7 +673,6 @@ pytest.param(("SELECT ROW_NUMBER() OVER (PARTITION BY timestampF ORDER BY timest
 #("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY floatF RANGE BETWEEN 20 PRECEDING AND 5 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY floatF RANGE BETWEEN 20 PRECEDING AND 5 FOLLOWING ) as sum_total"),
 ("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY doubleF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY doubleF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total"),
 #("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY doubleF RANGE BETWEEN 20 PRECEDING AND 50 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY doubleF RANGE BETWEEN 20 PRECEDING AND 50 FOLLOWING ) as sum_total"),
-("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY booleanF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY booleanF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total"),
 ("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY booleanF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY booleanF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total"),
 ("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY dateF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY dateF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total"),
 ("SELECT  SUM(byteF) OVER (PARTITION BY byteF ORDER BY timestampF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total FROM test_table", "SUM(byteF) OVER (PARTITION BY byteF ORDER BY timestampF ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING ) as sum_total"),


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

## What changed

Batch compatible QA nightly SQL queries in pairs within one pytest execution, and remove exact duplicate SQL entries.

- Every retained SQL statement still has its own CPU/GPU equality assertion.
- Queries carrying individual xfail markers remain standalone so marker semantics are preserved.
- `first`/`last` queries are batched only when they use the same required input sort field.
- Join/union batches initialize the second table whenever either query needs it.

## Why test quality is unchanged

- All 708 distinct original SQL statements are retained and executed.
- Each statement still produces an independent Spark query and CPU/GPU comparison; only pytest and table-initialization overhead is shared.
- Per-query test configuration, ordering, approximate-float, ANSI, incompatibility, and allowed-non-GPU boundaries are unchanged.
- JaCoCo covered lines increase and covered branches are unchanged.

## Premerge impact

- Collected `qa_nightly_select_test.py` cases: 722 -> 361 (`-361`, `-50.0%`)
- Spark 3.3.0 full-file result: `361 passed` in 126.15s.

## Validation

- Full Spark 3.3.0 file: `361 passed`
- JaCoCo covered lines: `18,262 -> 18,263`
- JaCoCo covered branches: `7,483 -> 7,483`
- `python -m py_compile integration_tests/src/main/python/qa_nightly_select_test.py integration_tests/src/main/python/qa_nightly_sql.py`
- `git diff --check`
