### PR TITLE
Classify shuffle-only changelog issues as features [skip ci]

### DIFF
--- a/scripts/generate-changelog
+++ b/scripts/generate-changelog
@@ -22,8 +22,8 @@ and issues that include the labels `bug`, `feature request`, `SQL`, `performance
 minus any issues with the labels `wontfix`, `invalid` or `duplicate`.
 
 For each project there should be an issue subsection for,
-Features: all issues with label `feature request` + `SQL`
-Performance: all issues with label `performance` + `shuffle`
+Features: all issues with label `feature request` + `SQL` + `shuffle`
+Performance: all issues with label `performance`
 Bugs fixed: all issues with label `bug`
 
 To deduplicate section, the priority should be `Bugs fixed > Performance > Features`
@@ -77,8 +77,8 @@ PRS = 'PRs'
 # Labels
 LABEL_WONTFIX, LABEL_INVALID, LABEL_DUPLICATE = 'wontfix', 'invalid', 'duplicate'
 LABEL_BUG = 'bug'
-LABEL_PERFORMANCE, LABEL_SHUFFLE = 'performance', 'shuffle'
-LABEL_FEATURE, LABEL_SQL = 'feature request', 'SQL'
+LABEL_PERFORMANCE = 'performance'
+LABEL_FEATURE, LABEL_SQL, LABEL_SHUFFLE = 'feature request', 'SQL', 'shuffle'
 # The release version from which the release branch changes (e.g., branch-YY.MM --> release/YY.MM)
 FROM_RELEASE = '25.12'
 # Queries
@@ -396,9 +396,9 @@ def rules(labels: set):
         return INVALID
     if LABEL_BUG in labels:
         return BUGS_FIXED
-    if LABEL_PERFORMANCE in labels or LABEL_SHUFFLE in labels:
+    if LABEL_PERFORMANCE in labels:
         return PERFORMANCE
-    if LABEL_FEATURE in labels or LABEL_SQL in labels:
+    if LABEL_FEATURE in labels or LABEL_SQL in labels or LABEL_SHUFFLE in labels:
         return FEATURES
     return INVALID
 


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/cudf-spark/issues/15659

The changelog generator previously treated every issue carrying the shuffle label as a performance change.

Shuffle identifies a functional area, so this incorrectly placed feature and usability work in the Performance section.

Require the explicit performance label for Performance entries and classify shuffle as Features when no higher-priority exclusion, bug, or performance label applies.

Keep the existing Bugs Fixed > Performance > Features precedence and continue fetching shuffle-labeled issues.


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
