### PR TITLE
Stabilize AQE SMJ-to-BHJ local-shuffle-reader unit test [fast-ut] [reduced-ci]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -643,10 +643,20 @@ class AdaptiveQueryExecSuite
 
     withGpuSparkSession(spark => {
       setupTestData(spark)
+      // Keep the filtered lowerCaseData side small enough for one SMJ -> BHJ conversion,
+      // but make the third input large enough that AQE cannot also broadcast the second
+      // join. With the tiny shared testData3, both joins can become BHJ depending on
+      // runtime shuffle stats (https://github.com/NVIDIA/cudf-spark/issues/15591).
+      import spark.implicits._
+      val largeThird = (0 until 10000).map(i => (i % 3 + 1, Some(i): Option[Int]))
+        .toDF("a", "b")
+        .repartition(col("a"))
+      registerAsParquetTable(spark, largeThird, "testData3Large")
+
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(spark,
         """
           |SELECT * FROM lowerCaseData t1 join testData2 t2
-          |ON t1.n = t2.a join testData3 t3 on t2.a = t3.a
+          |ON t1.n = t2.a join testData3Large t3 on t2.a = t3.a
           |where t1.l = 1
         """.stripMargin)
 


### PR DESCRIPTION
Fixes #15591.

### Description

- Make `Change merge join to broadcast join without local shuffle reader` use a larger third join input (`testData3Large`) instead of the tiny shared `testData3`, so AQE can convert only one SMJ to BHJ under the 50-byte broadcast/advisory thresholds.
- Keep asserting exactly one broadcast exchange and two non-local-reader shuffles for the remaining SMJ, matching the original test intent.
- Validated locally with CUDA 13 / `SPARK_CONF=spark.sql.ansi.enabled=false` that `AdaptiveQueryExecSuite` passes (including `Change merge join to broadcast join without local shuffle reader`): Spark 3.3.0 (`buildver=330`, Scala 2.12), Spark 3.4.0 (`buildver=340`, Scala 2.12), Spark 3.5.0 (`buildver=350`, Scala 2.12), and Spark 4.0.0 (`buildver=400`, Scala 2.13); ANSI-on run cancels this test as expected on Spark 4.0.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
