### PR TITLE
Fix Iceberg support for Spark 4.1.2 and 4.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,14 +786,15 @@
                 <spark.test.version>${spark412.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-41x</rapids.delta.artifactId1>
-                <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
-                <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
+                <iceberg.artifact.suffix>${spark41x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
+                <iceberg.runtime.version>${iceberg.111x.version}</iceberg.runtime.version>
+                <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId>
                 <slf4j.version>2.0.7</slf4j.version>
                 <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing,-options|-Werror</scala.javac.args>
             </properties>
             <modules>
                 <module>delta-lake/delta-41x</module>
-                <module>iceberg/iceberg-stub</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -824,14 +825,15 @@
                 <spark.test.version>${spark413.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-41x</rapids.delta.artifactId1>
-                <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
-                <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
+                <iceberg.artifact.suffix>${spark41x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
+                <iceberg.runtime.version>${iceberg.111x.version}</iceberg.runtime.version>
+                <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId>
                 <slf4j.version>2.0.7</slf4j.version>
                 <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing,-options|-Werror</scala.javac.args>
             </properties>
             <modules>
                 <module>delta-lake/delta-41x</module>
-                <module>iceberg/iceberg-stub</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
             <build>
                 <pluginManagement>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -786,14 +786,15 @@
                 <spark.test.version>${spark412.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-41x</rapids.delta.artifactId1>
-                <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
-                <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
+                <iceberg.artifact.suffix>${spark41x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
+                <iceberg.runtime.version>${iceberg.111x.version}</iceberg.runtime.version>
+                <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId>
                 <slf4j.version>2.0.7</slf4j.version>
                 <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing,-options|-Werror</scala.javac.args>
             </properties>
             <modules>
                 <module>delta-lake/delta-41x</module>
-                <module>iceberg/iceberg-stub</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -824,14 +825,15 @@
                 <spark.test.version>${spark413.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-41x</rapids.delta.artifactId1>
-                <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
-                <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
+                <iceberg.artifact.suffix>${spark41x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
+                <iceberg.runtime.version>${iceberg.111x.version}</iceberg.runtime.version>
+                <rapids.iceberg.artifactId>rapids-4-spark-iceberg-1-11-x</rapids.iceberg.artifactId>
                 <slf4j.version>2.0.7</slf4j.version>
                 <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing,-options|-Werror</scala.javac.args>
             </properties>
             <modules>
                 <module>delta-lake/delta-41x</module>
-                <module>iceberg/iceberg-stub</module>
+                <module>iceberg/iceberg-1-11-x</module>
             </modules>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
Corrects Spark 4.1.2 and 4.1.3 Iceberg packaging in the 26.08 release branch.

### Description

Spark 4.1.2 and 4.1.3 builds selected the Iceberg stub module and the Spark 4.0 / Iceberg 1.10 runtime properties. As a result, the distribution did not contain the Iceberg GPU integration rules and Iceberg scans and writes fell back to CPU.

Update both release profiles to match the supported Spark 4.1.x configuration:

- Build `iceberg/iceberg-1-11-x` instead of `iceberg/iceberg-stub`.
- Use the Spark 4.1 Iceberg artifact suffix and Iceberg 1.11 runtime version.
- Package `rapids-4-spark-iceberg-1-11-x` in the distribution.

Validated the equivalent Spark 4.1.2 and 4.1.3 profile configurations on a GPU system with JDK 17, CUDA 13, Iceberg 1.11.0, and the Apache Spark binary distributions.

- Spark 4.1.2 build: passed.
- Spark 4.1.3 build: passed.
- Spark 4.1.2 Iceberg integration tests: 400 passed, 18 skipped, 3 xpassed, 0 failed.
- Spark 4.1.3 Iceberg integration tests: 400 passed, 18 skipped, 3 xpassed, 0 failed.

The integration tests were run with:

```bash
integration_tests/run_pyspark_from_build.sh -m iceberg --iceberg -v -r fExXs
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`integration_tests/src/main/python/iceberg`)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
