### PR TITLE
Fall back to CPU for to_json sortKeys [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1708,6 +1708,27 @@ def test_structs_to_json_fallback_pretty():
         structs_to_json_fallback_class,
         conf=conf)
 
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='sortKeys option was added in Spark 4.2.0')
+@allow_non_gpu(*structs_to_json_fallback_allow)
+@pytest.mark.parametrize('sort_keys_option', ['sortKeys', 'sortkeys'])
+def test_structs_to_json_fallback_sort_keys(sort_keys_option):
+    def struct_to_json(spark):
+        return spark.range(3).select(
+            f.to_json(
+                f.struct(
+                    f.col('id').alias('b'),
+                    (f.col('id') + 1).alias('a')),
+                {sort_keys_option: True}).alias('my_json'))
+
+    conf = copy_and_update(_enable_all_types_conf,
+                           {'spark.rapids.sql.expression.StructsToJson': True})
+
+    assert_gpu_fallback_collect(
+        lambda spark: struct_to_json(spark),
+        structs_to_json_fallback_class,
+        conf=conf)
+
 #####################################################
 # Some from_json tests ported over from Apache Spark
 #####################################################

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuStructsToJson.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuStructsToJson.scala
@@ -41,6 +41,11 @@ class GpuStructsToJsonMeta(
     if (expr.options.get("pretty").exists(_.equalsIgnoreCase("true"))) {
       willNotWorkOnGpu("to_json option pretty=true is not supported")
     }
+    if (expr.options.exists { case (key, value) =>
+      key.equalsIgnoreCase("sortKeys") && value.equalsIgnoreCase("true")
+    }) {
+      willNotWorkOnGpu("to_json option sortKeys=true is not supported")
+    }
     val options = GpuJsonUtils.parseJSONOptions(expr.options)
     val hasDates = TrampolineUtil.dataTypeExistsRecursively(expr.child.dataType,
       _.isInstanceOf[DateType])


### PR DESCRIPTION

Contributes to #15502

### Description

Spark 4.2 adds the  sortKeys option to to_json. When enabled, Spark’s CPU implementation sorts struct fields and map entries alphabetically. The GPU implementation ignores this option and emits keys in schema or storage order which can produce different JSON strings for the same query.

This change prioritizes correctness by falling StructsToJson back to CPU when sortKeys=true is specified, including case-insensitive spellings such as sortkeys. The check is added to the shared GpuStructsToJsonMeta path, which also covers Spark 4.x expressions lowered through StructsToJsonEvaluator.


####Testing:
A Spark 4.2 test uses spark.range input with fields ordered b, a, avoiding constant folding and ensuring the test is sensitive to key ordering. It verifies both result equality and the expected CPU fallback for sortKeys and sortkeys.

```
json_test.py -k test_structs_to_json_fallback_sort_keys on Apache Spark 4.2.0 / Scala 2.13 — 2 passed
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
