### PR TITLE
Fix Parquet cache access across classloaders

### DIFF
--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -46,6 +46,7 @@ org/apache/iceberg/spark/source/GpuBaseReader.class
 org/apache/iceberg/spark/source/GpuSparkPlanningUtil.class
 org/apache/iceberg/spark/source/GpuSparkScanAccess.class
 org/apache/iceberg/spark/source/GpuSparkWriteAccess.class
+org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge.class
 org/apache/spark/sql/rapids/AdaptiveSparkPlanHelperShim*
 org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback*
 rapids/*.py

--- a/dist/unshimmed-from-each-spark3xx.txt
+++ b/dist/unshimmed-from-each-spark3xx.txt
@@ -9,4 +9,8 @@ com/nvidia/spark/rapids/delta/DeltaProbe.class
 com/nvidia/spark/rapids/delta/DeltaProvider.class
 com/nvidia/spark/rapids/delta/DeltaProvider$.class
 com/nvidia/spark/rapids/PlanShims*
+org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge330*
+org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge350*
+org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge400*
+org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge411*
 spark-*-info.properties

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVectorBridge.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector
+
+/**
+ * Root-loaded bridge for accessing Spark's package-private ParquetColumnVector.
+ */
+abstract class ParquetColumnVectorBridge {
+  def newParquetColumnVector(
+      column: ParquetColumn,
+      vector: WritableColumnVector,
+      capacity: Int,
+      memoryMode: MemoryMode,
+      missingColumns: java.util.Set[ParquetColumn],
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef
+
+  private def asParquetColumnVector(vector: AnyRef): ParquetColumnVector =
+    vector.asInstanceOf[ParquetColumnVector]
+
+  def getColumn(vector: AnyRef): ParquetColumn = asParquetColumnVector(vector).getColumn
+
+  def getChildren(vector: AnyRef): java.util.List[AnyRef] =
+    asParquetColumnVector(vector).getChildren.asInstanceOf[java.util.List[AnyRef]]
+
+  def getLeaves(vector: AnyRef): java.util.List[AnyRef] =
+    asParquetColumnVector(vector).getLeaves.asInstanceOf[java.util.List[AnyRef]]
+
+  def reset(vector: AnyRef): Unit = asParquetColumnVector(vector).reset()
+
+  def getColumnReader(vector: AnyRef): VectorizedColumnReader =
+    asParquetColumnVector(vector).getColumnReader
+
+  def setColumnReader(vector: AnyRef, reader: VectorizedColumnReader): Unit =
+    asParquetColumnVector(vector).setColumnReader(reader)
+
+  def getValueVector(vector: AnyRef): WritableColumnVector =
+    asParquetColumnVector(vector).getValueVector
+
+  def getRepetitionLevelVector(vector: AnyRef): WritableColumnVector =
+    asParquetColumnVector(vector).getRepetitionLevelVector
+
+  def getDefinitionLevelVector(vector: AnyRef): WritableColumnVector =
+    asParquetColumnVector(vector).getDefinitionLevelVector
+
+  def assemble(vector: AnyRef): Unit = asParquetColumnVector(vector).assemble()
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
@@ -83,7 +83,7 @@ class ShimCurrentBatchIterator(
   }
 
   val sparkSchema = parquetColumn.sparkType.asInstanceOf[StructType]
-  val parquetColumnVectors = (for (i <- 0 until sparkSchema.fields.length) yield {
+  val parquetColumnVectors: Array[AnyRef] = (for (i <- 0 until sparkSchema.fields.length) yield {
     ParquetCVShims.newParquetCV(sparkSchema, i, parquetColumn.children.apply(i),
       vectors(i), capacity, MemoryMode.OFF_HEAP, missingColumns, true)
   }).toArray
@@ -130,10 +130,10 @@ class ShimCurrentBatchIterator(
   }
 
   @throws[IOException]
-  private def initColumnReader(pages: PageReadStore, cv: ParquetColumnVector): Unit = {
-    if (!missingColumns.contains(cv.getColumn)) {
-      if (cv.getColumn.isPrimitive) {
-        val column = cv.getColumn
+  private def initColumnReader(pages: PageReadStore, cv: AnyRef): Unit = {
+    val column = ParquetCVShims.bridge.getColumn(cv)
+    if (!missingColumns.contains(column)) {
+      if (column.isPrimitive) {
         val reader = RapidsVectorizedColumnReader(
           column.descriptor.get,
           column.required,
@@ -144,10 +144,10 @@ class ShimCurrentBatchIterator(
           LegacyBehaviorPolicyShim.EXCEPTION_STR,
           null,
           writerVersion)
-        cv.setColumnReader(reader)
+        ParquetCVShims.bridge.setColumnReader(cv, reader)
       }
       else { // Not in missing columns and is a complex type: this must be a struct
-        for (childCv <- cv.getChildren.asScala) {
+        for (childCv <- ParquetCVShims.bridge.getChildren(cv).asScala) {
           initColumnReader(pages, childCv)
         }
       }
@@ -173,7 +173,7 @@ class ShimCurrentBatchIterator(
    */
   def nextBatch: Boolean = {
     for (vector <- parquetColumnVectors) {
-      vector.reset()
+      ParquetCVShims.bridge.reset(vector)
     }
     columnarBatch.setNumRows(0)
     if (rowsReturned >= totalRowCount) return false
@@ -181,18 +181,18 @@ class ShimCurrentBatchIterator(
 
     val num = Math.min(capacity.toLong, totalCountLoadedSoFar - rowsReturned).toInt
     for (cv <- parquetColumnVectors){
-      for (leafCv <- cv.getLeaves.asScala) {
-        val columnReader = leafCv.getColumnReader
+      for (leafCv <- ParquetCVShims.bridge.getLeaves(cv).asScala) {
+        val columnReader = ParquetCVShims.bridge.getColumnReader(leafCv)
         if (columnReader != null) {
           ParquetVectorizedReader.readBatchMethod.invoke(
             columnReader,
             num.asInstanceOf[AnyRef],
-            leafCv.getValueVector.asInstanceOf[AnyRef],
-            leafCv.getRepetitionLevelVector.asInstanceOf[AnyRef],
-            leafCv.getDefinitionLevelVector.asInstanceOf[AnyRef])
+            ParquetCVShims.bridge.getValueVector(leafCv).asInstanceOf[AnyRef],
+            ParquetCVShims.bridge.getRepetitionLevelVector(leafCv).asInstanceOf[AnyRef],
+            ParquetCVShims.bridge.getDefinitionLevelVector(leafCv).asInstanceOf[AnyRef])
         }
       }
-      cv.assemble()
+      ParquetCVShims.bridge.assemble(cv)
     }
     rowsReturned += num
     columnarBatch.setNumRows(num)

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge330.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge330.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,21 +25,16 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
-import org.apache.spark.sql.types.StructType
 
-object ParquetCVShims {
-  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge330
-
-  def newParquetCV(
-      sparkSchema: StructType,
-      idx: Int,
+object ParquetColumnVectorBridge330 extends ParquetColumnVectorBridge {
+  override def newParquetColumnVector(
       column: ParquetColumn,
       vector: WritableColumnVector,
       capacity: Int,
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): AnyRef = {
-    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
-      isTopLevel, null)
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef = {
+    new ParquetColumnVector(column, vector, capacity, memoryMode, missingColumns)
   }
 }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 import org.apache.spark.sql.types.StructType
 
 object ParquetCVShims {
+  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge330DB
 
   def newParquetCV(
       sparkSchema: StructType,
@@ -42,11 +43,11 @@ object ParquetCVShims {
       capacity: Int,
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): ParquetColumnVector = {
+      isTopLevel: Boolean): AnyRef = {
     val defaultValue = if (sparkSchema != null) {
       getExistenceDefaultValues(sparkSchema)
     } else null
-    ShimParquetColumnVector(column, vector, capacity, memoryMode, missingColumns, isTopLevel, 
-      defaultValue)
+    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
+      isTopLevel, defaultValue)
   }
 }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge330DB.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge330DB.scala
@@ -28,15 +28,15 @@ package org.apache.spark.sql.execution.datasources.parquet
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 
-object ShimParquetColumnVector {
-  def apply(
-    column: ParquetColumn,
-    vector: WritableColumnVector,
-    capacity: Int,
-    memoryMode: MemoryMode,
-    missingColumns: java.util.Set[ParquetColumn],
-    isTopLevel: Boolean,
-    defaultValue: Any): ParquetColumnVector = {
+object ParquetColumnVectorBridge330DB extends ParquetColumnVectorBridge {
+  override def newParquetColumnVector(
+      column: ParquetColumn,
+      vector: WritableColumnVector,
+      capacity: Int,
+      memoryMode: MemoryMode,
+      missingColumns: java.util.Set[ParquetColumn],
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef = {
     new ParquetColumnVector(column, vector, capacity, memoryMode, missingColumns, isTopLevel,
       defaultValue)
   }

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 import org.apache.spark.sql.types.StructType
 object ParquetCVShims {
+  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge350
 
   def newParquetCV(
       sparkSchema: StructType,
@@ -48,11 +49,11 @@ object ParquetCVShims {
       capacity: Int,
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): ParquetColumnVector = {
+      isTopLevel: Boolean): AnyRef = {
     val defaultValue = if (sparkSchema != null) {
       ResolveDefaultColumns.getExistenceDefaultValues(sparkSchema)(idx)
     } else null
-    new ParquetColumnVector(column, vector, capacity, memoryMode, missingColumns, isTopLevel,
-      defaultValue)
+    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
+      isTopLevel, defaultValue)
   }
 }

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge350.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge350.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,31 +15,37 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "330"}
-{"spark": "331"}
-{"spark": "332"}
-{"spark": "333"}
-{"spark": "334"}
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
-import org.apache.spark.sql.types.StructType
 
-object ParquetCVShims {
-  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge330
-
-  def newParquetCV(
-      sparkSchema: StructType,
-      idx: Int,
+object ParquetColumnVectorBridge350 extends ParquetColumnVectorBridge {
+  override def newParquetColumnVector(
       column: ParquetColumn,
       vector: WritableColumnVector,
       capacity: Int,
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): AnyRef = {
-    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
-      isTopLevel, null)
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef = {
+    new ParquetColumnVector(column, vector, capacity, memoryMode, missingColumns, isTopLevel,
+      defaultValue)
   }
 }

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,26 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.getExistenceDefaultValues
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
+import org.apache.spark.sql.types.StructType
 
-object ShimParquetColumnVector {
-  def apply(
-    column: ParquetColumn,
-    vector: WritableColumnVector,
-    capacity: Int,
-    memoryMode: MemoryMode,
-    missingColumns: java.util.Set[ParquetColumn],
-    isTopLevel: Boolean,
-    defaultValue: Any): ParquetColumnVector = {
-    new ParquetColumnVector(column, vector, capacity, memoryMode, missingColumns, isTopLevel,
-      defaultValue, "")
+object ParquetCVShims {
+  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge350DB143
+
+  def newParquetCV(
+      sparkSchema: StructType,
+      idx: Int,
+      column: ParquetColumn,
+      vector: WritableColumnVector,
+      capacity: Int,
+      memoryMode: MemoryMode,
+      missingColumns: java.util.Set[ParquetColumn],
+      isTopLevel: Boolean): AnyRef = {
+    val defaultValue = if (sparkSchema != null) {
+      getExistenceDefaultValues(sparkSchema)
+    } else null
+    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
+      isTopLevel, defaultValue)
   }
 }

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge350DB143.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge350DB143.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,23 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "400db173"}
+{"spark": "350db143"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 
-object ShimParquetColumnVector {
-  def apply(
-    column: ParquetColumn,
-    vector: WritableColumnVector,
-    capacity: Int,
-    memoryMode: MemoryMode,
-    missingColumns: java.util.Set[ParquetColumn],
-    isTopLevel: Boolean,
-    defaultValue: Any): ParquetColumnVector = {
-    new ParquetColumnVector(column, vector, capacity, missingColumns, isTopLevel,
+object ParquetColumnVectorBridge350DB143 extends ParquetColumnVectorBridge {
+  override def newParquetColumnVector(
+      column: ParquetColumn,
+      vector: WritableColumnVector,
+      capacity: Int,
+      memoryMode: MemoryMode,
+      missingColumns: java.util.Set[ParquetColumn],
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef = {
+    new ParquetColumnVector(column, vector, capacity, memoryMode, missingColumns, isTopLevel,
       defaultValue, "")
   }
 }

--- a/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
+++ b/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,17 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "330"}
-{"spark": "331"}
-{"spark": "332"}
-{"spark": "333"}
-{"spark": "334"}
+{"spark": "400db173"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.getExistenceDefaultValues
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 import org.apache.spark.sql.types.StructType
 
 object ParquetCVShims {
-  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge330
+  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge400DB173
 
   def newParquetCV(
       sparkSchema: StructType,
@@ -39,7 +36,10 @@ object ParquetCVShims {
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
       isTopLevel: Boolean): AnyRef = {
+    val defaultValue = if (sparkSchema != null) {
+      getExistenceDefaultValues(sparkSchema)
+    } else null
     bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
-      isTopLevel, null)
+      isTopLevel, defaultValue)
   }
 }

--- a/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge400DB173.scala
+++ b/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge400DB173.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,31 +15,23 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "330"}
-{"spark": "331"}
-{"spark": "332"}
-{"spark": "333"}
-{"spark": "334"}
+{"spark": "400db173"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
-import org.apache.spark.sql.types.StructType
 
-object ParquetCVShims {
-  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge330
-
-  def newParquetCV(
-      sparkSchema: StructType,
-      idx: Int,
+object ParquetColumnVectorBridge400DB173 extends ParquetColumnVectorBridge {
+  override def newParquetColumnVector(
       column: ParquetColumn,
       vector: WritableColumnVector,
       capacity: Int,
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): AnyRef = {
-    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
-      isTopLevel, null)
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef = {
+    new ParquetColumnVector(column, vector, capacity, missingColumns, isTopLevel,
+      defaultValue, "")
   }
 }

--- a/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
+++ b/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 import org.apache.spark.sql.types.StructType
 
 object ParquetCVShims {
+  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge411
 
   def newParquetCV(
       sparkSchema: StructType,
@@ -37,11 +38,11 @@ object ParquetCVShims {
       capacity: Int,
       memoryMode: MemoryMode,  // Ignored in Spark 4.1.0+
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): ParquetColumnVector = {
+      isTopLevel: Boolean): AnyRef = {
     val defaultValue = if (sparkSchema != null) {
       ResolveDefaultColumns.getExistenceDefaultValues(sparkSchema)(idx)
     } else null
-    // Spark 4.1.0 removed memoryMode parameter
-    new ParquetColumnVector(column, vector, capacity, missingColumns, isTopLevel, defaultValue)
+    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
+      isTopLevel, defaultValue)
   }
 }

--- a/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge411.scala
+++ b/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetColumnVectorBridge411.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,31 +15,25 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "330"}
-{"spark": "331"}
-{"spark": "332"}
-{"spark": "333"}
-{"spark": "334"}
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+{"spark": "420"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
-import org.apache.spark.sql.types.StructType
 
-object ParquetCVShims {
-  val bridge: ParquetColumnVectorBridge = ParquetColumnVectorBridge330
-
-  def newParquetCV(
-      sparkSchema: StructType,
-      idx: Int,
+object ParquetColumnVectorBridge411 extends ParquetColumnVectorBridge {
+  override def newParquetColumnVector(
       column: ParquetColumn,
       vector: WritableColumnVector,
       capacity: Int,
       memoryMode: MemoryMode,
       missingColumns: java.util.Set[ParquetColumn],
-      isTopLevel: Boolean): AnyRef = {
-    bridge.newParquetColumnVector(column, vector, capacity, memoryMode, missingColumns,
-      isTopLevel, null)
+      isTopLevel: Boolean,
+      defaultValue: Any): AnyRef = {
+    new ParquetColumnVector(column, vector, capacity, missingColumns, isTopLevel, defaultValue)
   }
 }


### PR DESCRIPTION
Addresses package-private access failures in Parquet cached batch reads.

### Description

When the RAPIDS distribution jar is installed on the system classpath, Spark's
`ParquetColumnVector` can be defined by the application classloader while
`ShimCurrentBatchIterator` is defined by the RAPIDS parallel-world classloader. JVM package access
includes the defining classloader, so direct references to Spark's package-private
`ParquetColumnVector` fail with `IllegalAccessError` even though both classes use the same package
name.

This change moves all `ParquetColumnVector` construction and access behind a root-layout bridge.
The bridge is loaded alongside Spark by the application classloader, while the parallel-world
code exchanges opaque `AnyRef` values across the classloader boundary. Shim-specific bridge
implementations preserve the constructor differences across supported Spark versions.

Validation:

- Packaged the SQL plugin for Spark 3.3 / Scala 2.12 with JDK 17.
- Packaged the SQL plugin for Spark 4.0 / Scala 2.13 with JDK 17.
- Reproduced the failure on vanilla Spark 4.0.0 with the distribution jar on driver and executor
  extra classpaths. The unpatched jar failed during a nested `CACHE TABLE` operation with
  `ParquetColumnVector` loaded by the application classloader and `ShimCurrentBatchIterator`
  loaded by `MutableURLClassLoader`.
- Repeated the same vanilla Spark test with the patched jar. Both cached table and cached view
  completed and returned 2,000 rows.
- Repeated the same A/B cache test in a multi-node GPU cluster using system-classpath jar
  installation. The original jar reproduced the error and the patched jar completed with 2,000
  rows from both caches.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
