### PR TITLE
[BUG] Preserve GroupPartitionsExec CPU fallback partitioning

### DIFF
--- a/sql-plugin/src/main/spark412/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark412/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -17,7 +17,6 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "412"}
 {"spark": "413"}
-{"spark": "420"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GroupPartitionsExecMeta.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GroupPartitionsExecMeta.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
+
+class GroupPartitionsExecMeta(
+    groupPartitions: GroupPartitionsExec,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends SparkPlanMeta[GroupPartitionsExec](groupPartitions, conf, parent, rule) {
+
+  override def tagPlanForGpu(): Unit = {
+    willNotWorkOnGpu("GroupPartitionsExec is not supported on GPU")
+  }
+
+  override def convertToCpu(): SparkPlan = {
+    // GroupPartitionsExec reads its child's KeyedPartitioning at execution time.
+    // GPU conversions can replace it with UnknownPartitioning, so keep the original
+    // CPU subtree until GroupPartitionsExec has a GPU implementation.
+    groupPartitions
+  }
+
+  override def convertToGpu(): GpuExec = {
+    throw new IllegalStateException("GroupPartitionsExec cannot be converted to GPU")
+  }
+}

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
+
+object SparkShimImpl extends Spark411PlusShims with HyperbolicExpressionShims {
+  private val shimExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
+    GpuOverrides.exec[GroupPartitionsExec](
+      "Groups data source partitions with the same partition key",
+      ExecChecks(TypeSig.all, TypeSig.all),
+      (groupPartitions, conf, parent, rule) =>
+        new GroupPartitionsExecMeta(groupPartitions, conf, parent, rule))
+  ).map(rule => (rule.getClassFor.asSubclass(classOf[SparkPlan]), rule)).toMap
+
+  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
+    super.getExecs ++ shimExecs
+}

--- a/tests/src/test/spark420/scala/com/nvidia/spark/rapids/GroupPartitionsExecFallbackSuite.scala
+++ b/tests/src/test/spark420/scala/com/nvidia/spark/rapids/GroupPartitionsExecFallbackSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids
+
+import java.util.Collections
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryCatalog}
+import org.apache.spark.sql.connector.distributions.Distributions
+import org.apache.spark.sql.connector.expressions.Expressions
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
+import org.apache.spark.sql.types.IntegerType
+
+class GroupPartitionsExecFallbackSuite extends SparkQueryCompareTestSuite {
+
+  private val conf = new SparkConf()
+    .set("spark.sql.catalog.testcat", classOf[InMemoryCatalog].getName)
+    .set(SQLConf.V2_BUCKETING_ENABLED.key, "true")
+    .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+    .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+
+  override protected def filterCapturedPlans(plans: Array[SparkPlan]): Array[SparkPlan] = {
+    super.filterCapturedPlans(plans).filter(_.exists(_.isInstanceOf[GroupPartitionsExec]))
+  }
+
+  testGpuFallback(
+    "GroupPartitionsExec fallback preserves storage-partitioned join results",
+    "GroupPartitionsExec",
+    createStoragePartitionedJoin,
+    conf = conf,
+    repart = 0,
+    sort = true,
+    execsAllowedNonGpu =
+      Seq("BatchScanExec", "FilterExec", "GroupPartitionsExec", "ProjectExec")) {
+    df => df
+  }
+
+  private def createStoragePartitionedJoin(spark: SparkSession) = {
+    val catalog = spark.sessionState.catalogManager
+      .catalog("testcat")
+      .asInstanceOf[InMemoryCatalog]
+    catalog.clearTables()
+
+    createTable(catalog, "left_table")
+    createTable(catalog, "right_table")
+    val rapidsEnabled = spark.conf.get(RapidsConf.SQL_ENABLED.key)
+    spark.conf.set(RapidsConf.SQL_ENABLED.key, "false")
+    try {
+      spark.sql(
+        "INSERT INTO testcat.ns.left_table VALUES (1, 10), (1, 20), (2, 30)")
+      spark.sql(
+        "INSERT INTO testcat.ns.right_table VALUES (1, 100), (2, 200), (2, 300)")
+    } finally {
+      spark.conf.set(RapidsConf.SQL_ENABLED.key, rapidsEnabled)
+    }
+
+    spark.sql(
+      """SELECT /*+ MERGE(l, r) */ l.id, l.value AS left_value, r.value AS right_value
+        |FROM testcat.ns.left_table l
+        |JOIN testcat.ns.right_table r ON l.id = r.id
+        |""".stripMargin)
+  }
+
+  private def createTable(catalog: InMemoryCatalog, name: String): Unit = {
+    catalog.createTable(
+      Identifier.of(Array("ns"), name),
+      Array(
+        Column.create("id", IntegerType),
+        Column.create("value", IntegerType)),
+      Array(Expressions.identity("id")),
+      Collections.emptyMap[String, String](),
+      Distributions.unspecified(),
+      Array.empty,
+      None,
+      None,
+      numRowsPerSplit = 1)
+  }
+}

--- a/tools/generated_files/420/operatorsScore.csv
+++ b/tools/generated_files/420/operatorsScore.csv
@@ -29,6 +29,7 @@ AppendDataExecV1,3.0
 AtomicCreateTableAsSelectExec,3.0
 AtomicReplaceTableAsSelectExec,3.0
 BatchScanExec,3.0
+GroupPartitionsExec,3.0
 MergeRowsExec,3.0
 OverwriteByExpressionExec,3.0
 OverwriteByExpressionExecV1,3.0

--- a/tools/generated_files/420/supportedExecs.csv
+++ b/tools/generated_files/420/supportedExecs.csv
@@ -29,6 +29,7 @@ AppendDataExecV1,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,
 AtomicCreateTableAsSelectExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 AtomicReplaceTableAsSelectExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 BatchScanExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
+GroupPartitionsExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,S,S,S,PS,PS,PS,S,S,S
 MergeRowsExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 OverwriteByExpressionExec,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S
 OverwriteByExpressionExecV1,S,None,Input/Output,S,S,S,S,S,S,S,S,PS,S,S,NS,S,NS,PS,PS,PS,NS,S,S


### PR DESCRIPTION
related to #15307.

### Description

- Register Spark 4.2 `GroupPartitionsExec` with a named metadata class that keeps its original CPU subtree during fallback, because converting its children can replace the required `KeyedPartitioning` with `UnknownPartitioning`.
- Move the Spark 4.2 shim registration into the Spark 4.2 shim set, because `GroupPartitionsExec` is specific to that Spark version.
- Regenerate the Spark 4.2 operator metadata CSVs so the tools module reflects the new execution rule and generated-file verification remains clean.
- Add `GroupPartitionsExecFallbackSuite` to verify that a storage-partitioned join falls back cleanly and returns the same results on CPU and GPU-enabled execution.
- Validated with `mvn -s $HOME/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -pl tests -am -DwildcardSuites=com.nvidia.spark.rapids.GroupPartitionsExecFallbackSuite package`.
- Regenerated Spark 4.2 operator metadata with `mvn -s $HOME/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests -pl tools -am package`.
- Ran Spark 4.2 Scala style validation with `mvn -s $HOME/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests -pl tests -am validate`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required