### PR TITLE
Normalize float/double inside GpuCollectSet for Spark 4.2 [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1156,6 +1156,123 @@ def test_hash_groupby_collect_partial_replace_fallback(data_gen,
         non_exist_classes=','.join(non_exist_clz),
         conf=conf)
 
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set float/double bit-key buffers and RESPECT NULLS need Spark 4.2+')
+@ignore_order(local=True)
+@allow_non_gpu('ObjectHashAggregateExec', 'SortAggregateExec',
+               'ShuffleExchangeExec', 'HashPartitioning', 'SortExec',
+               'SortArray', 'Alias', 'Literal', 'CollectSet',
+               'AggregateExpression', 'ProjectExec', 'Cast', *non_utc_allow)
+@pytest.mark.parametrize('replace_mode', _replace_modes_non_distinct, ids=idfn)
+@pytest.mark.parametrize('fp_type', ['FLOAT', 'DOUBLE'], ids=idfn)
+def test_hash_groupby_collect_partial_replace_respect_nulls_float_double(replace_mode, fp_type):
+    """Mixed CPU/GPU CollectSet for Float/Double with IGNORE/RESPECT NULLS on Spark 4.2+."""
+    conf = {'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
+            'spark.sql.adaptive.enabled': 'false',
+            'spark.sql.execution.useObjectHashAggregateExec': 'false'}
+
+    cpu_clz, gpu_clz = ['CollectSet'], ['GpuCollectSet']
+    if is_databricks_runtime():
+        if replace_mode == 'partial':
+            exist_clz, non_exist_clz = cpu_clz, gpu_clz
+        else:
+            exist_clz, non_exist_clz = gpu_clz, cpu_clz
+    else:
+        exist_clz = cpu_clz + gpu_clz
+        non_exist_clz = []
+
+    # Mixed-null and all-null groups exercise containsNull on the Spark 4.2 bit-key buffer.
+    sql = f"""
+        SELECT a,
+               sort_array(collect_set(b) IGNORE NULLS) AS ignore_set,
+               sort_array(collect_set(b) RESPECT NULLS) AS respect_set
+        FROM VALUES
+            (1, CAST(1.0 AS {fp_type})),
+            (1, CAST(NULL AS {fp_type})),
+            (1, CAST(1.0 AS {fp_type})),
+            (1, CAST(NULL AS {fp_type})),
+            (2, CAST(NULL AS {fp_type})),
+            (2, CAST(NULL AS {fp_type})),
+            (3, CAST(5.0 AS {fp_type})),
+            (3, CAST(NULL AS {fp_type}))
+        AS tab(a, b)
+        GROUP BY a
+    """
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.sql(sql),
+        exist_classes=','.join(exist_clz),
+        non_exist_classes=','.join(non_exist_clz),
+        conf=conf)
+
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set float/double normalized bit-key buffers need Spark 4.2+')
+@ignore_order(local=True)
+@allow_non_gpu('ObjectHashAggregateExec', 'SortAggregateExec',
+               'ShuffleExchangeExec', 'HashPartitioning', 'SortExec',
+               'SortArray', 'Alias', 'Literal', 'CollectSet',
+               'AggregateExpression', 'ProjectExec', 'Cast', *non_utc_allow)
+@pytest.mark.parametrize('replace_mode', _replace_modes_non_distinct, ids=idfn)
+@pytest.mark.parametrize('fp_type', ['FLOAT', 'DOUBLE'], ids=idfn)
+def test_hash_groupby_collect_partial_replace_float_double_edge_cases(replace_mode, fp_type):
+    """Deterministic +0/-0/NaN/inf/null CollectSet round-trip across mixed CPU/GPU stages."""
+    conf = {'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
+            'spark.sql.adaptive.enabled': 'false',
+            'spark.sql.execution.useObjectHashAggregateExec': 'false'}
+
+    cpu_clz, gpu_clz = ['CollectSet'], ['GpuCollectSet']
+    if is_databricks_runtime():
+        if replace_mode == 'partial':
+            exist_clz, non_exist_clz = cpu_clz, gpu_clz
+        else:
+            exist_clz, non_exist_clz = gpu_clz, cpu_clz
+    else:
+        exist_clz = cpu_clz + gpu_clz
+        non_exist_clz = []
+
+    # Put +0, -0, multiple NaN payloads, +/-inf and null in the same group so
+    # normalization/dedup is forced rather than relying on RepeatSeqGen sampling.
+    sql = f"""
+        SELECT a, sort_array(collect_set(b)) AS s
+        FROM VALUES
+            (1, CAST(0.0 AS {fp_type})),
+            (1, CAST(-0.0 AS {fp_type})),
+            (1, CAST('NaN' AS {fp_type})),
+            (1, CAST('NaN' AS {fp_type})),
+            (1, CAST('Infinity' AS {fp_type})),
+            (1, CAST('-Infinity' AS {fp_type})),
+            (1, CAST(NULL AS {fp_type})),
+            (1, CAST(1.5 AS {fp_type})),
+            (2, CAST(NULL AS {fp_type})),
+            (2, CAST(NULL AS {fp_type}))
+        AS tab(a, b)
+        GROUP BY a
+    """
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.sql(sql),
+        exist_classes=','.join(exist_clz),
+        non_exist_classes=','.join(non_exist_clz),
+        conf=conf)
+
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collect_set float/double normalized bit-key buffers need Spark 4.2+')
+@ignore_order(local=True)
+@allow_non_gpu('ProjectExec', 'Cast', *non_utc_allow)
+@pytest.mark.parametrize('fp_type', ['FLOAT', 'DOUBLE'], ids=idfn)
+def test_hash_reduction_collect_set_float_double_empty(fp_type):
+    """Empty typed Float/Double collect_set must return an empty array, not null."""
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql(f"""
+            SELECT sort_array(collect_set(b)) AS s
+            FROM VALUES (CAST(1.0 AS {fp_type})) AS tab(b)
+            WHERE 1 = 0
+        """))
+
+
 # The special case is to test when the physical plan is being re-written due to the re-optimize
 # of AQE taking effect, which is rare in real world scenarios. So far, this kind of problem only
 # has encountered when there exists a local aggregate ahead of the TypedImperativeAggregate. Then,

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2536,7 +2536,15 @@ def test_window_aggs_for_fully_unbounded_partitioned_collect_set():
     runs through the `GpuUnboundedToUnboundedAggWindowExec` (which optimizes it to run via sort-based group-by
     aggregations).
     Note: This optimization only holds for the partitioned case.  Unpartitioned windows are not supported yet.
