### PR TITLE
[BUG] Release bytes-in-flight quota on compression task failure or cancellation

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -729,7 +729,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         // Set to true as the very first act of call(). done() uses this to distinguish
         // "cancelled before call() ever ran" (safe to release quota there) from
         // "cancelled while call() was executing" (catch block releases after resources freed).
-        val callableStarted = new java.util.concurrent.atomic.AtomicBoolean(false)
+        val callableStarted = new AtomicBoolean(false)
         val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
           override def call(): CompressedRecord = {
             callableStarted.set(true)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -763,9 +763,8 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
                 // Note: excessQuota can be 0 if compression doesn't reduce size (or expands)
                 val excessQuota = math.max(0L, recordSize - compressedSize)
                 if (excessQuota > 0) {
-                  // addAndGet returns negative if done() already claimed quota via getAndSet(0).
-                  // In that case skip the direct release; the merger will also see a negative
-                  // getAndSet(0) and skip its release, preventing double-release on the success path.
+                  // addAndGet returns negative if done() already claimed quota via getAndSet(0);
+                  // skip the direct release. The merger also sees negative and skips.
                   val remaining = quotaToRelease.addAndGet(-excessQuota)
                   if (remaining >= 0) {
                     limiter.release(excessQuota)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -737,9 +737,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
           override def call(): CompressedRecord = {
             if (!cbOwner.compareAndSet(false, true)) {
-              // done() already closed cb and released quota; FutureTask state is
-              // already CANCELLED/INTERRUPTED so set(null) fails silently.
-              return null
+              // done() already closed cb and released quota; bail out.
+              throw new IOException(
+                s"Failed compression task for shuffle $shuffleId, map $mapId, " +
+                  s"partition $reducePartitionId: cancelled before starting")
             }
             try {
               withResource(cb) { _ =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -482,6 +482,22 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     private def fail(t: Throwable): Unit = {
       closeOutputStreamQuietly()
       completionFuture.completeExceptionally(t)
+      // Release quota for futures that already completed normally but were never
+      // processed by writeRecord. This unblocks any producer thread waiting in
+      // acquireOrBlock for quota that writeRecord will never release.
+      partitionRecords.values().asScala.foreach { recordQueue =>
+        val future = recordQueue.peek()
+        if (future != null && future.isDone && !future.isCancelled) {
+          try {
+            val toRelease = future.get().quotaToRelease.getAndSet(0)
+            if (toRelease > 0) {
+              limiter.release(toRelease)
+            }
+          } catch {
+            case _: Exception => // quota was released in the compression catch block
+          }
+        }
+      }
     }
   }
 
@@ -812,14 +828,11 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
             if (cbOwner.compareAndSet(false, true)) {
               cb.close()
             }
-            // On cancellation, release any remaining quota regardless of whether call()
-            // ran. Three cases:
-            //  1. call() never ran: quotaToRelease = recordSize, released here.
-            //  2. call() failed: catch block already claimed via getAndSet(0); returns 0.
-            //  3. call() succeeded but result was discarded (cancel(true) fired and the
-            //     interrupt was ignored): set(result) silently fails, merger never runs
-            //     writeRecord, so quota would otherwise leak. getAndSet(0) captures it.
-            if (isCancelled) {
+            // Release quota when cancelled, or when the merger has already failed (so
+            // writeRecord will never be called for this future's CompressedRecord).
+            // getAndSet(0) is idempotent: fail() may have already claimed it; returns 0.
+            if (isCancelled ||
+                batchForRecord.merger.completionFuture.isCompletedExceptionally) {
               val toRelease = quotaToRelease.getAndSet(0)
               if (toRelease > 0) {
                 limiter.release(toRelease)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -450,13 +450,17 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     private def hasReadyWork: Boolean = currentWorkState != NotReady
 
     private def writeRecord(record: CompressedRecord): Unit = {
-      if (record.compressedSize > 0) {
-        outputStream.write(record.buffer.getBuf, 0, record.compressedSize.toInt)
-      }
-      record.buffer.close()
-      val toRelease = record.quotaToRelease.getAndSet(0)
-      if (toRelease > 0) {
-        limiter.release(toRelease)
+      try {
+        withResource(record.buffer) { buffer =>
+          if (record.compressedSize > 0) {
+            outputStream.write(buffer.getBuf, 0, record.compressedSize.toInt)
+          }
+        }
+      } finally {
+        val toRelease = record.quotaToRelease.getAndSet(0)
+        if (toRelease > 0) {
+          limiter.release(toRelease)
+        }
       }
     }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -723,11 +723,16 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         val batchForRecord = currentBatch
         // Tracks how much quota this task still owes back to the limiter. Initialized to
         // the full recordSize; decremented when excessQuota is released early on the success
-        // path. getAndSet(0) in the catch block or done() atomically claims whatever remains,
-        // so exactly one path releases the quota even when cancel(true) races with call().
+        // path. getAndSet(0) in the catch block atomically claims whatever remains,
+        // ensuring quota is only released after call() has freed its resources.
         val quotaToRelease = new AtomicLong(recordSize)
+        // Set to true as the very first act of call(). done() uses this to distinguish
+        // "cancelled before call() ever ran" (safe to release quota there) from
+        // "cancelled while call() was executing" (catch block releases after resources freed).
+        val callableStarted = new java.util.concurrent.atomic.AtomicBoolean(false)
         val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
           override def call(): CompressedRecord = {
+            callableStarted.set(true)
             try {
               withResource(cb) { _ =>
                 // Create a new buffer for this record.
@@ -786,10 +791,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           }
         }) {
           override def done(): Unit = {
-            // For cancelled tasks, atomically claim and release whatever quota remains.
-            // getAndSet(0) ensures exactly one of the catch block and done() releases,
-            // even when cancel(true) races with an executing call().
-            if (isCancelled) {
+            // Only release quota here if call() never started. If call() did start,
+            // its catch block releases quota after withResource(cb) closes the buffer,
+            // ensuring quota is not freed while resources are still held.
+            if (isCancelled && !callableStarted.get) {
               val toRelease = quotaToRelease.getAndSet(0)
               if (toRelease > 0) {
                 limiter.release(toRelease)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -340,8 +340,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     private case object NotReady extends WorkState
     private case object EmptyPartition extends WorkState
     private case class ReadyRecord(
-        queue: ConcurrentLinkedQueue[Future[CompressedRecord]],
-        future: Future[CompressedRecord]) extends WorkState
+        queue: ConcurrentLinkedQueue[Future[CompressedRecord]]) extends WorkState
     private case object FinishedPartition extends WorkState
 
     def schedule(): Unit = {
@@ -386,12 +385,11 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
               // The producer has advanced beyond this partition without adding records.
               writer.getPartitionWriter(currentPartitionToWrite).openStream().close()
               currentPartitionToWrite += 1
-            case ReadyRecord(recordQueue, future) =>
+            case ReadyRecord(recordQueue) =>
               if (outputStream == null) {
                 outputStream = writer.getPartitionWriter(currentPartitionToWrite).openStream()
               }
-              recordQueue.poll()
-              writeRecord(future.get())
+              writeRecord(recordQueue)
             case FinishedPartition =>
               closeOutputStream()
               partitionRecords.remove(currentPartitionToWrite)
@@ -407,6 +405,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         case _: InterruptedException =>
           Thread.currentThread().interrupt()
           completionFuture.cancel(true)
+          limiter.signalFailure()
         case t: Throwable => fail(t)
       } finally {
         stepFuture.set(null)
@@ -436,7 +435,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           } else {
             val future = recordQueue.peek()
             if (future != null && future.isDone) {
-              ReadyRecord(recordQueue, future)
+              ReadyRecord(recordQueue)
             } else if (future == null && currentPartitionToWrite < maxQueued) {
               FinishedPartition
             } else {
@@ -449,17 +448,25 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
 
     private def hasReadyWork: Boolean = currentWorkState != NotReady
 
-    private def writeRecord(record: CompressedRecord): Unit = {
+    private def writeRecord(queue: ConcurrentLinkedQueue[Future[CompressedRecord]]): Unit = {
+      var record: CompressedRecord = null
+      var buffer: OpenByteArrayOutputStream = null
       try {
-        withResource(record.buffer) { buffer =>
-          if (record.compressedSize > 0) {
-            outputStream.write(buffer.getBuf, 0, record.compressedSize.toInt)
+        record = queue.peek().get()
+        buffer = record.buffer
+        if (record.compressedSize > 0) {
+          outputStream.write(buffer.getBuf, 0, record.compressedSize.toInt)
+        }
+        queue.poll()
+      } finally {
+        if (record != null) {
+          val toRelease = record.quotaToRelease.getAndSet(0)
+          if (toRelease > 0) {
+            limiter.release(toRelease)
           }
         }
-      } finally {
-        val toRelease = record.quotaToRelease.getAndSet(0)
-        if (toRelease > 0) {
-          limiter.release(toRelease)
+        if (buffer != null) {
+          buffer.close()
         }
       }
     }
@@ -487,15 +494,16 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       limiter.signalFailure()
       // Also release quota for already-completed futures that writeRecord will never see.
       partitionRecords.values().asScala.foreach { recordQueue =>
-        val future = recordQueue.peek()
-        if (future != null && future.isDone && !future.isCancelled) {
-          try {
-            val toRelease = future.get().quotaToRelease.getAndSet(0)
-            if (toRelease > 0) {
-              limiter.release(toRelease)
+        recordQueue.forEach { future =>
+          if (future != null && future.isDone && !future.isCancelled) {
+            try {
+              val toRelease = future.get().quotaToRelease.getAndSet(0)
+              if (toRelease > 0) {
+                limiter.release(toRelease)
+              }
+            } catch {
+              case _: Exception => // quota was released in the compression catch block
             }
-          } catch {
-            case _: Exception => // quota was released in the compression catch block
           }
         }
       }
@@ -1156,7 +1164,7 @@ class BytesInFlightLimiter(maxBytesInFlight: Long) {
       true
     } else {
       synchronized {
-        if (inFlight == 0 || sz + inFlight < maxBytesInFlight) {
+        if (inFlight == 0 || sz + inFlight <= maxBytesInFlight) {
           inFlight += sz
           true
         } else {
@@ -1330,22 +1338,10 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
     // Register a completion handler to close any queued cbs,
     // pending iterators, or futures
     onTaskCompletion(context) {
-      // remove any materialized batches
-      queued.forEach {
-        case (_, cb:ColumnarBatch) => cb.close()
-      }
-      queued.clear()
-
-      // close any materialized BlockState objects that are holding onto netty buffers or
-      // file descriptors
-      pendingIts.safeClose()
-      pendingIts.clear()
-
-      // we could have futures left that are either done or in flight
-      // we need to cancel them and then close out any `BlockState`
-      // objects that were created (to remove netty buffers or file descriptors)
+      // Cancel/join futures first so that no deserializeTask thread can call
+      // queued.offer() after we drain the queue below.
       val futuresAndCancellations = futures.map { f =>
-        val didCancel = f.cancel(true)
+        val didCancel = try { f.cancel(true) } catch { case _: Exception => false }
         (f, didCancel)
       }
 
@@ -1360,8 +1356,7 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
             // this could either be a successful future, or it finished with exception
             // the case when it will fail with exception is when the underlying stream is closed
             // as part of the shutdown process of the task.
-            future.get(10, TimeUnit.MILLISECONDS)
-              .foreach(_.close())
+            future.get(10, TimeUnit.MILLISECONDS).foreach(_.close())
           } catch {
             case t: Throwable =>
               // this is going to capture the first exception and not worry about others
@@ -1373,6 +1368,18 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
           }
         }
       futures.clear()
+
+      // All futures are now done or cancelled — no more queued.offer() calls can arrive.
+      // Safe to drain queued and pendingIts without a race.
+      queued.forEach {
+        case (_, cb:ColumnarBatch) => cb.close()
+      }
+      queued.clear()
+
+      // close any materialized BlockState objects that are holding onto netty buffers or
+      // file descriptors
+      pendingIts.safeClose()
+      pendingIts.clear()
       try {
         if (fallbackIter != null) {
           fallbackIter.close()
@@ -1486,18 +1493,29 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
           // here while we wait.
           waitTimeStart = System.nanoTime()
           val res = queued.take()
-          val queueWaitThisCall = System.nanoTime() - waitTimeStart
-          // limiter is now released immediately after deserialization in deserializeTask
-          res match {
-            case (_, _: ColumnarBatch) =>
-              popFetchedIfAvailable()
-            case _ => // do nothing
+          var success = false
+          try {
+            val queueWaitThisCall = System.nanoTime() - waitTimeStart
+            // limiter is now released immediately after deserialization in deserializeTask
+            res match {
+              case (_, _: ColumnarBatch) =>
+                popFetchedIfAvailable()
+              case _ => // do nothing
+            }
+            waitTime += queueWaitThisCall
+            deserWaitTimeNs.foreach(_ += queueWaitThisCall)
+            deserializationTimeNs.foreach(_ += waitTime)
+            shuffleReadTimeNs.foreach(_ += waitTime)
+            success = true
+            res
+          } finally {
+            if (!success) {
+              res match {
+                case (_, cb: ColumnarBatch) => cb.close()
+                case _ => // do nothing
+              }
+            }
           }
-          waitTime += queueWaitThisCall
-          deserWaitTimeNs.foreach(_ += queueWaitThisCall)
-          deserializationTimeNs.foreach(_ += waitTime)
-          shuffleReadTimeNs.foreach(_ += waitTime)
-          res
         }
 
         val uncompressedSize = result match {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -721,6 +721,11 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         waitTimeOnLimiterNs += System.nanoTime() - waitOnLimiterStart
 
         val batchForRecord = currentBatch
+        // Tracks how much quota this task still owes back to the limiter. Initialized to
+        // the full recordSize; decremented when excessQuota is released early on the success
+        // path. getAndSet(0) in the catch block or done() atomically claims whatever remains,
+        // so exactly one path releases the quota even when cancel(true) races with call().
+        val quotaToRelease = new AtomicLong(recordSize)
         val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
           override def call(): CompressedRecord = {
             try {
@@ -751,6 +756,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
                 val excessQuota = math.max(0L, recordSize - compressedSize)
                 if (excessQuota > 0) {
                   limiter.release(excessQuota)
+                  quotaToRelease.addAndGet(-excessQuota)
                 }
 
                 // Return CompressedRecord with buffer and remaining quota for Merger
@@ -759,7 +765,20 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
                 CompressedRecord(buffer, compressedSize, remainingQuota)
               }
             } catch {
+              case e: InterruptedException =>
+                Thread.currentThread().interrupt()
+                val toRelease = quotaToRelease.getAndSet(0)
+                if (toRelease > 0) {
+                  limiter.release(toRelease)
+                }
+                throw new IOException(
+                  s"Failed compression task for shuffle $shuffleId, map $mapId, " +
+                    s"partition $reducePartitionId", e)
               case e: Exception =>
+                val toRelease = quotaToRelease.getAndSet(0)
+                if (toRelease > 0) {
+                  limiter.release(toRelease)
+                }
                 throw new IOException(
                   s"Failed compression task for shuffle $shuffleId, map $mapId, " +
                     s"partition $reducePartitionId", e)
@@ -767,7 +786,15 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           }
         }) {
           override def done(): Unit = {
-            // FutureTask invokes done only after isDone becomes true.
+            // For cancelled tasks, atomically claim and release whatever quota remains.
+            // getAndSet(0) ensures exactly one of the catch block and done() releases,
+            // even when cancel(true) races with an executing call().
+            if (isCancelled) {
+              val toRelease = quotaToRelease.getAndSet(0)
+              if (toRelease > 0) {
+                limiter.release(toRelease)
+              }
+            }
             batchForRecord.scheduleMerger()
           }
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -482,9 +482,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     private def fail(t: Throwable): Unit = {
       closeOutputStreamQuietly()
       completionFuture.completeExceptionally(t)
-      // Release quota for futures that already completed normally but were never
-      // processed by writeRecord. This unblocks any producer thread waiting in
-      // acquireOrBlock for quota that writeRecord will never release.
+      // Signal the limiter so any producer blocked in acquireOrBlock wakes up and
+      // throws, allowing the write loop to exit and cleanupBatch to release all quotas.
+      limiter.signalFailure()
+      // Also release quota for already-completed futures that writeRecord will never see.
       partitionRecords.values().asScala.foreach { recordQueue =>
         val future = recordQueue.peek()
         if (future != null && future.isDone && !future.isCancelled) {
@@ -740,7 +741,13 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
 
         // Acquire limiter and process compression task immediately
         val waitOnLimiterStart = System.nanoTime()
-        limiter.acquireOrBlock(recordSize)
+        try {
+          limiter.acquireOrBlock(recordSize)
+        } catch {
+          case e: Exception =>
+            cb.close()  // prevent ref-count leak from incRefCountAndGetSize
+            throw e
+        }
         waitTimeOnLimiterNs += System.nanoTime() - waitOnLimiterStart
 
         val batchForRecord = currentBatch
@@ -1142,6 +1149,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
 
 class BytesInFlightLimiter(maxBytesInFlight: Long) {
   private var inFlight: Long = 0L
+  private var failed: Boolean = false
 
   def acquire(sz: Long): Boolean = {
     if (sz == 0) {
@@ -1163,6 +1171,9 @@ class BytesInFlightLimiter(maxBytesInFlight: Long) {
     if (!acquired) {
       synchronized {
         while (!acquired) {
+          if (failed) {
+            throw new IOException("Compression batch failed; quota acquisition aborted")
+          }
           acquired = acquire(sz)
           if (!acquired) {
             wait()
@@ -1170,6 +1181,11 @@ class BytesInFlightLimiter(maxBytesInFlight: Long) {
         }
       }
     }
+  }
+
+  def signalFailure(): Unit = synchronized {
+    failed = true
+    notifyAll()
   }
 
   def release(sz: Long): Unit = synchronized {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -729,13 +729,18 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         // path. getAndSet(0) in the catch block atomically claims whatever remains,
         // ensuring quota is only released after call() has freed its resources.
         val quotaToRelease = new AtomicLong(recordSize)
-        // Set to true as the very first act of call(). done() uses this to distinguish
-        // "cancelled before call() ever ran" (safe to release quota there) from
-        // "cancelled while call() was executing" (catch block releases after resources freed).
-        val callableStarted = new AtomicBoolean(false)
+        // CAS gate shared between call() and done(). Whoever wins compareAndSet(false, true)
+        // is responsible for closing cb and releasing quota. This prevents both a cb leak
+        // (done() fires for a cancelled-before-start task and cb is never closed) and
+        // double-close (done() and call() both try to close cb in the race window).
+        val cbOwner = new AtomicBoolean(false)
         val compressionTask = new FutureTask[CompressedRecord](new Callable[CompressedRecord] {
           override def call(): CompressedRecord = {
-            callableStarted.set(true)
+            if (!cbOwner.compareAndSet(false, true)) {
+              // done() already closed cb and released quota; FutureTask state is
+              // already CANCELLED/INTERRUPTED so set(null) fails silently.
+              return null
+            }
             try {
               withResource(cb) { _ =>
                 // Create a new buffer for this record.
@@ -797,10 +802,19 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           }
         }) {
           override def done(): Unit = {
-            // Only release quota here if call() never started. If call() did start,
-            // its catch block releases quota after withResource(cb) closes the buffer,
-            // ensuring quota is not freed while resources are still held.
-            if (isCancelled && !callableStarted.get) {
+            // If call() never ran, win the CAS to close cb (prevents the ref-count leak
+            // from incRefCountAndGetSize). Quota is handled separately below.
+            if (cbOwner.compareAndSet(false, true)) {
+              cb.close()
+            }
+            // On cancellation, release any remaining quota regardless of whether call()
+            // ran. Three cases:
+            //  1. call() never ran: quotaToRelease = recordSize, released here.
+            //  2. call() failed: catch block already claimed via getAndSet(0); returns 0.
+            //  3. call() succeeded but result was discarded (cancel(true) fired and the
+            //     interrupt was ignored): set(result) silently fails, merger never runs
+            //     writeRecord, so quota would otherwise leak. getAndSet(0) captures it.
+            if (isCancelled) {
               val toRelease = quotaToRelease.getAndSet(0)
               if (toRelease > 0) {
                 limiter.release(toRelease)
@@ -877,12 +891,20 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           var future = recordQueue.poll()
           while (future != null) {
             future.cancel(true)
-            // If future already completed, try to close the buffer
+            // If future completed normally (merger never processed it), release the
+            // remaining quota and close the buffer. Quota release comes first so that a
+            // buffer close failure does not leave the limiter stranded.
+            // Cancelled futures are handled by done().
             if (future.isDone && !future.isCancelled) {
               try {
-                future.get().buffer.close()
+                val record = future.get()
+                val toRelease = record.quotaToRelease.getAndSet(0)
+                if (toRelease > 0) {
+                  limiter.release(toRelease)
+                }
+                try { record.buffer.close() } catch { case _: Exception => }
               } catch {
-                case _: Exception => // Ignore cleanup errors
+                case _: Exception => // future.get() threw (e.g. failed compression task)
               }
             }
             future = recordQueue.poll()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -311,7 +311,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
    *
    * @param buffer The compressed data buffer (owned by this record, closed after writing)
    * @param compressedSize The actual size of compressed data in buffer
-   * @param remainingQuota The quota to release after writing to disk
+   * @param quotaToRelease The quota to release after writing to disk
    */
   private case class CompressedRecord(
     buffer: OpenByteArrayOutputStream,
@@ -402,10 +402,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         }
       } catch {
         case ee: ExecutionException => fail(ee.getCause)
-        case _: InterruptedException =>
+        case ie: InterruptedException =>
           Thread.currentThread().interrupt()
           completionFuture.cancel(true)
-          limiter.signalFailure()
+          limiter.signalFailure(ie)
         case t: Throwable => fail(t)
       } finally {
         stepFuture.set(null)
@@ -491,7 +491,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
       completionFuture.completeExceptionally(t)
       // Signal the limiter so any producer blocked in acquireOrBlock wakes up and
       // throws, allowing the write loop to exit and cleanupBatch to release all quotas.
-      limiter.signalFailure()
+      limiter.signalFailure(t)
       // Also release quota for already-completed futures that writeRecord will never see.
       partitionRecords.values().asScala.foreach { recordQueue =>
         recordQueue.forEach { future =>
@@ -749,12 +749,8 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
 
         // Acquire limiter and process compression task immediately
         val waitOnLimiterStart = System.nanoTime()
-        try {
+        closeOnExcept(cb) { _ =>
           limiter.acquireOrBlock(recordSize)
-        } catch {
-          case e: Exception =>
-            cb.close()  // prevent ref-count leak from incRefCountAndGetSize
-            throw e
         }
         waitTimeOnLimiterNs += System.nanoTime() - waitOnLimiterStart
 
@@ -838,22 +834,25 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
           }
         }) {
           override def done(): Unit = {
-            // If call() never ran, win the CAS to close cb (prevents the ref-count leak
-            // from incRefCountAndGetSize). Quota is handled separately below.
-            if (cbOwner.compareAndSet(false, true)) {
-              cb.close()
-            }
-            // Release quota when cancelled, or when the merger has already failed (so
-            // writeRecord will never be called for this future's CompressedRecord).
-            // getAndSet(0) is idempotent: fail() may have already claimed it; returns 0.
-            if (isCancelled ||
-                batchForRecord.merger.completionFuture.isCompletedExceptionally) {
-              val toRelease = quotaToRelease.getAndSet(0)
-              if (toRelease > 0) {
-                limiter.release(toRelease)
+            try {
+              // If call() never ran, win the CAS to close cb (prevents the ref-count leak
+              // from incRefCountAndGetSize). Quota is handled separately below.
+              if (cbOwner.compareAndSet(false, true)) {
+                cb.close()
               }
+            } finally {
+              // Release quota when cancelled, or when the merger has already failed (so
+              // writeRecord will never be called for this future's CompressedRecord).
+              // getAndSet(0) is idempotent: fail() may have already claimed it; returns 0.
+              if (isCancelled ||
+                  batchForRecord.merger.completionFuture.isCompletedExceptionally) {
+                val toRelease = quotaToRelease.getAndSet(0)
+                if (toRelease > 0) {
+                  limiter.release(toRelease)
+                }
+              }
+              batchForRecord.scheduleMerger()
             }
-            batchForRecord.scheduleMerger()
           }
         }
         val future = RapidsShuffleInternalManagerBase.queueWriteTask(compressionTask)
@@ -1157,7 +1156,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
 
 class BytesInFlightLimiter(maxBytesInFlight: Long) {
   private var inFlight: Long = 0L
-  private var failed: Boolean = false
+  private var failureCause: Throwable = null
 
   def acquire(sz: Long): Boolean = {
     if (sz == 0) {
@@ -1174,27 +1173,17 @@ class BytesInFlightLimiter(maxBytesInFlight: Long) {
     }
   }
 
-  def acquireOrBlock(sz: Long): Unit = {
-    var acquired = acquire(sz)
-    if (!acquired) {
-      synchronized {
-        while (!acquired) {
-          if (failed) {
-            throw new IOException("Compression batch failed; quota acquisition aborted")
-          }
-          acquired = acquire(sz)
-          if (!acquired) {
-            // Use a timeout so the failed flag is rechecked periodically even if
-            // signalFailure()'s notifyAll() arrives before this wait() starts.
-            wait(100)
-          }
-        }
-      }
+  def acquireOrBlock(sz: Long): Unit = synchronized {
+    while (failureCause == null && !acquire(sz)) {
+      wait()
+    }
+    if (failureCause != null) {
+      throw new IOException("Compression batch failed; quota acquisition aborted", failureCause)
     }
   }
 
-  def signalFailure(): Unit = synchronized {
-    failed = true
+  def signalFailure(t: Throwable): Unit = synchronized {
+    failureCause = t
     notifyAll()
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.NvtxRegistry
 import com.nvidia.spark.rapids.RapidsConf
 import com.nvidia.spark.rapids.RapidsPluginImplicits._

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -316,7 +316,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
   private case class CompressedRecord(
     buffer: OpenByteArrayOutputStream,
     compressedSize: Long,
-    remainingQuota: Long)
+    quotaToRelease: AtomicLong)
 
   /**
    * Cooperatively writes one GPU batch without occupying a merger thread while waiting for work.
@@ -454,7 +454,10 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
         outputStream.write(record.buffer.getBuf, 0, record.compressedSize.toInt)
       }
       record.buffer.close()
-      limiter.release(record.remainingQuota)
+      val toRelease = record.quotaToRelease.getAndSet(0)
+      if (toRelease > 0) {
+        limiter.release(toRelease)
+      }
     }
 
     private def closeOutputStream(): Unit = {
@@ -760,14 +763,18 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
                 // Note: excessQuota can be 0 if compression doesn't reduce size (or expands)
                 val excessQuota = math.max(0L, recordSize - compressedSize)
                 if (excessQuota > 0) {
-                  limiter.release(excessQuota)
-                  quotaToRelease.addAndGet(-excessQuota)
+                  // addAndGet returns negative if done() already claimed quota via getAndSet(0).
+                  // In that case skip the direct release; the merger will also see a negative
+                  // getAndSet(0) and skip its release, preventing double-release on the success path.
+                  val remaining = quotaToRelease.addAndGet(-excessQuota)
+                  if (remaining >= 0) {
+                    limiter.release(excessQuota)
+                  }
                 }
 
-                // Return CompressedRecord with buffer and remaining quota for Merger
-                // Total released = excessQuota + remainingQuota should equal recordSize
-                val remainingQuota = recordSize - excessQuota
-                CompressedRecord(buffer, compressedSize, remainingQuota)
+                // Return CompressedRecord carrying quotaToRelease so writeRecord can use
+                // getAndSet(0) to release the remainder — or skip if done() claimed it.
+                CompressedRecord(buffer, compressedSize, quotaToRelease)
               }
             } catch {
               case e: InterruptedException =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1176,7 +1176,9 @@ class BytesInFlightLimiter(maxBytesInFlight: Long) {
           }
           acquired = acquire(sz)
           if (!acquired) {
-            wait()
+            // Use a timeout so the failed flag is rechecked periodically even if
+            // signalFailure()'s notifyAll() arrives before this wait() starts.
+            wait(100)
           }
         }
       }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -112,6 +112,28 @@ class InterruptingTestColumnarBatchSerializer extends TestColumnarBatchSerialize
   }
 }
 
+// Fails writeValue for the record with key 0 (partition 0); succeeds for all others.
+// Deterministically triggers a merger failure on partition 0 while leaving other
+// partitions' CompressedRecords alive in the queue.
+class FailKeyZeroTestColumnarBatchSerializer extends TestColumnarBatchSerializer {
+  override def newInstance(): SerializerInstance = new TestColumnarBatchSerializerInstance() {
+    override def serializeStream(s: OutputStream): SerializationStream =
+      new TestColumnarBatchSerializationStream(s) {
+        private var currentKey = -1
+        override def writeKey[T: ClassTag](key: T): SerializationStream = {
+          currentKey = key.asInstanceOf[Int]
+          super.writeKey(key)
+        }
+        override def writeValue[T: ClassTag](value: T): SerializationStream =
+          if (currentKey == 0) {
+            throw new IOException("injected failure for key 0 (partition 0)")
+          } else {
+            super.writeValue(value)
+          }
+      }
+  }
+}
+
 class OutOfOrderTestColumnarBatchSerializer(
     firstStarted: CountDownLatch,
     secondSerialized: CountDownLatch,
@@ -1061,6 +1083,51 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
         "expected IOException to wrap the original InterruptedException")
       assert(writer.getBytesInFlight == 0,
         s"bytes in flight leaked after InterruptedException: ${writer.getBytesInFlight}")
+    } finally {
+      writer.stop(false)
+      if (writeThread.isAlive) {
+        writeThread.join(5000)
+      }
+    }
+  }
+
+
+  test("producer unblocks when merger fails and a successful future holds quota") {
+    // Rishi's scenario: record 0 fails (merger dies), record 1 succeeds and holds quota,
+    // record 2 then blocks on acquireOrBlock because maxBytesInFlight is exhausted.
+    // Without a fix the producer hangs forever: it is blocked before reaching
+    // mergerFuture.get() and cleanupBatch, so record 1's quota is never released.
+    //   record 0 = 64 bytes (key 0, fails)    -> inFlight: 64
+    //   record 1 = 65 bytes (key 1, succeeds) -> inFlight: 64+65=129 > 100, blocks;
+    //              record 0 releases 64 on fail -> record 1 unblocks -> inFlight: 65
+    //   record 2 = 66 bytes (key 2, succeeds) -> 65+66=131 > 100, BLOCKS
+    //              merger already dead; record 1 quota never released -> DEADLOCK
+    useUncompressedShuffleOutput()
+    when(dependency.serializer).thenReturn(new FailKeyZeroTestColumnarBatchSerializer())
+    val writer = new RapidsShuffleThreadedWriter[Int, ColumnarBatch](
+      blockManager, shuffleHandle, 0L, conf,
+      new ThreadSafeShuffleWriteMetricsReporter(taskContext.taskMetrics().shuffleWriteMetrics),
+      100L, shuffleExecutorComponents, numWriterThreads)
+
+    @volatile var writeFailure: Throwable = null
+    val writeThread = new Thread(() => {
+      try {
+        writer.write(createTestRecords(Iterator(0, 1, 2)))
+      } catch {
+        case t: Throwable => writeFailure = t
+      }
+    })
+
+    try {
+      writeThread.start()
+      writeThread.join(5000)
+      assert(!writeThread.isAlive,
+        "producer deadlocked: successful future's quota was never released after merger died")
+      assert(writeFailure != null, "expected write() to throw after merger failure")
+      assert(writeFailure.isInstanceOf[IOException],
+        s"expected IOException but got ${writeFailure.getClass.getName}")
+      assert(writer.getBytesInFlight == 0,
+        s"quota leaked after merger failure: ${writer.getBytesInFlight} bytes in flight")
     } finally {
       writer.stop(false)
       if (writeThread.isAlive) {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -1093,7 +1093,7 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
 
 
   test("producer unblocks when merger fails and a successful future holds quota") {
-    // Rishi's scenario: record 0 fails (merger dies), record 1 succeeds and holds quota,
+    // Scenario: record 0 fails (merger dies), record 1 succeeds and holds quota,
     // record 2 then blocks on acquireOrBlock because maxBytesInFlight is exhausted.
     // Without a fix the producer hangs forever: it is blocked before reaching
     // mergerFuture.get() and cleanupBatch, so record 1's quota is never released.

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -1026,7 +1026,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     }
   }
 
-  
   test("InterruptedException in compression releases bytes-in-flight quota") {
     // Same deadlock scenario as the IOException test: record 0 acquires 64 bytes,
     // record 1 (65 bytes) blocks because 64+65=129 > maxBytesInFlight=100.

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -102,6 +102,16 @@ class FailingTestColumnarBatchSerializer extends TestColumnarBatchSerializer {
   }
 }
 
+class InterruptingTestColumnarBatchSerializer extends TestColumnarBatchSerializer {
+  override def newInstance(): SerializerInstance = new TestColumnarBatchSerializerInstance() {
+    override def serializeStream(s: OutputStream): SerializationStream =
+      new TestColumnarBatchSerializationStream(s) {
+        override def writeValue[T: ClassTag](value: T): SerializationStream =
+          throw new InterruptedException("injected interruption during serialization")
+      }
+  }
+}
+
 class OutOfOrderTestColumnarBatchSerializer(
     firstStarted: CountDownLatch,
     secondSerialized: CountDownLatch,
@@ -966,6 +976,93 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     } finally {
       releaseBlockers.countDown()
       writerBlockers.foreach(_.get(5, TimeUnit.SECONDS))
+      writer.stop(false)
+      if (writeThread.isAlive) {
+        writeThread.join(5000)
+      }
+    }
+  }
+
+  // Regression test for https://github.com/NVIDIA/cudf-spark/issues/15611
+  test("compression failure must release bytes-in-flight quota or producer deadlocks") {
+    // Scenario: producer acquires quota for record 0 (64 bytes), queues its compression task.
+    // maxBytesInFlight=100 means record 1 (65 bytes) cannot be acquired: 64+65=129>100, so
+    // the producer blocks on acquireOrBlock. The compression task for record 0 then fails.
+    // Bug: the failure path did not release the 64-byte quota, so the producer blocked forever.
+    // Fix: on compression failure the stranded quota must be released to wake the producer.
+    when(dependency.serializer).thenReturn(new FailingTestColumnarBatchSerializer())
+    val writer = new RapidsShuffleThreadedWriter[Int, ColumnarBatch](
+      blockManager, shuffleHandle, 0L, conf,
+      new ThreadSafeShuffleWriteMetricsReporter(taskContext.taskMetrics().shuffleWriteMetrics),
+      100L, // record 0 = 64 bytes, record 1 = 65 bytes; 64+65=129 > 100 -> record 1 blocks
+      shuffleExecutorComponents, numWriterThreads)
+
+    @volatile var writeFailure: Throwable = null
+    val writeThread = new Thread(() => {
+      try {
+        writer.write(createTestRecords(Iterator(0, 1)))
+      } catch {
+        case t: Throwable => writeFailure = t
+      }
+    })
+
+    try {
+      writeThread.start()
+      writeThread.join(5000)
+      assert(!writeThread.isAlive,
+        "producer deadlocked: compression failure did not release bytes-in-flight quota")
+      assert(writeFailure != null,
+        "expected write() to throw IOException after compression failure")
+      assert(writeFailure.isInstanceOf[IOException],
+        s"expected IOException but got ${writeFailure.getClass.getName}: " +
+          writeFailure.getMessage)
+      assert(writer.getBytesInFlight == 0,
+        s"bytes in flight leaked after failure: ${writer.getBytesInFlight}")
+    } finally {
+      writer.stop(false)
+      if (writeThread.isAlive) {
+        writeThread.join(5000)
+      }
+    }
+  }
+
+  
+  test("InterruptedException in compression releases bytes-in-flight quota") {
+    // Same deadlock scenario as the IOException test: record 0 acquires 64 bytes,
+    // record 1 (65 bytes) blocks because 64+65=129 > maxBytesInFlight=100.
+    // The compression task throws InterruptedException. The quota for record 0
+    // must be released to unblock the producer, and the IOException must wrap
+    // the original InterruptedException.
+    when(dependency.serializer).thenReturn(new InterruptingTestColumnarBatchSerializer())
+    val writer = new RapidsShuffleThreadedWriter[Int, ColumnarBatch](
+      blockManager, shuffleHandle, 0L, conf,
+      new ThreadSafeShuffleWriteMetricsReporter(taskContext.taskMetrics().shuffleWriteMetrics),
+      100L, // record 0 = 64 bytes in flight; record 1 (65 bytes) blocks until released
+      shuffleExecutorComponents, numWriterThreads)
+
+    @volatile var writeFailure: Throwable = null
+    val writeThread = new Thread(() => {
+      try {
+        writer.write(createTestRecords(Iterator(0, 1)))
+      } catch {
+        case t: Throwable => writeFailure = t
+      }
+    })
+
+    try {
+      writeThread.start()
+      writeThread.join(5000)
+      assert(!writeThread.isAlive,
+        "producer deadlocked: InterruptedException did not release bytes-in-flight quota")
+      assert(writeFailure != null,
+        "expected write() to throw after injected InterruptedException")
+      assert(writeFailure.isInstanceOf[IOException],
+        s"expected IOException but got ${writeFailure.getClass.getName}")
+      assert(writeFailure.getCause.isInstanceOf[InterruptedException],
+        "expected IOException to wrap the original InterruptedException")
+      assert(writer.getBytesInFlight == 0,
+        s"bytes in flight leaked after InterruptedException: ${writer.getBytesInFlight}")
+    } finally {
       writer.stop(false)
       if (writeThread.isAlive) {
         writeThread.join(5000)


### PR DESCRIPTION
Fixes #15611

### Description

When a compression task failed or was cancelled, the maxBytesInFlight quota acquired by the writer before queuing the compression task was never released, causing two distinct deadlock/leak scenarios:

1. Task runs and throws: the catch block did not release the quota, so if a second record's acquisition then exceeded maxBytesInFlight the producer blocked on acquireOrBlock() indefinitely.

2. Task cancelled before starting: the cleanup path calls future.cancel(true) on queued tasks when an earlier failure is detected. The Callable never runs so neither the catch block nor the merger ever releases the quota.

Fix for (1): track quotaReleased inside the Callable (excessQuota may be released mid-task on successful compression). The catch block releases only the remaining unreleased portion so the blocked producer is woken without over-releasing inFlight.

Fix for (2): add an AtomicBoolean taskStarted per compression task. The FutureTask.done() override releases the full recordSize quota when isCancelled && !taskStarted, covering tasks that were queued but never executed.

Adds regression test: two records with maxBytesInFlight=100 (record 0 = 64 bytes, record 1 = 65 bytes; 64+65 > 100) and a failing serializer. Without the fix the write thread deadlocks; with the fix it throws IOException and getBytesInFlight() == 0. We also add an interrupting finalizer, that throws InterruptedException so we an test that path as well.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
