### PR TITLE
[BUG] Fix reverse for truncated trailing UTF-8 [databricks]

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -24,7 +24,9 @@ from marks import *
 from pyspark.sql.types import *
 import pyspark.sql.utils
 import pyspark.sql.functions as f
-from spark_session import with_cpu_session, with_gpu_session, is_databricks104_or_later, is_databricks_version_or_later, is_before_spark_320, is_spark_400_or_later, is_before_spark_340
+from spark_session import with_cpu_session, with_gpu_session, is_databricks104_or_later, \
+    is_databricks_version_or_later, is_before_spark_320, is_spark_400_or_later, \
+    is_before_spark_340, spark_version
 
 _regexp_conf = { 'spark.rapids.sql.regexp.enabled': 'true' }
 
@@ -1153,9 +1155,16 @@ def test_multi_contains_conditional(ansi):
 
 
 # SPARK-57507 / #15383: reverse must clamp truncated trailing UTF-8 to the row boundary.
-# Neighbor sentinel rows make an over-read observable. Expected values are Spark's fixed
-# semantics (golden), so the test does not depend on whether the running Spark CPU build
-# already contains SPARK-57507.
+# Neighbor sentinel rows make an over-read observable.
+def _cpu_reverse_has_spark_57507():
+    version = spark_version()
+    # The fix was backported to the 4.0.4, 4.1.3, and 4.2.0 release lines.
+    return ('4.0.4' <= version < '4.1.0'
+            or '4.1.3' <= version < '4.2.0'
+            or version >= '4.2.0')
+
+
+@ignore_order(local=True)
 @pytest.mark.parametrize('hex_in,expected_hex', [
     ('41CE', 'CE41'),                 # A + truncated 2-byte lead
     ('41E4B8', 'E4B841'),             # A + truncated 3-byte lead
@@ -1178,14 +1187,22 @@ def test_reverse_truncated_trailing_utf8(hex_in, expected_hex):
             ],
             'row_id INT, b BINARY'
         ).coalesce(1).selectExpr('row_id', 'CAST(b AS STRING) AS v')
-        out = df.selectExpr('row_id', 'hex(reverse(v)) as h')
-        # Collect first so AQE finalizes and RAPIDS replacements appear in the plan.
-        rows = out.collect()
-        plan = out._jdf.queryExecution().executedPlan().toString()
-        # Expression trees render as lowercase "gpureverse(...)", not the class name.
-        assert 'gpureverse' in plan.lower(), 'expected GpuReverse in plan, got:\n' + plan
-        return rows
+        return df.selectExpr('row_id', 'hex(reverse(v)) as h')
 
-    rows = with_gpu_session(do_it)
-    rows_by_id = {row['row_id']: row['h'] for row in rows}
-    assert rows_by_id[0] == expected_hex
+    if _cpu_reverse_has_spark_57507():
+        assert_cpu_and_gpu_are_equal_collect_with_capture(
+            do_it, exist_classes='GpuReverse', require_non_empty=True)
+    else:
+        # Older CPU builds over-read malformed trailing UTF-8, so validate the GPU result
+        # against Spark's corrected semantics instead of asserting CPU/GPU equality.
+        def collect_gpu(spark):
+            out = do_it(spark)
+            rows = out.collect()
+            plan = out._jdf.queryExecution().executedPlan().toString()
+            # Expression trees render as lowercase "gpureverse(...)", not the class name.
+            assert 'gpureverse' in plan.lower(), 'expected GpuReverse in plan, got:\n' + plan
+            return rows
+
+        rows = with_gpu_session(collect_gpu)
+        rows_by_id = {row['row_id']: row['h'] for row in rows}
+        assert rows_by_id[0] == expected_hex

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -1172,13 +1172,13 @@ def test_reverse_truncated_trailing_utf8(hex_in, expected_hex):
         # (not allowed in GpuCpuBridge); feed raw bytes via BINARY then cast to STRING.
         df = spark.createDataFrame(
             [
-                (bytearray.fromhex(hex_in),),
-                (bytearray.fromhex('FFFFFFFF'),),
-                (bytearray.fromhex('414243'),),
+                (0, bytearray.fromhex(hex_in)),
+                (1, bytearray.fromhex('FFFFFFFF')),
+                (2, bytearray.fromhex('414243')),
             ],
-            'b BINARY'
-        ).coalesce(1).selectExpr('CAST(b AS STRING) AS v')
-        out = df.selectExpr('hex(reverse(v)) as h')
+            'row_id INT, b BINARY'
+        ).coalesce(1).selectExpr('row_id', 'CAST(b AS STRING) AS v')
+        out = df.selectExpr('row_id', 'hex(reverse(v)) as h')
         # Collect first so AQE finalizes and RAPIDS replacements appear in the plan.
         rows = out.collect()
         plan = out._jdf.queryExecution().executedPlan().toString()
@@ -1187,4 +1187,5 @@ def test_reverse_truncated_trailing_utf8(hex_in, expected_hex):
         return rows
 
     rows = with_gpu_session(do_it)