+
+    On Spark 4.2+, Float/Double CollectSet uses a bit-key hash-agg projection that is incompatible with
+    GpuUnboundedToUnboundedAggWindowExec. Mixed-type unbounded windows that include Float/Double therefore
+    fall back to regular GpuWindowExec for the whole Window node (allBatched=false). Float/Double-only
+    unbounded coverage is in test_window_aggs_for_fully_unbounded_partitioned_collect_set_float_double_spark420.
     """
+    # On Spark 4.2+ float/double force the mixed WindowExec onto GpuWindowExec.
+    expected_exec = (['GpuWindowExec'] if is_spark_420_or_later()
+                     else ['GpuUnboundedToUnboundedAggWindowExec'])
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: gen_df(spark, _gen_data_for_collect_set, length=2048),
         "window_collect_table",
@@ -2594,7 +2602,53 @@ def test_window_aggs_for_fully_unbounded_partitioned_collect_set():
               'spark.rapids.sql.window.unboundedAgg.enabled': True,
               'spark.sql.parquet.int96RebaseModeInWrite': 'LEGACY',
               'spark.sql.adaptive.enabled': 'false'},
-        validate_execs_in_gpu_plan=['GpuUnboundedToUnboundedAggWindowExec'])
+        validate_execs_in_gpu_plan=expected_exec)
+
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='Spark 4.2 float/double CollectSet uses bit-key hash path incompatible '
+                           'with GpuUnboundedToUnboundedAggWindowExec')
+@ignore_order(local=True)
+@allow_non_gpu('ShuffleExchangeExec')
+@pytest.mark.parametrize('fp_type', ['FLOAT', 'DOUBLE'], ids=idfn)
+def test_window_aggs_for_fully_unbounded_partitioned_collect_set_float_double_spark420(fp_type):
+    """
+    Spark 4.2+ Float/Double collect_set over fully unbounded frames must fall back to
+    GpuWindowExec (normalize in-place) rather than the unbounded group-by shortcut.
+    """
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: spark.sql(f"""
+            SELECT * FROM VALUES
+                (1, 1, CAST(0.0 AS {fp_type})),
+                (1, 2, CAST(-0.0 AS {fp_type})),
+                (1, 3, CAST('NaN' AS {fp_type})),
+                (1, 4, CAST('NaN' AS {fp_type})),
+                (1, 5, CAST(NULL AS {fp_type})),
+                (1, 6, CAST('Infinity' AS {fp_type})),
+                (2, 1, CAST(1.5 AS {fp_type})),
+                (2, 2, CAST(NULL AS {fp_type}))
+            AS tab(a, b, c)
+        """),
+        "window_collect_table",
+        """
+        SELECT a, b,
+               sort_array(ignore_set) AS ignore_set,
+               sort_array(respect_set) AS respect_set
+        FROM (
+            SELECT a, b,
+                   collect_set(c) IGNORE NULLS OVER
+                     (PARTITION BY a ORDER BY b
+                      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ignore_set,
+                   collect_set(c) RESPECT NULLS OVER
+                     (PARTITION BY a ORDER BY b
+                      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS respect_set
+            FROM window_collect_table
+        ) t
+        """,
+        conf={'spark.rapids.sql.window.collectSet.enabled': True,
+              'spark.rapids.sql.window.unboundedAgg.enabled': True,
+              'spark.sql.adaptive.enabled': 'false'},
+        validate_execs_in_gpu_plan=['GpuWindowExec'])
 
 
 @pytest.mark.skipif(not is_spark_420_or_later(),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3862,16 +3862,23 @@ object GpuOverrides extends Logging {
 
         override def aggBufferAttribute: AttributeReference = {
           val aggBuffer = c.aggBufferAttributes.head
-          aggBuffer.copy(dataType = c.dataType)(aggBuffer.exprId, aggBuffer.qualifier)
+          // Match Spark 4.2+ CollectSet buffer layout for float/double (normalized bit keys).
+          val ignoreNulls = TypeUtilsShims.collectSetIgnoreNulls(c)
+          val bufferElementType =
+            TypeUtilsShims.collectSetCpuBufferElementType(c.child.dataType)
+          aggBuffer.copy(dataType = ArrayType(bufferElementType, !ignoreNulls))(
+            aggBuffer.exprId, aggBuffer.qualifier)
         }
 
-        override def createCpuToGpuBufferConverter(): CpuToGpuAggregateBufferConverter =
-          new CpuToGpuCollectSetBufferConverter(c.child.dataType,
-            !TypeUtilsShims.collectSetIgnoreNulls(c))
+        override def createCpuToGpuBufferConverter(): CpuToGpuAggregateBufferConverter = {
+          val ignoreNulls = TypeUtilsShims.collectSetIgnoreNulls(c)
+          new CpuToGpuCollectBufferConverter(
+            TypeUtilsShims.collectSetCpuBufferElementType(c.child.dataType),
+            !ignoreNulls)
+        }
 
         override def createGpuToCpuBufferConverter(): GpuToCpuAggregateBufferConverter =
-          new GpuToCpuCollectSetBufferConverter(c.child.dataType,
-            !TypeUtilsShims.collectSetIgnoreNulls(c))
+          new GpuToCpuCollectBufferConverter()
 
         override val supportBufferConversion: Boolean = true
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
@@ -557,8 +557,10 @@ object GpuWindowExecMeta {
         false // Must be both unbounded, and have a group by specification.
       } else {
         func match {
-          case _: GpuUnboundedToUnboundedWindowAgg => true
-          case GpuAggregateExpression(_: GpuUnboundedToUnboundedWindowAgg, _, _, _, _) => true
+          case a: GpuUnboundedToUnboundedWindowAgg =>
+            a.supportsUnboundedToUnboundedWindowExec
+          case GpuAggregateExpression(a: GpuUnboundedToUnboundedWindowAgg, _, _, _, _) =>
+            a.supportsUnboundedToUnboundedWindowExec
           case _ => false
         }
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -985,8 +985,13 @@ trait GpuUnboundToUnboundWindowWithFixer {
 /**
  * This is used to tag a GpuAggregateFunction that it has been tested to work properly
  * with `GpuUnboundedToUnboundedAggWindowExec`.
+ *
+ * Implementations may opt out when their hash-agg [[GpuAggregateFunction.inputProjection]]
+ * is incompatible with the unbounded-agg shortcut (which only accepts BoundReference/Literal).
  */
-trait GpuUnboundedToUnboundedWindowAgg extends GpuAggregateFunction
+trait GpuUnboundedToUnboundedWindowAgg extends GpuAggregateFunction {
+  def supportsUnboundedToUnboundedWindowExec: Boolean = true
+}
 
 /**
  * Fixes up a count operation for unbounded preceding to unbounded following

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -22,7 +22,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
 import com.nvidia.spark.rapids.jni.Aggregation64Utils
-import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, HashUtils, ShimExpression,
+import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression,
   TypeUtilsShims}
 import com.nvidia.spark.rapids.window._
 
@@ -2019,6 +2019,11 @@ case class GpuCollectSet(
 
   private lazy val useNormalizedBitKeys: Boolean = bufferElementType != child.dataType
 
+  // Bit-key inputProjection is incompatible with GpuUnboundedToUnboundedAggWindowExec, which only
+  // accepts BoundReference/Literal projections and never applies evaluateExpression. Keep the
+  // Spark 4.2+ float/double path on regular GpuWindowExec (windowInputProjection + rolling).
+  override def supportsUnboundedToUnboundedWindowExec: Boolean = !useNormalizedBitKeys
+
   override lazy val inputProjection: Seq[Expression] = {
     if (useNormalizedBitKeys) {
       Seq(GpuCollectSetNormalizedBitKey(child))
@@ -2031,7 +2036,7 @@ case class GpuCollectSet(
   // floats in-place rather than switching the window input to bit keys.
   override lazy val windowInputProjection: Seq[Expression] = {
     if (useNormalizedBitKeys) {
-      Seq(GpuNormalizeFloatingPointForCollectSet(child))
+      Seq(GpuNormalizeNaNAndZero(child))
     } else {
       Seq(child)
     }
@@ -2069,45 +2074,9 @@ case class GpuCollectSet(
 }
 
 /**
- * Helpers matching Spark's NormalizeFloatingNumbers for CollectSet float/double keys:
- * canonicalize NaN payloads and map -0.0 to +0.0.
- */
-object CollectSetFloatingNormalize {
-  def normalize(cv: ColumnVector): ColumnVector = {
-    val dtype = cv.getType
-    require(dtype == DType.FLOAT32 || dtype == DType.FLOAT64,
-      s"CollectSet floating normalize expects FLOAT32/FLOAT64, found $dtype")
-    // Canonicalize NaN payloads first (Spark FLOAT_NORMALIZER / DOUBLE_NORMALIZER), then
-    // reuse HashUtils for signed-zero normalization (-0.0 -> +0.0).
-    val withCanonNan = withResource(cv.isNan) { isNan =>
-      withResource(nanScalar(dtype)) { nan =>
-        isNan.ifElse(nan, cv)
-      }
-    }
-    withResource(withCanonNan) { normalizedNan =>
-      HashUtils.normalizeInput(normalizedNan)
-    }
-  }
-
-  private def nanScalar(dtype: DType): Scalar =
-    if (dtype == DType.FLOAT32) {
-      Scalar.fromFloat(Float.NaN)
-    } else {
-      Scalar.fromDouble(Double.NaN)
-    }
-}
-
-/** Normalize float/double values for CollectSet without changing the logical type. */
-case class GpuNormalizeFloatingPointForCollectSet(child: Expression) extends GpuUnaryExpression {
-  override def dataType: DataType = child.dataType
-
-  override def doColumnar(input: GpuColumnVector): ColumnVector =
-    CollectSetFloatingNormalize.normalize(input.getBase)
-}
-
-/**
  * Normalize float/double and bit-cast to the Spark 4.2 CollectSet buffer key type
- * (Float -> Int, Double -> Long).
+ * (Float -> Int, Double -> Long). Uses cuDF normalizeNANsAndZeros (same as
+ * [[GpuNormalizeNaNAndZero]]) for NaN payload and signed-zero canonicalization.
  */
 case class GpuCollectSetNormalizedBitKey(child: Expression) extends GpuUnaryExpression {
   override def dataType: DataType = {
@@ -2120,7 +2089,7 @@ case class GpuCollectSetNormalizedBitKey(child: Expression) extends GpuUnaryExpr
   }
 
   override def doColumnar(input: GpuColumnVector): ColumnVector = {
-    withResource(CollectSetFloatingNormalize.normalize(input.getBase)) { normalized =>
+    withResource(input.getBase.normalizeNANsAndZeros()) { normalized =>
       val bitsType = GpuColumnVector.getNonNestedRapidsType(dataType)
       withResource(normalized.bitCastTo(bitsType)) { bits =>
         bits.copyToColumnVector()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -22,7 +22,8 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
 import com.nvidia.spark.rapids.jni.Aggregation64Utils
-import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression, TypeUtilsShims}
+import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, HashUtils, ShimExpression,
+  TypeUtilsShims}
 import com.nvidia.spark.rapids.window._
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -1924,6 +1925,15 @@ trait GpuCollectBase
   def child: Expression
   protected def arrayContainsNull: Boolean = false
 
+  /**
+   * Element type stored in the aggregation buffer. Defaults to the result element type.
+   * Spark 4.2+ CollectSet overrides this for float/double to store normalized bit keys.
+   */
+  protected def bufferElementType: DataType = child.dataType
+
+  protected final def bufferDataType: DataType =
+    ArrayType(bufferElementType, containsNull = arrayContainsNull)
+
   override def nullable: Boolean = false
 
   override def dataType: DataType = ArrayType(child.dataType, containsNull = arrayContainsNull)
@@ -1931,16 +1941,16 @@ trait GpuCollectBase
   override def children: Seq[Expression] = child :: Nil
 
   // WINDOW FUNCTION
-  override val windowInputProjection: Seq[Expression] = Seq(child)
+  override lazy val windowInputProjection: Seq[Expression] = Seq(child)
 
-  override val initialValues: Seq[Expression] = {
-    Seq(GpuLiteral.create(new GenericArrayData(Array.empty[Any]), dataType))
+  override lazy val initialValues: Seq[Expression] = {
+    Seq(GpuLiteral.create(new GenericArrayData(Array.empty[Any]), bufferDataType))
   }
 
-  override val inputProjection: Seq[Expression] = Seq(child)
+  override lazy val inputProjection: Seq[Expression] = Seq(child)
 
   protected final lazy val outputBuf: AttributeReference =
-    AttributeReference("inputBuf", dataType)()
+    AttributeReference("inputBuf", bufferDataType)()
 }
 
 /**
@@ -1985,6 +1995,11 @@ case class GpuCollectList(
  *
  * The two 'offset' parameters are not used by GPU version, but are here for the compatibility
  * with the CPU version and automated checks.
+ *
+ * On Spark 4.2+, CollectSet stores float/double aggregation buffers as normalized bit patterns
+ * (INT/LONG) so HashSet can treat NaNs and signed zeros as equal. GPU CollectSet mirrors that
+ * by normalizing and bit-keying in [[inputProjection]], so mixed CPU/GPU aggregate stages share
+ * the same buffer layout without host-side per-row float↔bits converters.
  */
 case class GpuCollectSet(
     child: Expression,
@@ -1998,10 +2013,36 @@ case class GpuCollectSet(
 
   override protected def arrayContainsNull: Boolean = !ignoreNulls
 
+  // Spark 4.2+ float/double buffers use normalized bit keys (see TypeUtilsShims).
+  override protected def bufferElementType: DataType =
+    TypeUtilsShims.collectSetCpuBufferElementType(child.dataType)
+
+  private lazy val useNormalizedBitKeys: Boolean = bufferElementType != child.dataType
+
+  override lazy val inputProjection: Seq[Expression] = {
+    if (useNormalizedBitKeys) {
+      Seq(GpuCollectSetNormalizedBitKey(child))
+    } else {
+      Seq(child)
+    }
+  }
+
+  // Window collect_set emits the result array directly from rolling aggregation, so normalize
+  // floats in-place rather than switching the window input to bit keys.
+  override lazy val windowInputProjection: Seq[Expression] = {
+    if (useNormalizedBitKeys) {
+      Seq(GpuNormalizeFloatingPointForCollectSet(child))
+    } else {
+      Seq(child)
+    }
+  }
+
   override lazy val updateAggregates: Seq[CudfAggregate] =
-    Seq(new CudfCollectSet(dataType, nullPolicy))
-  override lazy val mergeAggregates: Seq[CudfAggregate] = Seq(new CudfMergeSets(dataType))
-  override lazy val evaluateExpression: Expression = outputBuf
+    Seq(new CudfCollectSet(bufferDataType, nullPolicy))
+  override lazy val mergeAggregates: Seq[CudfAggregate] = Seq(new CudfMergeSets(bufferDataType))
+  override lazy val evaluateExpression: Expression =
+    if (useNormalizedBitKeys) GpuCollectSetBitKeysToValues(outputBuf) else outputBuf
+
   override def aggBufferAttributes: Seq[AttributeReference] = outputBuf :: Nil
 
   override def prettyName: String = "collect_set"
@@ -2025,6 +2066,97 @@ case class GpuCollectSet(
   // A `COLLECT_SET` window aggregation over (2, -1) should yield an empty array [],
   // not null, for the first row.
   override def getMinPeriods: Int = 0
+}
+
+/**
+ * Helpers matching Spark's NormalizeFloatingNumbers for CollectSet float/double keys:
+ * canonicalize NaN payloads and map -0.0 to +0.0.
+ */
+object CollectSetFloatingNormalize {
+  def normalize(cv: ColumnVector): ColumnVector = {
+    val dtype = cv.getType
+    require(dtype == DType.FLOAT32 || dtype == DType.FLOAT64,
+      s"CollectSet floating normalize expects FLOAT32/FLOAT64, found $dtype")
+    // Canonicalize NaN payloads first (Spark FLOAT_NORMALIZER / DOUBLE_NORMALIZER), then
+    // reuse HashUtils for signed-zero normalization (-0.0 -> +0.0).
+    val withCanonNan = withResource(cv.isNan) { isNan =>
+      withResource(nanScalar(dtype)) { nan =>
+        isNan.ifElse(nan, cv)
+      }
+    }
+    withResource(withCanonNan) { normalizedNan =>
+      HashUtils.normalizeInput(normalizedNan)
+    }
+  }
+
+  private def nanScalar(dtype: DType): Scalar =
+    if (dtype == DType.FLOAT32) {
+      Scalar.fromFloat(Float.NaN)
+    } else {
+      Scalar.fromDouble(Double.NaN)
+    }
+}
+
+/** Normalize float/double values for CollectSet without changing the logical type. */
+case class GpuNormalizeFloatingPointForCollectSet(child: Expression) extends GpuUnaryExpression {
+  override def dataType: DataType = child.dataType
+
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    CollectSetFloatingNormalize.normalize(input.getBase)
+}
+
+/**
+ * Normalize float/double and bit-cast to the Spark 4.2 CollectSet buffer key type
+ * (Float -> Int, Double -> Long).
+ */
+case class GpuCollectSetNormalizedBitKey(child: Expression) extends GpuUnaryExpression {
+  override def dataType: DataType = {
+    val keyType = TypeUtilsShims.collectSetCpuBufferElementType(child.dataType)
+    if (keyType == child.dataType) {
+      throw new IllegalStateException(
+        s"CollectSet bit-key conversion only applies when buffer keys differ, found $keyType")
+    }
+    keyType
+  }
+
+  override def doColumnar(input: GpuColumnVector): ColumnVector = {
+    withResource(CollectSetFloatingNormalize.normalize(input.getBase)) { normalized =>
+      val bitsType = GpuColumnVector.getNonNestedRapidsType(dataType)
+      withResource(normalized.bitCastTo(bitsType)) { bits =>
+        bits.copyToColumnVector()
+      }
+    }
+  }
+}
+
+/**
+ * Convert a CollectSet aggregation buffer of normalized bit keys back to float/double values.
+ * Int keys -> Float, Long keys -> Double.
+ */
+case class GpuCollectSetBitKeysToValues(child: Expression) extends GpuUnaryExpression {
+  override def dataType: DataType = child.dataType match {
+    case ArrayType(IntegerType, containsNull) => ArrayType(FloatType, containsNull)
+    case ArrayType(LongType, containsNull) => ArrayType(DoubleType, containsNull)
+    case t =>
+      throw new IllegalStateException(
+        s"CollectSet bit-key buffer must be ArrayType(IntegerType|LongType), found $t")
+  }
+
+  override def doColumnar(input: GpuColumnVector): ColumnVector = {
+    val list = input.getBase
+    withResource(list.getChildColumnView(0)) { bitsView =>
+      val outDType = bitsView.getType match {
+        case DType.INT32 => DType.FLOAT32
+        case DType.INT64 => DType.FLOAT64
+        case t => throw new IllegalStateException(s"Unexpected CollectSet bit-key cudf type $t")
+      }
+      withResource(bitsView.bitCastTo(outDType)) { valuesView =>
+        withResource(list.replaceListChild(valuesView)) { replaced =>
+          replaced.copyToColumnVector()
+        }
+      }
+    }
+  }
 }
 
 class CpuToGpuCollectBufferConverter(
@@ -2076,163 +2208,6 @@ case class GpuToCpuCollectBufferTransition(
     // in ArrayData(UnsafeArrayData).
     val arrayData = input.asInstanceOf[ArrayData]
     projection.apply(InternalRow.apply(arrayData)).getBytes
-  }
-}
-
-/**
- * CollectSet buffer converters.
- *
- * Spark 4.2 changed CollectSet's CPU agg buffer for FloatType/DoubleType to store normalized
- * bit patterns (IntegerType/LongType) so HashSet can treat NaNs and signed zeros as equal.
- * GPU CollectSet still stores the logical float/double values, so mixed CPU/GPU aggregation
- * stages must convert between the two buffer layouts.
- */
-class CpuToGpuCollectSetBufferConverter(
-    elementType: DataType,
-    containsNull: Boolean = false) extends CpuToGpuAggregateBufferConverter {
-  def createExpression(child: Expression): CpuToGpuBufferTransition = {
-    CpuToGpuCollectSetBufferTransition(child, elementType, containsNull)
-  }
-}
-
-case class CpuToGpuCollectSetBufferTransition(
-    override val child: Expression,
-    private val elementType: DataType,
-    private val containsNull: Boolean) extends CpuToGpuBufferTransition {
-
-  private lazy val row = new UnsafeRow(1)
-  private lazy val cpuElementType: DataType =
-    TypeUtilsShims.collectSetCpuBufferElementType(elementType)
-
-  override def dataType: DataType = ArrayType(elementType, containsNull)
-
-  override protected def nullSafeEval(input: Any): ArrayData = {
-    val bytes = input.asInstanceOf[Array[Byte]]
-    row.pointTo(bytes, bytes.length)
-    val cpuArray = row.getArray(0)
-    if (cpuElementType == elementType) {
-      cpuArray.copy()
-    } else {
-      CollectSetBufferConversions.cpuBitsToGpuValues(cpuArray, elementType, containsNull)
-    }
-  }
-}
-
-class GpuToCpuCollectSetBufferConverter(
-    elementType: DataType,
-    containsNull: Boolean = false) extends GpuToCpuAggregateBufferConverter {
-  def createExpression(child: Expression): GpuToCpuBufferTransition = {
-    GpuToCpuCollectSetBufferTransition(child, elementType, containsNull)
-  }
-}
-
-case class GpuToCpuCollectSetBufferTransition(
-    override val child: Expression,
-    private val elementType: DataType,
-    private val containsNull: Boolean) extends GpuToCpuBufferTransition {
-
-  private lazy val cpuElementType: DataType =
-    TypeUtilsShims.collectSetCpuBufferElementType(elementType)
-  private lazy val cpuBufferType: DataType = ArrayType(cpuElementType, containsNull)
-  private lazy val projection = UnsafeProjection.create(Array[DataType](cpuBufferType))
-
-  override protected def nullSafeEval(input: Any): Array[Byte] = {
-    val arrayData = input.asInstanceOf[ArrayData]
-    val cpuArray = if (cpuElementType == elementType) {
-      arrayData
-    } else {
-      CollectSetBufferConversions.gpuValuesToCpuBits(arrayData, elementType, containsNull)
-    }
-    projection.apply(InternalRow.apply(cpuArray)).getBytes
-  }
-}
-
-object CollectSetBufferConversions {
-  // Matches Spark's NormalizeFloatingNumbers.FLOAT_NORMALIZER / DOUBLE_NORMALIZER.
-  private def normalizeFloat(f: Float): Float = {
-    if (f.isNaN) {
-      Float.NaN
-    } else if (f == -0.0f) {
-      0.0f
-    } else {
-      f
-    }
-  }
-
-  private def normalizeDouble(d: Double): Double = {
-    if (d.isNaN) {
-      Double.NaN
-    } else if (d == -0.0d) {
-      0.0d
-    } else {
-      d
-    }
-  }
-
-  def gpuValuesToCpuBits(
-      arrayData: ArrayData,
-      elementType: DataType,
-      containsNull: Boolean): ArrayData = {
-    val n = arrayData.numElements()
-    val out = new Array[Any](n)
-    var i = 0
-    elementType match {
-      case FloatType =>
-        while (i < n) {
-          if (containsNull && arrayData.isNullAt(i)) {
-            out(i) = null
-          } else {
-            out(i) = java.lang.Float.floatToIntBits(normalizeFloat(arrayData.getFloat(i)))
-          }
-          i += 1
-        }
-      case DoubleType =>
-        while (i < n) {
-          if (containsNull && arrayData.isNullAt(i)) {
-            out(i) = null
-          } else {
-            out(i) = java.lang.Double.doubleToLongBits(normalizeDouble(arrayData.getDouble(i)))
-          }
-          i += 1
-        }
-      case other =>
-        throw new IllegalStateException(
-          s"Unexpected CollectSet GPU-to-CPU buffer conversion for $other")
-    }
-    new GenericArrayData(out)
-  }
-
-  def cpuBitsToGpuValues(
-      arrayData: ArrayData,
-      elementType: DataType,
-      containsNull: Boolean): ArrayData = {
-    val n = arrayData.numElements()
-    val out = new Array[Any](n)
-    var i = 0
-    elementType match {
-      case FloatType =>
-        while (i < n) {
-          if (containsNull && arrayData.isNullAt(i)) {
-            out(i) = null
-          } else {
-            out(i) = java.lang.Float.intBitsToFloat(arrayData.getInt(i))
-          }
-          i += 1
-        }
-      case DoubleType =>
-        while (i < n) {
-          if (containsNull && arrayData.isNullAt(i)) {
-            out(i) = null
-          } else {
-            out(i) = java.lang.Double.longBitsToDouble(arrayData.getLong(i))
-          }
-          i += 1
-        }
-      case other =>
-        throw new IllegalStateException(
-          s"Unexpected CollectSet CPU-to-GPU buffer conversion for $other")
-    }
-    new GenericArrayData(out)
   }
 }
 

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
@@ -42,6 +42,7 @@ object TypeUtilsShims {
   val collectSetFloatNanEquality: NaNEquality = NaNEquality.ALL_EQUAL
 
   // Spark 4.2 CollectSet keys float/double by normalized bit patterns in the agg buffer.
+  // GPU CollectSet uses the same buffer element types so mixed CPU/GPU stages match.
   def collectSetCpuBufferElementType(childType: DataType): DataType = childType match {
     case FloatType => IntegerType
     case DoubleType => LongType


### PR DESCRIPTION
Contributes to #15463.

related to [this comment](https://github.com/NVIDIA/cudf-spark/issues/15463#issuecomment-5184231315)

### Description

- Normalize NaN / `-0.0` and store Spark 4.2 CollectSet float/double agg buffers as Int/Long bit keys inside `GpuCollectSet`, so GPU uniqueness matches CPU without host-side per-row float↔bits converters.
- Reuse the generic Collect buffer converters for mixed CPU/GPU hashAgg stages, because GPU and CPU buffer layouts now match on Spark 4.2+.
- Keep pre-4.2 shims on the previous Float/Double buffer path via `TypeUtilsShims.collectSetCpuBufferElementType`.
- Opt Spark 4.2 float/double `GpuCollectSet` out of `GpuUnboundedToUnboundedAggWindowExec` (bit-key `inputProjection` is incompatible with that shortcut) and keep the window path on regular `GpuWindowExec` with `GpuNormalizeNaNAndZero`.
- Reuse cuDF `normalizeNANsAndZeros()` instead of a custom NaN/`-0.0` normalize helper.
- Validated locally on Spark 4.2.0 / Scala 2.13 / CUDA 13 with `DATAGEN_SEED=1785353212`: new/updated ITs for mixed-stage Float/Double `RESPECT NULLS`, deterministic `+0`/`-0`/NaN/inf edges, empty typed reduction, and fully-unbounded Float/Double windows (`14 passed`); also `mvn -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests -pl sql-plugin,dist,integration_tests -am package` and `mvn -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests -pl sql-plugin -am package`.

This follows the direction discussed on #15463 (normalize inside `collect_set` rather than expanding host-side converters).

### Performance

Operator-level microbench (not NDS) comparing current `main` (#15455 host CollectSet float↔bits converters) vs this PR.

- Hardware: NVIDIA RTX 5880 Ada Generation
- Spark 4.2.0 / Scala 2.13 / CUDA 13 / `spark.rapids.memory.gpu.allocSize=8192m`
- Data includes ~2% NaN and ~2% `-0.0` in float/double columns
- Method: 1 warmup + 3 iters, report median wall time
- Timed SQL (equivalent to the DataFrame microbench):

```sql
SELECT SUM(sf) AS sum_f, SUM(sd) AS sum_d
FROM (
  SELECT
    k,
    SIZE(COLLECT_SET(f)) AS sf,
    SIZE(COLLECT_SET(d)) AS sd
  FROM (
    SELECT
      CAST(id % ${num_groups} AS INT) AS k,
      CASE
        WHEN (id % 50) = 0 THEN CAST('NaN' AS FLOAT)
        WHEN (id % 50) = 1 THEN CAST(-0.0 AS FLOAT)
        ELSE CAST(CAST((id % 997) AS FLOAT) / 10.0 AS FLOAT)
      END AS f,
      CASE
        WHEN (id % 50) = 2 THEN CAST('NaN' AS DOUBLE)
        WHEN (id % 50) = 3 THEN CAST(-0.0 AS DOUBLE)
        ELSE CAST(CAST((id % 1009) AS DOUBLE) / 10.0 AS DOUBLE)
      END AS d
    FROM range(0, ${num_rows})
  )
  GROUP BY k
)
```

#### Suite C: 200,000,000 rows / 500,000 groups (mixed modes ~12–13s)

| Case | main median (s) | PR median (s) | Speedup (main/PR) | Notes |
|------|----------------:|--------------:|------------------:|-------|
| `pure_gpu` | 3.160 | 3.235 | 0.98x | pure GPU (short at this scale) |
| `mixed_partial_gpu` | 12.443 | 11.553 | 1.08x | GPU partial + CPU final |
| `mixed_final_gpu` | 13.133 | 12.935 | 1.02x | CPU partial + GPU final |

Checksums matched (`sum_f=sum_d=192020000`).

#### Suite D: 1,000,000,000 rows / 1,000,000 groups (pure GPU ~15s)

| Case | main median (s) | PR median (s) | Speedup (main/PR) | Notes |
|------|----------------:|--------------:|------------------:|-------|
| `pure_gpu` | 15.725 | 15.436 | 1.02x | pure GPU |

Checksums matched (`sum_f=957160000`, `sum_d=960040000`).

**Takeaway:** no meaningful wall-time regression vs `main` at multi-second scale. Mixed `partial` lean (~1.08x) is consistent with avoiding host float↔bits conversion on GPU buffer boundaries; pure GPU is within noise (~±2%).


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required


