### PR TITLE
Fix mergeIdenticalProjects dropping alias-producing GpuProjects in DV predicate pushdown [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -390,7 +390,10 @@ object DVPredicatePushdown extends ShimPredicateHelper {
       GpuProjectExec(projList2, child, enablePreSplit1), enablePreSplit2) =>
         val projSet1 = projList1.map(_.exprId).toSet
         val projSet2 = projList2.map(_.exprId).toSet
-        if (projSet1 == projSet2) {
+        // An Alias carries the exprId it defines, so equal exprId sets do not imply
+        // identical projections: merging over an alias-computing child would drop the
+        // alias's only producer ("Couldn't find <attr>"). Merge only pure pass-throughs.
+        if (projSet1 == projSet2 && projList2.forall(_.isInstanceOf[AttributeReference])) {
           GpuProjectExec(projList1, child, enablePreSplit1 && enablePreSplit2)
         } else {
           p

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
@@ -516,7 +516,10 @@ private object DB173DVPredicatePushdown extends ShimPredicateHelper {
       GpuProjectExec(projList2, child, enablePreSplit1), enablePreSplit2) =>
         val projSet1 = projList1.map(_.exprId).toSet
         val projSet2 = projList2.map(_.exprId).toSet
-        if (projSet1 == projSet2) {
+        // An Alias carries the exprId it defines, so equal exprId sets do not imply
+        // identical projections: merging over an alias-computing child would drop the
+        // alias's only producer ("Couldn't find <attr>"). Merge only pure pass-throughs.
+        if (projSet1 == projSet2 && projList2.forall(_.isInstanceOf[AttributeReference])) {
           GpuProjectExec(projList1, child, enablePreSplit1 && enablePreSplit2)
         } else {
           p

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -1305,6 +1305,87 @@ def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
         assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
 
 
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
+                    reason="Delta Lake deletion vector support is required")
+@pytest.mark.skipif(is_databricks_runtime() and not is_databricks173_or_later(),
+                    reason="Deletion vector scan is not supported on Databricks before 17.3")
+@pytest.mark.skipif(is_before_spark_353(),
+                    reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
+def test_delta_dv_pushdown_keeps_alias_producer(spark_tmp_path, spark_tmp_table_factory):
+    """
+    Regression test for https://github.com/NVIDIA/cudf-spark/issues/15598:
+    DVPredicatePushdown.mergeIdenticalProjects treated a pass-through project over an
+    alias-computing project as identical because their exprId sets are equal, and dropped
+    the alias's only producer, failing at execution with "Couldn't find <attr>". A
+    same-name decimal-to-double cast under a reordering aggregate reproduces that shape.
+    """
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    view_name = spark_tmp_table_factory.get()
+    conf = {
+        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true"
+    }
+
+    def create_delta(spark):
+        spark.range(2000).selectExpr(
+            "CAST(id AS INT) AS order_num",
+            "CAST(id % 13 AS INT) AS item_sk",
+            "CAST(id AS DECIMAL(38,6)) AS net_paid",
+            "CAST(id % 500 AS INT) AS ship_date_sk",
+            "id % 7 = 0 AS ingest_deleted"
+        ).coalesce(1).write.format("delta") \
+            .option("delta.enableDeletionVectors", "true") \
+            .save(data_path)
+        count = spark.sql(
+            f"DELETE FROM delta.`{data_path}` WHERE ingest_deleted AND order_num % 2 = 0") \
+            .collect()[0][0]
+        assert count > 100, "Expected enough rows to be deleted to create deletion vectors"
+
+    def read_table(spark):
+        # The view supplies the soft-delete filter and column pruning; its expansion
+        # layers the projects that mergeIdenticalProjects later inspects.
+        spark.sql(f"""
+            CREATE OR REPLACE TEMPORARY VIEW {view_name} AS
+            SELECT order_num, item_sk, net_paid, ship_date_sk
+            FROM delta.`{data_path}`
+            WHERE NOT ingest_deleted
+        """)
+        # The same-name cast-alias with the group keys reordered puts a pass-through
+        # project over the alias-computing project; the aggregate feeds a shuffle where
+        # the unguarded merge caused the bind failure.
+        df = spark.sql(f"""
+            SELECT order_num, item_sk,
+                   SUM(net_paid) AS net_paid,
+                   concat_ws(',', sort_array(collect_list(CAST(ship_date_sk AS STRING))))
+                       AS ship_dates
+            FROM (
+                SELECT ship_date_sk,
+                       CAST(net_paid AS DOUBLE) AS net_paid,
+                       order_num, item_sk
+                FROM {view_name}
+                WHERE order_num IS NOT NULL AND item_sk IS NOT NULL
+            )
+            GROUP BY order_num, item_sk
+        """)
+        is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
+        if is_gpu:
+            _assert_db173_gpu_delta_scan_if_enabled(spark, df)
+            explain_str = str(df._jdf.queryExecution().executedPlan())
+            # The DV pushdown pass must have run for this test to exercise
+            # mergeIdenticalProjects: the internal skip-row columns are gone.
+            assert "__delta_internal_is_row_deleted" not in explain_str
+            if is_databricks173_or_later():
+                assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
+        return df
+
+    with_cpu_session(create_delta, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
+
+
 def _test_delta_dv_filter_after_native_scan(spark_tmp_path, cpu_bridge_enabled):
     data_path = spark_tmp_path + "/DELTA_DATA"
     conf = {

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -1371,19 +1371,26 @@ def test_delta_dv_pushdown_keeps_alias_producer(spark_tmp_path, spark_tmp_table_
             )
             GROUP BY order_num, item_sk
         """)
-        is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
-        if is_gpu:
-            _assert_db173_gpu_delta_scan_if_enabled(spark, df)
-            explain_str = str(df._jdf.queryExecution().executedPlan())
-            # The DV pushdown pass must have run for this test to exercise
-            # mergeIdenticalProjects: the internal skip-row columns are gone.
-            assert "__delta_internal_is_row_deleted" not in explain_str
-            if is_databricks173_or_later():
-                assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
         return df
 
+    def assert_dv_pushdown_plan(plan):
+        from conftest import spark_jvm
+
+        # Inspect the plan after collection so an adaptive plan has been finalized.
+        # The DV pushdown pass must have run for this test to exercise
+        # mergeIdenticalProjects: the internal skip-row columns are gone.
+        callback = spark_jvm().org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+        explain_str = str(callback.extractExecutedPlan(plan))
+        assert "__delta_internal_is_row_deleted" not in explain_str
+        if is_databricks173_or_later():
+            assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
+
     with_cpu_session(create_delta, conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        read_table,
+        exist_classes=r"Gpu(FileSourceScanExec|FileGpuScan)",
+        conf=conf,
+        gpu_plan_assertion=assert_dv_pushdown_plan)
 
 
 def _test_delta_dv_filter_after_native_scan(spark_tmp_path, cpu_bridge_enabled):


### PR DESCRIPTION
Fixes #15598.

### Description

On DBR 17.3 (spark400db173 shim), mergeIdenticalProjects in DB173DVPredicatePushdown treats
two adjacent GpuProjectExec nodes as identical when their projectLists have equal exprId sets,
then drops the child. An Alias carries the exprId it defines, so a pass-through parent over an
alias-computing child has an identical exprId set by construction. The merge deletes the only
producer of the alias attribute and the query fails at execution with `Couldn't find <attr>`.
Any plan with an adjacent pass-through-over-alias project pair is exposed at default configs,
deletion vectors on the table are not required. Full root cause is in #15598.

The fix only merges when the child projectList is a pure pass-through (all AttributeReference).

Validation:

- A/B against the live 26.08.0-SNAPSHOT jar by invoking both versions on the same inputs: the
  guarded merge leaves the bug shape unmerged and still collapses a genuine duplicate
  (pass-through over pass-through), so the cleanup this pass was written for keeps working.
- End-to-end TPC-DS repro: fails with the same signature on DV and no-DV tables at default
  configs, passes with `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=false`,
  clean on CPU. I can attach the repro notebook and a LORE dump of the invalid stage.
- The originally failing production workload completes on GPU with that conf as a workaround,
  so we are not blocked in the meantime.

I chose the narrow guard over inlining the child's aliases the way CollapseProject does because
the guard only restricts the existing rewrite, so it cannot introduce new plan shapes, and the
A/B run showed the pass still collapses the duplicate pass-through pairs it was written to
clean up. Inlining would need CollapseProject's safety checks (reference counting,
non-determinism) ported to GPU expression trees, which I did not want to attempt in a shim I
cannot build locally. Happy to rework in that direction if preferred.

Per review, the identical helper in the OSS delta-33x-41x common sources now gets the same
guard in this PR, and there is a new integration test in delta_lake_test.py reproducing the
failing shape.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
