### PR TITLE
fix: remove unused data_type local in test_or

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -427,7 +427,6 @@ def test_and(data_gen):
 
 @pytest.mark.parametrize('data_gen', boolean_gens, ids=idfn)
 def test_or(data_gen):
-    data_type = data_gen.data_type
     assert_gpu_ast(is_supported=True,
                    func=lambda spark: binary_op_df(spark, data_gen).select(
                        f.col('a') | f.lit(True),


### PR DESCRIPTION
Fixes #xxxx.

### Description

Removes the unused `data_type` local variable from the `test_or` integration test in `integration_tests/src/main/python/ast_test.py`. The variable is assigned but never referenced in the test body, so its removal has no effect on the test behavior or the GPU AST assertion.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests (`test_or` in `ast_test.py`)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
