### PR TITLE
Guard collated PivotFirst against GPU execution [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -701,7 +701,7 @@ def test_hash_grpby_pivot_collation_fallback(collation):
         spark.createDataFrame(
             [(1, 'SALES', 100), (1, 'sales', 50), (1, None, 20)],
             ['emp_id', 'dept', 'amount']).createOrReplaceTempView('collation_pivot_input')
-        return spark.sql(
+        df = spark.sql(
             f"""
             SELECT * FROM (
               SELECT emp_id, COLLATE(dept, '{collation}') AS dept, amount
@@ -709,6 +709,11 @@ def test_hash_grpby_pivot_collation_fallback(collation):
             )
             PIVOT (SUM(amount) FOR dept IN ('sales' AS sales))
             """)
+        explain = spark.sparkContext._jvm.com.nvidia.spark.rapids.ExplainPlan \
+            .explainPotentialGpuPlan(df._jdf, 'ALL')
+        assert ('PivotFirst does not support non-UTF8_BINARY string collations on the GPU'
+                in explain)
+        return df
 
     assert_gpu_fallback_collect(
         do_pivot,

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -689,6 +689,33 @@ def test_hash_grpby_pivot(data_gen, conf):
             .agg(f.sum('c')),
         conf = copy_and_update(conf, {'spark.sql.ansi.enabled': False}))
 
+
+@pytest.mark.skipif(not is_spark_420_or_later(),
+                    reason='collation-aware PivotFirst is fixed in Spark 4.2')
+@pytest.mark.parametrize('collation', ['UNICODE', 'UTF8_LCASE', 'UNICODE_CI'])
+@allow_non_gpu('ProjectExec', 'Collate', 'ResolvedCollation', 'HashAggregateExec',
+               'SortAggregateExec', 'SortExec', 'PivotFirst', 'AggregateExpression',
+               'Alias', 'GetArrayItem', 'Literal', 'ShuffleExchangeExec', 'HashPartitioning')
+def test_hash_grpby_pivot_collation_fallback(collation):
+    def do_pivot(spark):
+        spark.createDataFrame(
+            [(1, 'SALES', 100), (1, 'sales', 50), (1, None, 20)],
+            ['emp_id', 'dept', 'amount']).createOrReplaceTempView('collation_pivot_input')
+        return spark.sql(
+            f"""
+            SELECT * FROM (
+              SELECT emp_id, COLLATE(dept, '{collation}') AS dept, amount
+              FROM collation_pivot_input
+            )
+            PIVOT (SUM(amount) FOR dept IN ('sales' AS sales))
+            """)
+
+    assert_gpu_fallback_collect(
+        do_pivot,
+        'PivotFirst',
+        conf={'spark.sql.adaptive.enabled': False})
+
+
 @approximate_float
 @ignore_order(local=True)
 @incompat

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2228,6 +2228,14 @@ object GpuOverrides extends Logging {
           TypeSig.all))),
       (pivot, conf, p, r) => new ImperativeAggExprMeta[PivotFirst](pivot, conf, p, r) {
         override def tagAggForGpu(): Unit = {
+          pivot.pivotColumn.dataType match {
+            // `StringType` is the UTF8_BINARY singleton, while `st` may be another
+            // StringType instance whose collation differs from UTF8_BINARY in Spark 4.x.
+            case st: StringType if st != StringType =>
+              willNotWorkOnGpu(
+                "PivotFirst does not support non-UTF8_BINARY string collations on the GPU")
+            case _ =>
+          }
           // If pivotColumnValues doesn't have distinct values, fall back to CPU
           if (pivot.pivotColumnValues.distinct.lengthCompare(pivot.pivotColumnValues.length) != 0) {
             willNotWorkOnGpu("PivotFirst does not work on the GPU when there are duplicate" +


### PR DESCRIPTION
Fixes #15608.

### Description
- Add an explicit defense-in-depth veto for non-UTF8_BINARY `PivotFirst` columns so future type-signature changes cannot accidentally enable byte-level GPU equality; the existing string `ParamCheck` already causes fallback today.
- Add Spark 4.2 integration coverage for `UNICODE`, `UTF8_LCASE`, and `UNICODE_CI`, including null input, and assert the exact new tagging reason so the test fails when the explicit veto is absent.
- Validation: `mvn -s ~/.m2/settings_art.xml -Dbuildver=350 -Dcuda.version=cuda13 -DskipTests validate` and `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests validate` passed.
- Validation: packaged the Spark 4.2 plugin and integration tests, then ran `SPARK_HOME=$HOME/work/tools/spark-4.2.0-bin-hadoop3 TEST=test_hash_grpby_pivot_collation_fallback ./run_pyspark_from_build.sh`; all three cases passed after adding the explicit-reason assertion.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required