### PR TITLE
[fast-ut] [reduced-it] Add ArrayAggregate and ArraySort corner cases [databricks]

### DIFF
--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -163,11 +163,7 @@ def test_sort_array_lit(data_gen):
 # array_sort runs on the GPU for flat (non-nested) element types. A nested element type (array or
 # struct) falls back to the CPU: cudf's listSortRows applies one null order at every nesting level,
 # but Spark's array_sort needs null elements last and null sub-elements first.
-_array_sort_gens = non_nested_array_gens
-
-# array_sort(arr) with the default comparator (ascending, nulls last) must run on GPU.
-# Capture the plan so a silent CPU fallback (which still matches results) fails the test.
-@pytest.mark.parametrize('data_gen', _array_sort_gens + [
+_array_sort_gens = non_nested_array_gens + [
     ArrayGen(FloatGen(
         no_nans=True,
         special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')])),
@@ -175,7 +171,11 @@ _array_sort_gens = non_nested_array_gens
         no_nans=True,
         special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')])),
     ArrayGen(StringGen(pattern='(| |hello|你好|🙂)')),
-], ids=idfn)
+]
+
+# array_sort(arr) with the default comparator (ascending, nulls last) must run on GPU.
+# Capture the plan so a silent CPU fallback (which still matches results) fails the test.
+@pytest.mark.parametrize('data_gen', _array_sort_gens, ids=idfn)
 def test_array_sort(data_gen):
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: unary_op_df(spark, data_gen).select(f.array_sort(f.col('a'))),

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -167,7 +167,15 @@ _array_sort_gens = non_nested_array_gens
 
 # array_sort(arr) with the default comparator (ascending, nulls last) must run on GPU.
 # Capture the plan so a silent CPU fallback (which still matches results) fails the test.
-@pytest.mark.parametrize('data_gen', _array_sort_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', _array_sort_gens + [
+    ArrayGen(FloatGen(
+        no_nans=True,
+        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')])),
+    ArrayGen(DoubleGen(
+        no_nans=True,
+        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')])),
+    ArrayGen(StringGen(pattern='(| |hello|你好|🙂)')),
+], ids=idfn)
 def test_array_sort(data_gen):
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: unary_op_df(spark, data_gen).select(f.array_sort(f.col('a'))),

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -14,7 +14,8 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
+from asserts import (assert_cpu_and_gpu_are_equal_collect_with_capture,
+                     assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect)
 from data_gen import *
 from marks import allow_non_gpu, allow_non_gpu_conditional, disable_ansi_mode, ignore_order
 from spark_session import is_before_spark_340, is_databricks_runtime
@@ -46,19 +47,23 @@ def test_tiered_project_with_complex_transform():
         '(acc, x) -> least(acc, CAST(x as BIGINT))', '9223372036854775807L'),
     (ArrayGen(FloatGen(
         no_nans=True,
-        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]),
+        min_length=1, max_length=1),
         '(acc, x) -> acc + x', 'CAST(0 AS FLOAT)'),
     (ArrayGen(FloatGen(
         no_nans=True,
-        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]),
+        min_length=1, max_length=1),
         '(acc, x) -> acc * x', 'CAST(1 AS FLOAT)'),
     (ArrayGen(DoubleGen(
         no_nans=True,
-        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]),
+        min_length=1, max_length=1),
         '(acc, x) -> acc + x', 'CAST(0 AS DOUBLE)'),
     (ArrayGen(DoubleGen(
         no_nans=True,
-        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]),
+        min_length=1, max_length=1),
         '(acc, x) -> acc * x', 'CAST(1 AS DOUBLE)'),
 ], ids=['sum', 'product', 'max', 'min',
         'float-sum-corners', 'float-product-corners',
@@ -68,8 +73,9 @@ def test_array_aggregate_numeric_ops(data_gen, lambda_sql, init_sql):
     def do_it(spark):
         return unary_op_df(spark, data_gen).selectExpr(
             f'aggregate(a, {init_sql}, {lambda_sql}) as res')
-    assert_gpu_and_cpu_are_equal_collect(
-        do_it, conf={'spark.rapids.sql.variableFloatAgg.enabled': 'true'})
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it, exist_classes='GpuArrayAggregate',
+        conf={'spark.rapids.sql.variableFloatAgg.enabled': 'true'})
 
 
 @pytest.mark.parametrize('gen, lambda_sql, init_sql', [

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import struct
+
 import pytest
 
 from asserts import (assert_cpu_and_gpu_are_equal_collect_with_capture,
@@ -84,6 +86,37 @@ def test_array_aggregate_numeric_ops(data_gen, lambda_sql, init_sql):
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         do_it, exist_classes='GpuArrayAggregate',
         conf={'spark.rapids.sql.variableFloatAgg.enabled': 'true'})
+
+
+@pytest.mark.parametrize('data_type, pack_format', [
+    ('float', '>f'),
+    ('double', '>d'),
+], ids=['float', 'double'])
+@disable_ansi_mode
+def test_array_sort_and_aggregate_signed_zero_bits(data_type, pack_format):
+    conf = {'spark.rapids.sql.variableFloatAgg.enabled': 'true'}
+
+    def do_it(spark):
+        return spark.createDataFrame(
+            [([-0.0, 0.0],)], f'a array<{data_type}>').selectExpr(
+                'array_sort(a) as sorted',
+                f'aggregate(a, CAST(1 AS {data_type}), (acc, x) -> acc * x) as product')
+
+    def canonicalize(cpu, gpu):
+        def to_raw_bits(rows):
+            return [
+                ([struct.pack(pack_format, value) for value in row.sorted],
+                 struct.pack(pack_format, row.product))
+                for row in rows
+            ]
+        return to_raw_bits(cpu), to_raw_bits(gpu)
+
+    # The shared float oracle treats signed zeros as equal. First require both GPU expressions,
+    # then compare the same deterministic results bit-for-bit in a second CPU/GPU run.
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it, exist_classes='GpuArraySort,GpuArrayAggregate', conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it, conf=conf, result_canonicalize_func_before_compare=canonicalize)
 
 
 @pytest.mark.parametrize('gen, lambda_sql, init_sql', [

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -35,19 +35,41 @@ def test_tiered_project_with_complex_transform():
     assert_gpu_and_cpu_are_equal_collect(do_project, conf=confs)
 
 
-@pytest.mark.parametrize('lambda_sql, init_sql, gen_max', [
-    ('(acc, x) -> acc + CAST(x as BIGINT)', '0L', 100),
-    ('(acc, x) -> acc * CAST(x as BIGINT)', '1L', 3),
-    ('(acc, x) -> greatest(acc, CAST(x as BIGINT))', '-9223372036854775808L', 100),
-    ('(acc, x) -> least(acc, CAST(x as BIGINT))', '9223372036854775807L', 100),
-], ids=['sum', 'product', 'max', 'min'])
+@pytest.mark.parametrize('data_gen, lambda_sql, init_sql', [
+    (ArrayGen(IntegerGen(min_val=-100, max_val=100), max_length=8),
+        '(acc, x) -> acc + CAST(x as BIGINT)', '0L'),
+    (ArrayGen(IntegerGen(min_val=-3, max_val=3), max_length=8),
+        '(acc, x) -> acc * CAST(x as BIGINT)', '1L'),
+    (ArrayGen(IntegerGen(min_val=-100, max_val=100), max_length=8),
+        '(acc, x) -> greatest(acc, CAST(x as BIGINT))', '-9223372036854775808L'),
+    (ArrayGen(IntegerGen(min_val=-100, max_val=100), max_length=8),
+        '(acc, x) -> least(acc, CAST(x as BIGINT))', '9223372036854775807L'),
+    (ArrayGen(FloatGen(
+        no_nans=True,
+        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        '(acc, x) -> acc + x', 'CAST(0 AS FLOAT)'),
+    (ArrayGen(FloatGen(
+        no_nans=True,
+        special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        '(acc, x) -> acc * x', 'CAST(1 AS FLOAT)'),
+    (ArrayGen(DoubleGen(
+        no_nans=True,
+        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        '(acc, x) -> acc + x', 'CAST(0 AS DOUBLE)'),
+    (ArrayGen(DoubleGen(
+        no_nans=True,
+        special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]), max_length=1),
+        '(acc, x) -> acc * x', 'CAST(1 AS DOUBLE)'),
+], ids=['sum', 'product', 'max', 'min',
+        'float-sum-corners', 'float-product-corners',
+        'double-sum-corners', 'double-product-corners'])
 @disable_ansi_mode
-def test_array_aggregate_numeric_ops(lambda_sql, init_sql, gen_max):
-    gen = IntegerGen(min_val=-gen_max, max_val=gen_max)
+def test_array_aggregate_numeric_ops(data_gen, lambda_sql, init_sql):
     def do_it(spark):
-        return unary_op_df(spark, ArrayGen(gen, max_length=8)).selectExpr(
+        return unary_op_df(spark, data_gen).selectExpr(
             f'aggregate(a, {init_sql}, {lambda_sql}) as res')
-    assert_gpu_and_cpu_are_equal_collect(do_it)
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it, conf={'spark.rapids.sql.variableFloatAgg.enabled': 'true'})
 
 
 @pytest.mark.parametrize('gen, lambda_sql, init_sql', [

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -45,6 +45,14 @@ def test_tiered_project_with_complex_transform():
         '(acc, x) -> greatest(acc, CAST(x as BIGINT))', '-9223372036854775808L'),
     (ArrayGen(IntegerGen(min_val=-100, max_val=100), max_length=8),
         '(acc, x) -> least(acc, CAST(x as BIGINT))', '9223372036854775807L'),
+    (ArrayGen(
+        ByteGen(special_cases=[BYTE_MIN, BYTE_MAX, 0, 1, -1]),
+        min_length=1, max_length=8),
+        '(acc, x) -> acc + x', 'CAST(0 AS TINYINT)'),
+    (ArrayGen(
+        ShortGen(special_cases=[SHORT_MIN, SHORT_MAX, 0, 1, -1]),
+        min_length=1, max_length=8),
+        '(acc, x) -> acc + x', 'CAST(0 AS SMALLINT)'),
     (ArrayGen(FloatGen(
         no_nans=True,
         special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, float('nan')]),
@@ -65,7 +73,7 @@ def test_tiered_project_with_complex_transform():
         special_cases=[DOUBLE_MIN, DOUBLE_MAX, 0.0, -0.0, float('nan')]),
         min_length=1, max_length=1),
         '(acc, x) -> acc * x', 'CAST(1 AS DOUBLE)'),
-], ids=['sum', 'product', 'max', 'min',
+], ids=['sum', 'product', 'max', 'min', 'byte-sum-corners', 'short-sum-corners',
         'float-sum-corners', 'float-product-corners',
         'double-sum-corners', 'double-product-corners'])
 @disable_ansi_mode


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim350 vs nightly b14; ArrayAggregate and ArraySort production paths were already covered)

Closes #15616

## Summary

Extend the existing Python integration tests for the two corner-case targets:

- `ArraySort`: Float and Double finite extrema, positive and negative zero, NaN, plus empty, blank, ASCII, CJK, and emoji strings. The capture assertion requires `GpuArraySort`.
- `ArrayAggregate`: explicit Byte/Short boundaries and Float/Double SUM/PRODUCT over finite extrema, positive and negative zero, and NaN. Together with the existing cases, every currently GPU-supported aggregate state/input family is covered; unsupported Decimal, Date, Timestamp, and String paths are not counted. Every parameter requires `GpuArrayAggregate`.

Positive and negative infinity are intentionally out of scope for this milestone. Existing test functions were extended inline so the coverage scanner can attribute the literal generators without duplicating test scaffolding. Float/Double aggregation enables `spark.rapids.sql.variableFloatAgg.enabled=true` and uses one-element non-empty arrays for deterministic strict CPU/GPU comparison.

## Validation

Spark 3.3.0 / Python 3.10, current branch build:

```text
collection_ops_test.py::test_array_sort
higher_order_functions_test.py::test_array_aggregate_numeric_ops
51 passed, 24 warnings in 58.28s
```

Spark 3.5.0 / shim350, JaCoCo run against nightly anchor `4f725f15`:

```text
51 passed, 39703 deselected, 12 warnings in 36.89s
covered lines: +0
```

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
