### PR TITLE
[fast-ut] [reduced-it] [TEST] Add regex range-start regression coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -752,10 +752,14 @@ def test_word_boundaries():
         conf=_regexp_conf)
 
 def test_character_classes():
-    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
+    gen = (mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
+        .with_special_case(']^_')
+        .with_special_case('^')
+        .with_special_case('-'))
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'rlike(a, "[abcd]")',
+                'rlike(a, "[]-_]")',
                 'rlike(a, "[^\n\r]")',
                 'rlike(a, "[\n-\\]")',
                 'rlike(a, "[+--]")',

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -128,7 +128,8 @@ class RegularExpressionParserSuite extends AnyFunSuite {
           ListBuffer(RegexChar('a'))), RegexEscaped(']'))))
   }
 
-  test("issue-15564: character class ranges beginning with ] or ^") {
+  test("character class ranges beginning with ] or ^") {
+    // https://github.com/NVIDIA/cudf-spark/issues/15564
     val cases = Seq(
       raw"[]-_]" -> RegexCharacterClass(negated = false,
         ListBuffer(RegexCharacterRange(RegexChar(']'), RegexChar('_')))),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -128,6 +128,26 @@ class RegularExpressionParserSuite extends AnyFunSuite {
           ListBuffer(RegexChar('a'))), RegexEscaped(']'))))
   }
 
+  test("issue-15564: character class ranges beginning with ] or ^") {
+    val cases = Seq(
+      raw"[]-_]" -> RegexCharacterClass(negated = false,
+        ListBuffer(RegexCharacterRange(RegexChar(']'), RegexChar('_')))),
+      raw"[^]-_]" -> RegexCharacterClass(negated = true,
+        ListBuffer(RegexCharacterRange(RegexChar(']'), RegexChar('_')))),
+      raw"[^^-_]" -> RegexCharacterClass(negated = true,
+        ListBuffer(RegexCharacterRange(RegexChar('^'), RegexChar('_')))),
+      raw"[a^-_]" -> RegexCharacterClass(negated = false,
+        ListBuffer(RegexChar('a'), RegexCharacterRange(RegexChar('^'), RegexChar('_')))),
+      raw"[\^-_]" -> RegexCharacterClass(negated = false,
+        ListBuffer(RegexCharacterRange(RegexEscaped('^'), RegexChar('_')))))
+
+    cases.foreach { case (pattern, expected) =>
+      val ast = parse(pattern)
+      assert(ast === RegexSequence(ListBuffer(expected)))
+      assert(ast.toRegexString === pattern)
+    }
+  }
+
   test("escaped brackets") {
     assert(parse("\\[([A-Z]+)\\]") ===
       RegexSequence(ListBuffer(


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim 350, nightly b14 at `4f725f15`; the new regression cases execute production lines already covered by the nightly aggregate)

Closes #15564
Contributes to #14733

## What this fixes

Adds the missing regression contract for Java character-class ranges whose start character is `]` or `^`, including Java's `[]-_]` form.

## Approach

- Assert the exact parser AST and regex serialization round-trip for five positive, negated, embedded, and escaped forms.
- Extend the existing Python `RLIKE` character-class parity test with `[]-_]` and deterministic boundary inputs.

## Whole-system design assessment

Disposition: `COVERAGE_ONLY`

The current parser, AST serialization, Java regex behavior, Spark CPU execution, and GPU execution already agree for the targeted forms, so no production-code change is needed. This does not alter group/AST representation, rewrite rules, or serialization and does not conflict with the inline/scoped flag work in #15484.

## Tests added

- Scala unit: `RegularExpressionParserSuite` -> `issue-15564: character class ranges beginning with ] or ^`
- Python IT: existing `test_character_classes`

## Local validation

Scala suite:

```text
Tests: succeeded 46, failed 0, canceled 0, ignored 0, pending 0
```

Python IT (Spark 3.3, Python 3.10):

```text
1 passed, 91 deselected, 2 warnings in 5.78s
```

End-to-end reproduction on the patched dist JAR:

```text
RAPIDS Enabled: YES
Plugins Loaded: YES
GPU Operators: YES
range-start-bracket-caret: PASS (AST, round-trip, Java/Spark-CPU/GPU parity)
```

## Performance impact

Test-only change. The existing Python test gains one `RLIKE` expression and three deterministic special-case inputs; there is no production runtime impact.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
