### PR TITLE
Stale R470 driver footnote contradicts R525+ requirement [skip ci]

### DIFF
--- a/docs/archive.md
+++ b/docs/archive.md
@@ -51,7 +51,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.3 LTS
 		Spark runtime 3.0
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For EMR support, please refer to the
@@ -160,7 +160,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.3 LTS
 		Spark runtime 3.0
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For EMR support, please refer to the
@@ -264,7 +264,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For EMR support, please refer to the
@@ -378,7 +378,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For EMR support, please refer to the
@@ -487,7 +487,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For EMR support, please refer to the
@@ -590,7 +590,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the
@@ -697,7 +697,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the
@@ -788,7 +788,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the
@@ -874,7 +874,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the
@@ -963,7 +963,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the
@@ -1054,7 +1054,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.1
 		Spark runtime 2.2
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the

--- a/docs/download.md
+++ b/docs/download.md
@@ -68,7 +68,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 		Spark runtime 2.3 LTS
 		Spark runtime 3.0
 
-*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R525. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For EMR support, please refer to the


### PR DESCRIPTION
Fixes #15890.

### Description

The RAPIDS Accelerator for Apache Spark requires NVIDIA driver R525 or newer. Several archived release notes in `docs/archive.md` and the current download page in `docs/download.md` still carry the old footnote "Some hardware may have a minimum driver version greater than R470". This PR updates those footnotes to R525 for every release whose stated requirement is already R525+. Historical sections that actually specify R470+ retain the original R470 footnote.

Changes:
- `docs/download.md`: update the compatibility footnote to R525.
- `docs/archive.md`: update the same footnote to R525 in all R525+ release sections, while leaving R470+ historical sections unchanged.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required (documentation-only change)

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
