### PR TITLE
[DOC] Fix RAPIDS installation link to pass premerge check [skip ci]

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -509,7 +509,7 @@ The tests can be enabled by just appending the option `--cudf_udf` to the comman
 cudf_udf tests needs a couple of different settings, they may need to run separately.
 
 To enable cudf_udf tests, need following pre requirements:
-   * Install cuDF Python library on all the nodes running executors. The instruction could be found at [here](https://docs.rapids.ai/install/). Please follow the steps to choose the version based on your environment and install the cuDF library via Conda or use other ways like building from source.
+   * Install the cuDF Python library on all executor nodes. Use the [RAPIDS install selector](https://docs.rapids.ai/install#selector) to choose the version for your environment and install cuDF with Conda, or build it from source.
    * Disable the GPU exclusive mode on all the nodes running executors. The sample command is `sudo nvidia-smi -c DEFAULT`
 
 To run cudf_udf tests, need following configuration changes:

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -509,7 +509,7 @@ The tests can be enabled by just appending the option `--cudf_udf` to the comman
 cudf_udf tests needs a couple of different settings, they may need to run separately.
 
 To enable cudf_udf tests, need following pre requirements:
-   * Install cuDF Python library on all the nodes running executors. The instruction could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cuDF library via Conda or use other ways like building from source.
+   * Install cuDF Python library on all the nodes running executors. The instruction could be found at [here](https://docs.rapids.ai/install/). Please follow the steps to choose the version based on your environment and install the cuDF library via Conda or use other ways like building from source.
    * Disable the GPU exclusive mode on all the nodes running executors. The sample command is `sudo nvidia-smi -c DEFAULT`
 
 To run cudf_udf tests, need following configuration changes:


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (documentation-only change; no sql-plugin code or test changes)

## Summary

- Replace the broken `https://rapids.ai/start.html` link in the cuDF UDF integration-test prerequisites.
- Link directly to the current RAPIDS installation guide at `https://docs.rapids.ai/install/`.

Closes #15647

## Root cause

The legacy RAPIDS URL stopped redirecting after the RAPIDS website migrated to the NVIDIA domain on August 11, 2026. It now returns HTTP 404 even though the website source repository still declares a redirect to the current installation guide.

## Validation

- `npx --yes markdown-link-check@3.8.7 --config .github/workflows/markdown-links-check/markdown-links-check-config.json --verbose integration_tests/README.md`
  - 30 links checked successfully.
  - `https://docs.rapids.ai/install/` returned HTTP 200.
- `git diff --check`

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
