### PR TITLE
Skip Iceberg V3 tests for REST catalogs [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -35,8 +35,10 @@ iceberg_unsupported_mark = pytest.mark.skipif(
 runtime_iceberg_version = os.environ.get("EXPECTED_ICEBERG_VERSION")
 supports_iceberg_v3 = (
     runtime_iceberg_version is not None and
-    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 9))
-ICEBERG_V3_UNSUPPORTED_REASON = "Iceberg v3 only supported after iceberg 1.9.0"
+    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 9) and
+    not is_iceberg_rest_catalog())
+ICEBERG_V3_UNSUPPORTED_REASON = (
+    "Iceberg v3 requires Iceberg 1.9.0 or later and a catalog backend with v3 support")
 
 # iceberg supported types
 iceberg_table_gen = MappingProxyType({


### PR DESCRIPTION
Fixes #15656.

### Description

Iceberg V3 fallback tests currently use client-version detection only. The REST catalog test environment uses a backend release that rejects `format-version=3` during table creation, before RAPIDS fallback paths are exercised.

This change excludes REST catalog runs from the shared Iceberg V3 capability flag. Local Hadoop catalog runs continue to cover the V3 fallback paths. Upgrading the REST catalog backend and restoring V3 REST coverage is tracked by #15657.

Validation:

- Focused REST catalog V3 selection: `12 skipped, 34892 deselected`
- `python3 -m py_compile integration_tests/src/main/python/iceberg/__init__.py`
- `git diff --check`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
