### PR TITLE
Upgrade UCX to 1.22.0

### DIFF
--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_no_rdma
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #   - ROCKY_VER: Rocky Linux OS version
 
 ARG CUDA_VER=13.0.1
-ARG UCX_VER=1.19.1-rc2
+ARG UCX_VER=1.22.0
 ARG UCX_CUDA_VER=13
 ARG UCX_ARCH=x86_64
 ARG ROCKY_VER=8

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_rdma
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #   - ROCKY_VER: Rocky Linux OS version
 
 ARG CUDA_VER=13.0.1
-ARG UCX_VER=1.19.1-rc2
+ARG UCX_VER=1.22.0
 ARG UCX_CUDA_VER=13
 ARG UCX_ARCH=x86_64
 ARG ROCKY_VER=8

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #
 
 ARG CUDA_VER=13.0.1
-ARG UCX_VER=1.19.1-rc2
+ARG UCX_VER=1.22.0
 ARG UCX_CUDA_VER=13
 ARG UCX_ARCH=x86_64
 ARG UBUNTU_VER=22.04
@@ -52,5 +52,6 @@ RUN apt-get install -y wget bzip2 libgomp1
 RUN mkdir /tmp/ucx_install && cd /tmp/ucx_install && \
   wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
-  apt install -y /tmp/ucx_install/*.deb && \
+  apt install -y --no-install-recommends $(ls /tmp/ucx_install/*.deb | grep -v ucx-cuda) && \
+  dpkg -i --force-depends /tmp/ucx_install/ucx-cuda-*.deb && \
   rm -rf /tmp/ucx_install

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-# Sample Dockerfile to install UCX in a Unbuntu 22.04 image with RDMA support.
+# Sample Dockerfile to install UCX in a Ubuntu 22.04 image with RDMA support.
 #
 # The parameters are: 
 #   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest
@@ -27,7 +27,7 @@
 #   - UBUNTU_VER: 22.04 by default
 #
 # The Dockerfile first fetches and builds `rdma-core` to satisfy requirements for
-# the ucx-ib and ucx-rdma RPMs.
+# the ucx-ib and ucx-rdma DEBs.
 #
 # Note that tzdata has to be installed with a time zone configuration, and UTC has been picked in this container
 #
@@ -35,7 +35,7 @@
 
 ARG RDMA_CORE_VERSION=32.1
 ARG CUDA_VER=13.0.1
-ARG UCX_VER=1.19.1-rc2
+ARG UCX_VER=1.22.0
 ARG UCX_CUDA_VER=13
 ARG UCX_ARCH=x86_64
 ARG UBUNTU_VER=22.04
@@ -95,5 +95,6 @@ RUN apt-get install -y wget bzip2 libgomp1
 RUN cd /tmp/ucx_install && \
   wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
-  apt install -y /tmp/ucx_install/*.deb && \
+  apt install -y --no-install-recommends $(ls /tmp/ucx_install/*.deb | grep -v ucx-cuda) && \
+  dpkg -i --force-depends /tmp/ucx_install/ucx-cuda-*.deb && \
   rm -rf /tmp/ucx_install

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 # Arguments:
 #       CUDA_VER=[12.X.Y,13.X.Y]
 #       UBUNTU_VER=[22.04,24.04]
-#       UCX_VER=1.19.1-rc2
+#       UCX_VER=1.22.0
 #       TARGETPLATFORM=[linux/amd64,linux/arm64]
 #       ARCH=[amd64,arm64]
 #       UCX_ARCH=[x86_64,aarch64]
@@ -29,7 +29,7 @@
 
 ARG CUDA_VER=13.0.1
 ARG UBUNTU_VER=22.04
-ARG UCX_VER=1.19.1-rc2
+ARG UCX_VER=1.22.0
 ARG TARGETPLATFORM=linux/amd64
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
@@ -77,7 +77,8 @@ RUN UCX_CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f1` && \
     cd /tmp/ucx && \
     wget https://github.com/openucx/ucx/releases/download/v${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5-cuda${UCX_CUDA_VER}-${UCX_ARCH}.tar.bz2 && \
     tar -xvf *.bz2 && \
-    apt install -y /tmp/ucx/*.deb && \
+    apt install -y --no-install-recommends $(ls /tmp/ucx/*.deb | grep -v ucx-cuda) && \
+    dpkg -i --force-depends /tmp/ucx/ucx-cuda-*.deb && \
     rm -rf /tmp/ucx
 
 # export JAVA_HOME for mvn option 'source-javadoc'

--- a/pom.xml
+++ b/pom.xml
@@ -1001,7 +1001,11 @@
         https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties#L1993-L1994
         -->
         <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing|-Werror</scala.javac.args>
-        <ucx.baseVersion>1.19.1-rc2</ucx.baseVersion>
+        <!-- NOTE: upstream republished the UCX 1.22.0 JUCX artifact as 1.22.0-1; the original
+             org.openucx:jucx:1.22.0 jar contains an rc1 build. See the "Known issues" section of
+             https://github.com/openucx/ucx/releases/tag/v1.22.0. The native UCX installed by the
+             Dockerfiles is plain 1.22.0 (the GitHub release tag) - this mismatch is intentional. -->
+        <ucx.baseVersion>1.22.0-1</ucx.baseVersion>
         <roaringbitmap.version>1.0.6</roaringbitmap.version>
         <!-- ucx x86 is just the base version (implied), arm is specified under arm64 profile. -->
         <ucx.version>${ucx.baseVersion}</ucx.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1001,7 +1001,11 @@
         https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties#L1993-L1994
         -->
         <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing|-Werror</scala.javac.args>
-        <ucx.baseVersion>1.19.1-rc2</ucx.baseVersion>
+        <!-- NOTE: upstream republished the UCX 1.22.0 JUCX artifact as 1.22.0-1; the original
+             org.openucx:jucx:1.22.0 jar contains an rc1 build. See the "Known issues" section of
+             https://github.com/openucx/ucx/releases/tag/v1.22.0. The native UCX installed by the
+             Dockerfiles is plain 1.22.0 (the GitHub release tag) - this mismatch is intentional. -->
+        <ucx.baseVersion>1.22.0-1</ucx.baseVersion>
         <roaringbitmap.version>1.0.6</roaringbitmap.version>
         <!-- ucx x86 is just the base version (implied), arm is specified under arm64 profile. -->
         <ucx.version>${ucx.baseVersion}</ucx.version>


### PR DESCRIPTION
Fixes #14055

### Description

Upgrades UCX from `1.19.1-rc2` to **1.22.0** across the Maven POMs and all five Dockerfiles. Supersedes the stale #14383, which targeted 1.20.0 and stalled on the DEB packaging problem described below.


#### ⚠️ `jucx` is pinned to `1.22.0-1`, not `1.22.0` — this is not a typo

Upstream republished the 1.22.0 JUCX artifact as `1.22.0-1`. The original `org.openucx:jucx:1.22.0` jar is an **rc1 build**: its `libjucx_amd64.so` is dated 2026-07-01, which is the `v1.22.0-rc1` tag date, whereas `1.22.0-1` is dated
2026-08-03, matching the actual release.
The v1.22.0 release notes say so directly under *Known issues*:

> JUCX package for this release was renamed to `1.22.0-1`, please avoid using `1.22.0`.

Both `jucx:1.22.0` and `jucx:1.22.0-1` resolve on Maven Central, so a naive `1.22.0` pin builds green while silently shipping an rc1 JNI binding.

The **native** UCX GitHub release tag is plain `v1.22.0`, so `ucx.baseVersion` (`1.22.0-1`) and `ARG UCX_VER` (`1.22.0`) intentionally differ. A comment in `pom.xml` records why, so it does not get "corrected" later.

`ucx.baseVersion` is the only pin needed — the `arm64` profile's `${ucx.baseVersion}-aarch64` resolves to `jucx:1.22.0-1-aarch64`, which exists.

#### UCX DEB packaging workaround — still required

Since UCX 1.20, the Ubuntu `ucx-cuda` package pulls NVIDIA driver userspace libraries into the image, shadowing the host-injected `libcuda.so.1` and producing `Driver/library version mismatch`. Read from the shipped 1.22.0 artifacts
(x86_64 and aarch64 identical):

```
cuda12:  Depends:    libc6 (>= 2.34), ucx
         Recommends: libnvidia-compute | libnvidia-ml1
cuda13:  Depends:    libc6, libgcc-s1, libgomp1,
                     libnvidia-compute-580 (>= 580.65.06),   <-- hard, concrete
                     libstdc++6, ucx
         Recommends: libnvidia-compute | libnvidia-ml1
```

`--no-install-recommends` alone is therefore **not** sufficient for the default CUDA 13 build, so #14383's two-step install is retained in the three Ubuntu Dockerfiles:

1. `apt install --no-install-recommends` for `ucx` / `ucx-xpmem` (and, in the RDMA image, the locally built `rdma-core` debs)
2. `dpkg -i --force-depends` for `ucx-cuda` only

**Rocky/RPM is unaffected** — those packages express only soname-level requires (`libcuda.so.1`, `libcudart.so.13`), and the Dockerfiles already use `rpm -i --nodeps`, which installs cleanly and pulls no NVIDIA packages. Those two
files get the version bump only.

#### This also fixes a pre-existing bug

At `1.19.1-rc2` the CUDA 13 variant **already** declared a hard driver dependency, so the default Ubuntu example images were affected before this upgrade. The change is not purely a version bump on that path.

#### Upstream status

openucx/ucx#11257 is still **open**. openucx/ucx#11141 and openucx/ucx#11267 are merged and `debian/control.in` no longer *declares* driver dependencies, but the residual hard `Depends` persists in the release artifact — it appears alongside other obviously auto-generated entries (`libgcc-s1`, `libgomp1`, `libstdc++6`) and only in the CUDA 13 build, so it is most likely `dpkg-shlibdeps`-generated on a builder that has the 580 driver installed. It can therefore reappear or vanish per release with no control-file change, which is why the workaround is not version-gated.

### How this was tested

Local GPU host (RTX A5000, driver 580.173.02):

- **UCX shuffle integration tests**: run inside the blossom image against Spark 3.5.7 in standalone mode via
  `invoke_shuffle_integration_test UCX ./integration_tests/run_pyspark_from_build.sh premerge 3.5.7` → **85 passed, 0 failed** (87s). The driver log confirms UCX was genuinely active rather than silently falling back:

- `mvn clean verify -DskipTests -Dbuildver=357` → **BUILD SUCCESS**. `ucx.version` resolves to `1.22.0-1` by default and `1.22.0-1-aarch64` under `-Parm64`; both artifacts download. Build log shows `Excluding org.openucx:jucx:jar:1.22.0-1 from the shaded jar`.
- The `libjucx_amd64.so` in the dist jar is **672,976 bytes**, matching the `1.22.0-1` jar rather than the rc1-contaminated `1.22.0` jar (675,056 bytes) — independent confirmation the correct binding shipped.
- `Dockerfile.ubuntu_no_rdma` (CUDA 13 default), `Dockerfile.rocky_no_rdma` (CUDA 13) and `jenkins/Dockerfile-blossom.ubuntu` (`--build-arg CUDA_VER=12.0.1`, as Blossom builds it) all build. In each, with a GPU attached: `ucx_info -v` reports **1.22.0**, `cuda_copy` and `cuda_ipc` transports are present, **no** `libnvidia-*` packages are installed, and `nvidia-smi` still reports the host driver 580.173.02.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
        (The four Dockerfiles under `docs/additional-functionality/shuffle-docker-examples/` are published documentation that users copy; both the UCX version and the Ubuntu install steps changed.)
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
        Existing tests covering this change, selected by `-m shuffle_test`:
        - `integration_tests/src/main/python/hash_aggregate_test.py::test_hash_grpby_sum`
        - `integration_tests/src/main/python/hash_aggregate_test.py::test_hash_grpby_sum_full_decimal`
     These are the only `@shuffle_test-marked` tests in the tree; 85 parametrizations ran and passed under `spark.rapids.shuffle.mode=UCX`. Also exercised by `jenkins/spark-premerge-build.sh::rapids_shuffle_smoke_test` and by `doc/Jenkinsfile.ucx` (`ucx_perftest` against the example images).
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required


P.S: UCX integration tests do not run on the Databricks pipeline at all. The `[databricks]` tag is omitted.

--
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>