### PR TITLE
Fix pre-merge auto test-selection for databricks tests [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -136,7 +136,7 @@ pipeline {
 
                     // check if need trigger databricks CI build
                     if (title ==~ /.*\[databricks\].*/ ||
-                            (normal_build && databricksCodeChanged())) {
+                            (normal_build && databricksTestNeeded())) {
                         db_build = true
                     }
                 }
@@ -576,15 +576,19 @@ void checkoutCode(String url, String sha) {
     stash(name: "source_tree", includes: "**,.git/**", useDefaultExcludes: false)
 }
 
-boolean databricksCodeChanged() {
+boolean databricksTestNeeded() {
     def output = sh(script: '''
             # get merge BASE from merged pull request. Log message e.g. "Merge HEAD into BASE"
             BASE_REF=$(git --no-pager log --oneline -1 | awk '{ print $NF }')
-            git --no-pager diff --name-only ${BASE_REF} HEAD | grep -lE 'sql-plugin/src/main/.*[0-9x-]db/|databricks' || true
+            # Search for Databricks/Delta-related paths, including:
+            # - numbered shim directories such as spark330db/ and spark350db143/
+            # - all Delta Lake paths such as delta-lake/delta-33x/ and scala2.13/delta-lake/
+            # - any path containing "databricks", such as jenkins/databricks/
+            git --no-pager diff --name-only ${BASE_REF} HEAD | grep -lE 'sql-plugin/src/main/.*[0-9x-]db[0-9]*/|(^|/)delta-lake/|databricks' || true
         ''', returnStdout: true).trim()
 
     if (output) {
-        echo "Found databricks-related changed files"
+        echo "Found databricks/delta-related files changed"
         return true
     }
     return false

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -584,7 +584,7 @@ boolean databricksTestNeeded() {
             # - numbered shim directories such as spark330db/ and spark350db143/
             # - all Delta Lake paths such as delta-lake/delta-33x/ and scala2.13/delta-lake/
             # - any path containing "databricks", such as jenkins/databricks/
-            git --no-pager diff --name-only ${BASE_REF} HEAD | grep -lE 'sql-plugin/src/main/.*[0-9x-]db[0-9]*/|(^|/)delta-lake/|databricks' || true
+            git --no-pager diff --name-only ${BASE_REF} HEAD | grep -E 'sql-plugin/src/main/.*[0-9x-]db[0-9]*/|(^|/)delta-lake/|databricks' || true
         ''', returnStdout: true).trim()
 
     if (output) {


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark/issues/15609.

### Description

The Databricks pre-merge test-selection logic only recognized shim directories ending exactly in `db/` or paths containing `databricks`. As a result, it missed:

- Version-suffixed Databricks shim directories such as `spark350db143/` and `spark400db173/`
- Delta Lake changes whose paths did not contain `databricks`
- Changes under the generated `scala2.13/delta-lake/` mirror

This change:

- Extends the shim matcher to support numeric suffixes after `db`
- Triggers Databricks tests for every path under `delta-lake/` and `scala2.13/delta-lake/`
- Renames `databricksCodeChanged()` to `databricksTestNeeded()` to better describe its purpose
- Adds examples documenting the matched paths
- Updates the detection log message to include Delta Lake changes

Shared shim files in ordinary Spark shim directories that only reference Databricks versions through shim annotations remain outside the scope of this change, because I'm not sure whether they should always tested on Databricks. They can be still tested using the `databricks` tag in the title if needed. We can also extend the auto test selection logic in the future to include them as well.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
