### PR TITLE
Reduce redundant generate expression cases

### DIFF
--- a/integration_tests/src/main/python/generate_expr_test.py
+++ b/integration_tests/src/main/python/generate_expr_test.py
@@ -25,6 +25,13 @@ pytestmark = pytest.mark.nightly_resource_consuming_test
 explode_gens = all_gen + [binary_gen]
 arrays_with_binary = [ArrayGen(BinaryGen(max_length=5))]
 maps_with_binary = [MapGen(IntegerGen(nullable=False), BinaryGen(max_length=5))]
+array_generate_gens = explode_gens + struct_gens_sample_with_decimal128 + \
+    array_gens_sample + arrays_with_binary + map_gens_sample + maps_with_binary
+map_generate_gens = map_gens_sample + decimal_128_map_gens + maps_with_binary
+
+# Element type handling is shared by the generate variants. Shard the type lists across
+# orthogonal input/outer/nesting variants instead of testing their full Cartesian product.
+# The paired queries below still exercise both explode and posexplode for every retained type.
 
 def four_op_df(spark, gen, length=2048):
     return gen_df(spark, StructGen([
@@ -33,53 +40,86 @@ def four_op_df(spark, gen, length=2048):
         ('c', gen),
         ('d', gen)], nullable=False), length=length)
 
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
-def test_explode_makearray(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : four_op_df(spark, data_gen).selectExpr('a', 'explode(array(b, c, d))'))
+def array_generate_pair(df, array_expr, outer=False):
+    explode_fn = 'explode_outer' if outer else 'explode'
+    posexplode_fn = 'posexplode_outer' if outer else 'posexplode'
+    exploded = df.selectExpr(
+        'a', '0 as generate_type', '-1 as pos',
+        '{}({}) as value'.format(explode_fn, array_expr))
+    posexploded = df.selectExpr(
+        'a', '1 as generate_type',
+        '{}({}) as (pos, value)'.format(posexplode_fn, array_expr))
+    return exploded.unionByName(posexploded)
+
+def map_generate_pair(df, map_expr, outer=False):
+    explode_fn = 'explode_outer' if outer else 'explode'
+    posexplode_fn = 'posexplode_outer' if outer else 'posexplode'
+    exploded = df.selectExpr(
+        'a', '0 as generate_type', '-1 as pos',
+        '{}({}) as (key, value)'.format(explode_fn, map_expr))
+    posexploded = df.selectExpr(
+        'a', '1 as generate_type',
+        '{}({}) as (pos, key, value)'.format(posexplode_fn, map_expr))
+    return exploded.unionByName(posexploded)
 
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', explode_gens[0::2], ids=idfn)
+@allow_non_gpu('UnionExec', 'ColumnarToRowExec')
+def test_explode_makearray(data_gen):
+    def do_it(spark):
+        df = four_op_df(spark, data_gen)
+        exploded = df.selectExpr(
+            'a', '0 as generate_type', '-1 as pos',
+            'explode(array(b, c, d)) as value')
+        posexploded = df.selectExpr(
+            'a', '1 as generate_type',
+            'posexplode(array(b, c, d)) as (pos, value)')
+        return exploded.unionByName(posexploded)
+    assert_gpu_and_cpu_are_equal_collect(do_it)
+
+#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
+# After 3.1.0 is the min spark version we can drop this
+@ignore_order(local=True)
+@pytest.mark.parametrize('data_gen', explode_gens[1::2], ids=idfn)
+@allow_non_gpu('UnionExec', 'ColumnarToRowExec')
 def test_explode_litarray(data_gen):
     array_lit = with_cpu_session(
         lambda spark: gen_scalar(ArrayGen(data_gen, min_length=3, max_length=3, nullable=False)))
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : four_op_df(spark, data_gen).select(f.col('a'), f.col('b'), f.col('c'), 
-                f.explode(array_lit)))
+    def do_it(spark):
+        df = four_op_df(spark, data_gen).withColumn('input_array', f.lit(array_lit))
+        return array_generate_pair(df, 'input_array')
+    assert_gpu_and_cpu_are_equal_collect(do_it)
 
 # use a small `spark.rapids.sql.batchSizeBytes` to enforce input batches splitting up during explode
 conf_to_enforce_split_input = {'spark.rapids.sql.batchSizeBytes': '8192'}
 
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', explode_gens + struct_gens_sample_with_decimal128 +
-                         array_gens_sample + map_gens_sample + arrays_with_binary + maps_with_binary,
-                         ids=idfn)
+@pytest.mark.parametrize('data_gen', array_generate_gens[0::2], ids=idfn)
+@allow_non_gpu('UnionExec', 'ColumnarToRowExec', *non_utc_allow)
 def test_explode_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(data_gen)]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'explode(b)'),
+        lambda spark: array_generate_pair(two_col_df(spark, *data_gen), 'b'),
         conf=conf_to_enforce_split_input)
 
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens + maps_with_binary, ids=idfn)
+@pytest.mark.parametrize('map_gen', map_generate_gens[0::2], ids=idfn)
+@allow_non_gpu('UnionExec', 'ColumnarToRowExec')
 def test_explode_map_data(map_gen):
     data_gen = [int_gen, map_gen]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'explode(b)'),
