### PR TITLE
Remove unused data_type locals in test_and and test_or

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -405,7 +405,6 @@ def test_columnar_pow(data_descr):
 
 @pytest.mark.parametrize('data_gen', boolean_gens, ids=idfn)
 def test_and(data_gen):
-    data_type = data_gen.data_type
     assert_gpu_ast(is_supported=True,
         func=lambda spark: binary_op_df(spark, data_gen).select(
             f.col('a') & f.lit(True),
@@ -414,7 +413,6 @@ def test_and(data_gen):
 
 @pytest.mark.parametrize('data_gen', boolean_gens, ids=idfn)
 def test_or(data_gen):
-    data_type = data_gen.data_type
     assert_gpu_ast(is_supported=True,
                    func=lambda spark: binary_op_df(spark, data_gen).select(
                        f.col('a') | f.lit(True),


### PR DESCRIPTION
No issue filed — this is a code-quality fix for unused local variables.

### Description

Removes the unused `data_type` local variable from both the `test_and` and `test_or` integration tests in `integration_tests/src/main/python/ast_test.py`. The variable is assigned but never referenced in either test body, so its removal has no effect on test behavior or the GPU AST assertions.

This combines the changes originally proposed separately in #15639 (`test_and`) and #15640 (`test_or`).

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required