### PR TITLE
Fix NVSkills workflow permissions [skip ci]

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -17,11 +17,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -31,6 +34,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
### Description

The shared `NVIDIA/skills/.github/workflows/team-request.yml@main` workflow began requesting `statuses: read`. See https://github.com/NVIDIA/skills/blob/main/.github/workflows/request-nvskills-ci.yml.

However the cuDF Spark caller only granted `contents: read` and `pull-requests: read`. GitHub validates reusable workflow permissions before evaluating the job condition, so ordinary issue comments and pushes produced startup failures even when they were unrelated to `/nvskills-ci`.

This change synchronizes `.github/workflows/request-nvskills-ci.yml` with the current shared workflow template by:

- granting `statuses: read` to the reusable workflow;
- triggering the workflow for pull request lifecycle events; and
- invoking the shared status gate for those pull request events.

This stops the startup-failure notifications and enables the pull request status gate expected by the current shared workflow. There is no user-facing product change.

Validation:

- Parsed `.github/workflows/request-nvskills-ci.yml` with Ruby's YAML parser.
- Verified that the workflow body matches the current `NVIDIA/skills` caller
  template.
- Ran `git diff --check`.

### Checklists

Documentation

- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing

- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance

- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
