### PR TITLE
Exclude AWS Netty jars from Spark 4.1 S3Tables classpath

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -34,6 +34,7 @@ PROJECT_REPO_HOST=$(sed -E 's#^(.*://)?([^/@]*@)?([^/:]+).*#\3#' <<< "$PROJECT_R
 
 download_maven_jars() {
   local coordinates=$1
+  local exclude_group_ids=${2:-}
   local coordinate
   local group_id
   local artifact_id
@@ -41,6 +42,7 @@ download_maven_jars() {
   local dependency_dir
   local pom_file
   local -a coordinates_array
+  local -a dependency_copy_args
   local -a jars
 
   dependency_dir=$(mktemp -d "$ARTF_ROOT/maven-dependencies-XXXXXX")
@@ -75,12 +77,19 @@ EOF
     echo "</project>"
   } > "$pom_file"
 
+  dependency_copy_args=(
+    -DincludeScope=runtime
+    -DincludeTypes=jar
+    "-DoutputDirectory=$dependency_dir/jars"
+  )
+  if [[ -n "$exclude_group_ids" ]]; then
+    dependency_copy_args+=("-DexcludeGroupIds=$exclude_group_ids")
+  fi
+
   (
     cd "$WORKSPACE"
     $MVN -q -B -f "$pom_file" dependency:copy-dependencies \
-      -DincludeScope=runtime \
-      -DincludeTypes=jar \
-      -DoutputDirectory="$dependency_dir/jars"
+      "${dependency_copy_args[@]}"
   ) >&2 || return 1
 
   mapfile -d '' -t jars < <(
@@ -454,7 +463,15 @@ software.amazon.awssdk:url-connection-client:${AWS_SDK_VERSION},\
 software.amazon.awssdk:s3tables:${AWS_SDK_VERSION},\
 org.apache.hadoop:hadoop-aws:${HADOOP_AWS_VERSION},\
 com.amazonaws:aws-java-sdk-bundle:${AWS_SDK_BUNDLE_VERSION}"
-      ICEBERG_S3TABLES_EXTRA_CLASSPATH=$(download_maven_jars "$ICEBERG_S3TABLES_JARS")
+      # Spark 4.1 uses Netty 4.2, which cannot coexist with the Netty 4.1 jars pulled in by
+      # AWS SDK 2.x. Let AWS use the Netty version provided by Spark instead.
+      local exclude_group_ids=""
+      if [[ "$ICEBERG_SPARK_VER" == "4.1" ]]; then
+        exclude_group_ids="io.netty"
+      fi
+      ICEBERG_S3TABLES_EXTRA_CLASSPATH=$(
+        download_maven_jars "$ICEBERG_S3TABLES_JARS" "$exclude_group_ids"
+      )
 
       # Requires to setup s3 buckets and namespaces to run iceberg s3tables tests.
       # These steps are included in the test pipeline.

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -463,6 +463,7 @@ software.amazon.awssdk:url-connection-client:${AWS_SDK_VERSION},\
 software.amazon.awssdk:s3tables:${AWS_SDK_VERSION},\
 org.apache.hadoop:hadoop-aws:${HADOOP_AWS_VERSION},\
 com.amazonaws:aws-java-sdk-bundle:${AWS_SDK_BUNDLE_VERSION}"
+
       # Spark 4.1 uses Netty 4.2, which cannot coexist with the Netty 4.1 jars pulled in by
       # AWS SDK 2.x. Let AWS use the Netty version provided by Spark instead.
       local exclude_group_ids=""


### PR DESCRIPTION
Fixes #15675.

### Description

Spark 4.1.x provides Netty 4.2, while the AWS SDK dependencies used by the Iceberg S3Tables integration tests resolve Netty 4.1. Placing both versions on `spark.driver.extraClassPath` and `spark.executor.extraClassPath` allows the older AWS Netty jars to shadow Spark's Netty classes, causing a `SingleThreadEventLoop` `NoSuchMethodError` during `SparkContext` initialization.

This change allows `download_maven_jars` to exclude optional Maven dependency groups. The S3Tables path excludes `io.netty` only for Spark 4.1.x, so the AWS client uses Spark's Netty 4.2 classes. Other Spark versions and other users of `download_maven_jars` retain the existing dependency resolution behavior.

Local validation with Spark 4.1.1, Scala 2.13, and JDK 17:

- Reproduced the reported `NoSuchMethodError` with the current S3Tables dependency classpath.
- Re-ran the same `SparkContext` startup smoke test after excluding `io.netty`; the resolved extra classpath contained no `io.netty` provider jars and Spark 4.1.1 initialized successfully.
- Verified the default `download_maven_jars` call still preserves Netty dependencies when no exclusion is requested.
- Ran `bash -n jenkins/spark-tests.sh` and `git diff --check`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
