### PR TITLE
Preserve AQE coalesced hash partition boundaries [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuCustomShuffleReaderExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuCustomShuffleReaderExec.scala
@@ -16,7 +16,7 @@
 package org.apache.spark.sql.rapids.execution
 
 import com.nvidia.spark.rapids.{CoalesceGoal, GpuExec, GpuMetric}
-import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
+import com.nvidia.spark.rapids.shims.{CoalescedHashPartitioningShim, ShimUnaryExecNode}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -84,7 +84,7 @@ case class GpuCustomShuffleReaderExec(
       // partitions is changed.
       child.outputPartitioning match {
         case h: HashPartitioning =>
-          h.copy(numPartitions = partitionSpecs.length)
+          CoalescedHashPartitioningShim(h, partitionSpecs)
         case r: RangePartitioning =>
           r.copy(numPartitions = partitionSpecs.length)
         // This can only happen for `REBALANCE_PARTITIONS_BY_NONE`, which uses

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShim.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShim.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "350"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
+import org.apache.spark.sql.execution.ShufflePartitionSpec
+
+object CoalescedHashPartitioningShim {
+  def apply(
+      hashPartitioning: HashPartitioning,
+      partitionSpecs: Seq[ShufflePartitionSpec]): Partitioning = {
+    hashPartitioning.copy(numPartitions = partitionSpecs.length)
+  }
+}

--- a/sql-plugin/src/main/spark342/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShim.scala
+++ b/sql-plugin/src/main/spark342/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShim.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "400db173"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.plans.physical.{CoalescedBoundary,
+  CoalescedHashPartitioning, HashPartitioning, Partitioning}
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.execution.{CoalescedPartitionSpec, ShufflePartitionSpec}
+
+object CoalescedHashPartitioningShim {
+  def apply(
+      hashPartitioning: HashPartitioning,
+      partitionSpecs: Seq[ShufflePartitionSpec]): Partitioning = {
+    val boundaries = partitionSpecs.map {
+      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex, _) =>
+        CoalescedBoundary(startReducerIndex, endReducerIndex)
+      case other =>
+        throw new IllegalStateException(
+          s"Unexpected partition spec for coalesced hash partitioning: $other")
+    }
+    CurrentOrigin.withOrigin(hashPartitioning.origin) {
+      CoalescedHashPartitioning(hashPartitioning, boundaries)
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShimSuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShimSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "350"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
+import org.apache.spark.sql.execution.CoalescedPartitionSpec
+import org.apache.spark.sql.types.IntegerType
+
+class CoalescedHashPartitioningShimSuite extends AnyFunSuite {
+  test("legacy Spark versions report the coalesced partition count") {
+    val hashPartitioning = HashPartitioning(
+      Seq(AttributeReference("key", IntegerType)()), 8)
+    val specs = Seq(
+      CoalescedPartitionSpec(0, 3, None),
+      CoalescedPartitionSpec(3, 8, None))
+
+    val result = CoalescedHashPartitioningShim(hashPartitioning, specs)
+
+    assert(result == hashPartitioning.copy(numPartitions = 2))
+  }
+}

--- a/tests/src/test/spark342/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShimSuite.scala
+++ b/tests/src/test/spark342/scala/com/nvidia/spark/rapids/shims/CoalescedHashPartitioningShimSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "400db173"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.physical.{CoalescedBoundary,
+  CoalescedHashPartitioning, HashPartitioning}
+import org.apache.spark.sql.execution.CoalescedPartitionSpec
+import org.apache.spark.sql.types.IntegerType
+
+class CoalescedHashPartitioningShimSuite extends AnyFunSuite {
+  test("new Spark versions preserve coalesced reducer boundaries") {
+    val hashPartitioning = HashPartitioning(
+      Seq(AttributeReference("key", IntegerType)()), 8)
+    val specs = Seq(
+      CoalescedPartitionSpec(0, 3, None),
+      CoalescedPartitionSpec(3, 8, None))
+
+    val result = CoalescedHashPartitioningShim(hashPartitioning, specs)
+
+    assert(result == CoalescedHashPartitioning(hashPartitioning,
+      Seq(CoalescedBoundary(0, 3), CoalescedBoundary(3, 8))))
+  }
+}


### PR DESCRIPTION
Fixes #15594.

### Description

Backport #15593 to `release/26.08` after the original PR was inadvertently merged into `main`.

This is an exact cherry-pick of the squash commit from #15593. It reports the original reducer boundaries when AQE coalesces hash partitions on Spark versions supporting `CoalescedHashPartitioning`, while preserving the prior behavior through version-specific shims.

No additional tests were run locally. The stable patch ID matches the commit merged by #15593, whose CI completed successfully.

### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
