### PR TITLE
[fast-ut] [reduced-it] Add BloomFilterMightContain corner cases [databricks]

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -1367,7 +1367,13 @@ def check_bloom_filter_join(confs, expected_classes, is_multi_column, probe_gen=
     def do_join(spark):
         left = spark.range(100000)
         if probe_gen is not None:
-            corner_rows = unary_op_df(spark, probe_gen).select(col("a").alias("id"))
+            corner_values = list(probe_gen.list_of_special_cases)
+            if probe_gen.nullable:
+                corner_values.append(None)
+            corner_schema = StructType([
+                StructField("id", probe_gen.data_type, nullable=probe_gen.nullable)])
+            corner_rows = spark.createDataFrame(
+                [(value,) for value in corner_values], schema=corner_schema)
             left = left.unionByName(corner_rows)
         if is_multi_column:
             left = left.withColumn("second_id", col("id") % 5)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -1363,14 +1363,17 @@ dataproc_bloom_filter_probe_allow = (
     else ()
 )
 
-def check_bloom_filter_join(confs, expected_classes, is_multi_column):
+def check_bloom_filter_join(confs, expected_classes, is_multi_column, probe_gen=None):
     def do_join(spark):
+        left = spark.range(100000)
+        if probe_gen is not None:
+            corner_rows = unary_op_df(spark, probe_gen).select(col("a").alias("id"))
+            left = left.unionByName(corner_rows)
         if is_multi_column:
-            left = spark.range(100000).withColumn("second_id", col("id") % 5)
+            left = left.withColumn("second_id", col("id") % 5)
             right = spark.range(10).withColumn("id2", col("id").cast("string")).withColumn("second_id", col("id") % 5)
             return right.filter("cast(id2 as bigint) % 3 = 0").join(left, (left.id == right.id) & (left.second_id == right.second_id), "inner")
         else:
-            left = spark.range(100000)
             right = spark.range(10).withColumn("id2", col("id").cast("string"))
             return right.filter("cast(id2 as bigint) % 3 = 0").join(left, left.id == right.id, "inner")
     all_confs = copy_and_update(bloom_filter_confs, confs)
@@ -1379,12 +1382,17 @@ def check_bloom_filter_join(confs, expected_classes, is_multi_column):
 @ignore_order(local=True)
 @pytest.mark.parametrize("batch_size", ['1g', '1000'], ids=idfn)
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
+@pytest.mark.parametrize("probe_gen", [
+    LongGen(special_cases=[LONG_MIN, LONG_MAX, 0, 1, -1])
+], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
-def test_bloom_filter_join(batch_size, is_multi_column):
+def test_bloom_filter_join(batch_size, is_multi_column, probe_gen):
+    # Runtime bloom-filter rewriting inserts might_contain(...) on the large probe side.
     conf = {"spark.rapids.sql.batchSizeBytes": batch_size}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,GpuBloomFilterAggregate",
-                            is_multi_column=is_multi_column)
+                            is_multi_column=is_multi_column,
+                            probe_gen=probe_gen)
 
 @allow_non_gpu(
     "ShuffleExchangeExec", "And", "BloomFilterMightContain", "GetStructField",


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim350 vs nightly b14; +1 branch)

Closes #15618

## Summary

- Extend the existing runtime Bloom filter join IT with literal nullable Long probe data.
- Cover exactly `LONG_MIN`, `LONG_MAX`, zero, one, negative one, and null through an explicit Long schema rather than generating 2,048 random rows.
- Preserve the existing single-column/multi-column and batch-size matrix.
- Require both `GpuBloomFilterMightContain` and `GpuBloomFilterAggregate` in every modified GPU plan.

## Traceability

- RAPIDS test: `integration_tests/src/main/python/join_test.py::test_bloom_filter_join`
- Existing coverage extended in place; no duplicate test function was added.
- The executed GPU plan applies `might_contain(...)` to the corner-data branch.

## Validation

Spark 3.3.0 / Python 3.10, current head `e952913b4`:

```text
16 passed, 34861 deselected, 6 warnings in 40.19s
```

Spark 3.5.0 / shim350, exact four modified combinations, current Python test code:

```text
4 passed, 34879 deselected, 6 warnings in 23.72s
covered lines: +0
covered branches: +1
```

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