-    assert rows[0]['h'] == expected_hex
+    rows_by_id = {row['row_id']: row['h'] for row in rows}
+    assert rows_by_id[0] == expected_hex

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -1150,3 +1150,41 @@ def test_multi_contains_conditional(ansi):
                     ELSE CAST(a AS LONG)
                 END as result'''),
             conf = conf)
+
+
+# SPARK-57507 / #15383: reverse must clamp truncated trailing UTF-8 to the row boundary.
+# Neighbor sentinel rows make an over-read observable. Expected values are Spark's fixed
+# semantics (golden), so the test does not depend on whether the running Spark CPU build
+# already contains SPARK-57507.
+@pytest.mark.parametrize('hex_in,expected_hex', [
+    ('41CE', 'CE41'),                 # A + truncated 2-byte lead
+    ('41E4B8', 'E4B841'),             # A + truncated 3-byte lead
+    ('41F090', 'F09041'),             # A + truncated 4-byte lead
+    ('E4B896CE', 'CEE4B896'),         # complete 世 + orphan 2-byte lead
+    ('41C3A9', 'C3A941'),             # well-formed 2-byte control
+    ('41E4B896', 'E4B89641'),         # well-formed 3-byte control
+    ('41F0908D88', 'F0908D8841'),     # well-formed 4-byte control
+], ids=idfn)
+def test_reverse_truncated_trailing_utf8(hex_in, expected_hex):
+    def do_it(spark):
+        # Keep target + sentinel neighbors adjacent in one partition so an over-read
+        # into the next row is observable. Avoid ORDER BY (CPU shuffle) and unhex
+        # (not allowed in GpuCpuBridge); feed raw bytes via BINARY then cast to STRING.
+        df = spark.createDataFrame(
+            [
+                (bytearray.fromhex(hex_in),),
+                (bytearray.fromhex('FFFFFFFF'),),
+                (bytearray.fromhex('414243'),),
+            ],
+            'b BINARY'
+        ).coalesce(1).selectExpr('CAST(b AS STRING) AS v')
+        out = df.selectExpr('hex(reverse(v)) as h')
+        # Collect first so AQE finalizes and RAPIDS replacements appear in the plan.
+        rows = out.collect()
+        plan = out._jdf.queryExecution().executedPlan().toString()
+        # Expression trees render as lowercase "gpureverse(...)", not the class name.
+        assert 'gpureverse' in plan.lower(), 'expected GpuReverse in plan, got:\n' + plan
+        return rows
+
+    rows = with_gpu_session(do_it)
+    assert rows[0]['h'] == expected_hex

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -26,7 +26,7 @@ import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
 import com.nvidia.spark.rapids.BoolUtils.isAllValidTrue
 import com.nvidia.spark.rapids.GpuListUtils
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.jni.{GpuListSliceUtils, MapUtils}
+import com.nvidia.spark.rapids.jni.{GpuListSliceUtils, MapUtils, StringUtils}
 import com.nvidia.spark.rapids.shims.{GetSequenceSize, NullIntolerantShim, ShimExpression}
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
@@ -674,7 +674,14 @@ case class GpuReverse(child: Expression) extends GpuUnaryExpression {
   override def dataType: DataType = child.dataType
 
   override protected def doColumnar(input: GpuColumnVector): ColumnVector = {
-    input.getBase.reverseStringsOrLists()
+    // Strings use Spark UTF8String.reverse semantics (SPARK-57507): clamp truncated trailing
+    // multi-byte UTF-8 widths to the bytes remaining in each row. libcudf reverse can
+    // over-read into the next row for malformed Spark StringType values.
+    if (child.dataType.isInstanceOf[StringType]) {
+      StringUtils.reverseStrings(input.getBase)
+    } else {
+      input.getBase.reverseStringsOrLists()
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #15383.

### Description

- Routes GPU string `reverse` through the Spark-safe API added by https://github.com/NVIDIA/cudf-spark-jni/pull/4930 so a truncated trailing UTF-8 character is clamped to its row boundary instead of reading bytes from the next row; array reversal retains the existing cuDF path.
- Adds `test_reverse_truncated_trailing_utf8` with malformed trailing sequences, valid controls, and neighboring sentinel rows so the regression is observable on every supported Spark version; releases containing SPARK-57507 use the standard CPU/GPU comparison and older releases use corrected golden outputs.
- Validated Scala 2.12 scalastyle with `mvn -s ~/.m2/settings_art.xml -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests validate` to catch shared-source style regressions.
- Validated Scala 2.13 scalastyle with `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=400 -Dcuda.version=cuda13 -DskipTests validate` to cover the alternate Scala build.
- Built the Spark 4.0.4 plugin with `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=404 -Dcuda.version=cuda13 -DskipTests clean package` to verify the fixed-CPU comparison path compiles.
- Ran `test_reverse_truncated_trailing_utf8` on Spark 3.3.0 and Spark 4.0.4; all seven parameterized cases passed on both, including `GpuReverse` plan validation.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required