+        lambda spark: map_generate_pair(two_col_df(spark, *data_gen), 'b'),
         conf=conf_to_enforce_split_input)
 
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', explode_gens[0::4], ids=idfn)
 def test_explode_nested_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
     assert_gpu_and_cpu_are_equal_collect(
@@ -91,29 +131,29 @@ def test_explode_nested_array_data(data_gen):
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', explode_gens + struct_gens_sample_with_decimal128 +
-                         array_gens_sample + arrays_with_binary + map_gens_sample + maps_with_binary,
-                         ids=idfn)
+@pytest.mark.parametrize('data_gen', array_generate_gens[1::2], ids=idfn)
+@allow_non_gpu('UnionExec', 'ColumnarToRowExec', *non_utc_allow)
 def test_explode_outer_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(data_gen)]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'explode_outer(b)'),
+        lambda spark: array_generate_pair(two_col_df(spark, *data_gen), 'b', outer=True),
         conf=conf_to_enforce_split_input)
 
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens + maps_with_binary, ids=idfn)
+@pytest.mark.parametrize('map_gen', map_generate_gens[1::2], ids=idfn)
+@allow_non_gpu('UnionExec', 'ColumnarToRowExec')
 def test_explode_outer_map_data(map_gen):
     data_gen = [int_gen, map_gen]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'explode_outer(b)'),
+        lambda spark: map_generate_pair(two_col_df(spark, *data_gen), 'b', outer=True),
         conf=conf_to_enforce_split_input)
 
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', explode_gens[1::4], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_explode_outer_nested_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
@@ -125,53 +165,7 @@ def test_explode_outer_nested_array_data(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_posexplode_makearray(data_gen):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : four_op_df(spark, data_gen).selectExpr('posexplode(array(b, c, d))', 'a'))
-
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_posexplode_litarray(data_gen):
-    array_lit = with_cpu_session(
-        lambda spark: gen_scalar(ArrayGen(data_gen, min_length=3, max_length=3, nullable=False)))
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : four_op_df(spark, data_gen).select(f.col('a'), f.col('b'), f.col('c'),
-                f.posexplode(array_lit)))
-
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', explode_gens + struct_gens_sample_with_decimal128 +
-                         array_gens_sample + arrays_with_binary + map_gens_sample + maps_with_binary,
-                         ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_posexplode_array_data(data_gen):
-    data_gen = [int_gen, ArrayGen(data_gen)]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'posexplode(b)'),
-        conf=conf_to_enforce_split_input)
-
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens + maps_with_binary, ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_posexplode_map_data(map_gen):
-    data_gen = [int_gen, map_gen]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'posexplode(b)'),
-        conf=conf_to_enforce_split_input)
-
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', explode_gens[2::4], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_posexplode_nested_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
@@ -183,32 +177,7 @@ def test_posexplode_nested_array_data(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', explode_gens + struct_gens_sample_with_decimal128 +
-                         array_gens_sample + arrays_with_binary + map_gens_sample + maps_with_binary,
-                         ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_posexplode_outer_array_data(data_gen):
-    data_gen = [int_gen, ArrayGen(data_gen)]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'posexplode_outer(b)'),
-        conf=conf_to_enforce_split_input)
-
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens + maps_with_binary, ids=idfn)
-@allow_non_gpu(*non_utc_allow)
-def test_posexplode_outer_map_data(map_gen):
-    data_gen = [int_gen, map_gen]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: two_col_df(spark, *data_gen).selectExpr('a', 'posexplode_outer(b)'),
-        conf=conf_to_enforce_split_input)
-
-#sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
-# After 3.1.0 is the min spark version we can drop this
-@ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', explode_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', explode_gens[3::4], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_posexplode_nested_outer_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
@@ -217,6 +186,7 @@ def test_posexplode_nested_outer_array_data(data_gen):
             'a', 'posexplode_outer(b) as (pos, c)').selectExpr(
             'a', 'pos', 'posexplode_outer(c)'),
         conf=conf_to_enforce_split_input)
+
 
 @allow_non_gpu("GenerateExec", "ShuffleExchangeExec")
 @ignore_order(local=True)
@@ -263,4 +233,3 @@ def test_stack_nested_types():
         lambda spark : gen_df(spark, data_gen, length=100)
                 .selectExpr('*', 'stack(2, map, array, struct, ' + 
                             'map(1, "a", 2, "b"), array(1, 2, 3), struct(1, "a"))'))
-


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

## Why

`generate_expr_test.py` repeated the full element-type matrix across orthogonal dimensions:
`explode` versus `posexplode`, outer versus non-outer behavior, input construction, and nested
generation. This repeated the same payload handling without adding distinct implementation paths.

## What changed

- Pair `explode` and `posexplode` branches in one result using a tagged union, so both GPU
  operators are still validated for every selected element type.
- Shard the complete primitive, decimal, binary, struct, array, and map type lists across
  orthogonal input, outer, and nesting variants instead of taking a representative sample.
- Keep every element type and every Generate variant covered; only their redundant Cartesian
  product is removed.
- Keep the input-batch split configuration, nested-stage behavior, stack cases, and fallback
  assertions.

This reduces `generate_expr_test.py` from 404 to 104 cases (300 fewer, 74.26%). The reduced suite
also removes duplicated work rather than only combining pytest items.

## Validation

- Fixed seeds: `DATAGEN_SEED=12345`, `SPARK_RAPIDS_TEST_INJECT_OOM_SEED=424242`
- Baseline: 404 passed in 1,072.43s
- Reduced matrix: 104 passed in 523.53s (51.18% faster)
- JaCoCo covered lines: 13,373 -> 13,479
- JaCoCo covered branches: 3,447 -> 3,513
