### PR TITLE
Remove inert InMemoryTableScanExec allowances in cache_test.py [databricks]

### DIFF
--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -21,9 +21,9 @@ from conftest import is_not_utc
 from data_gen import *
 from pyspark import StorageLevel
 import pyspark.sql.functions as f
-from spark_session import with_cpu_session, with_gpu_session, is_spark_350_or_351
+from spark_session import with_cpu_session, with_gpu_session
 from join_test import create_df
-from marks import incompat, allow_non_gpu, allow_non_gpu_conditional, ignore_order, disable_ansi_mode
+from marks import incompat, allow_non_gpu, ignore_order, disable_ansi_mode
 import pyspark.mllib.linalg as mllib
 import pyspark.ml.linalg as ml
 
@@ -374,7 +374,6 @@ def test_batch_no_cols(with_x_session):
 
 @ignore_order(local=True)
 @allow_non_gpu("ShuffleExchangeExec", "ColumnarToRowExec")
-@allow_non_gpu_conditional(is_spark_350_or_351(), "InMemoryTableScanExec")
 @pytest.mark.parametrize("data_gen", integral_gens, ids=idfn)
 @pytest.mark.parametrize('enable_vectorized_conf', enable_vectorized_confs, ids=idfn)
 def test_aqe_cache_version_specific_behavior(data_gen, enable_vectorized_conf):
@@ -397,7 +396,6 @@ def test_aqe_cache_version_specific_behavior(data_gen, enable_vectorized_conf):
 @ignore_order(local=True)
 @allow_non_gpu("CollectLimitExec", "ShuffleExchangeExec", "ColumnarToRowExec")
 @pytest.mark.parametrize('enable_vectorized_conf', enable_vectorized_confs, ids=idfn)
-@allow_non_gpu_conditional(is_spark_350_or_351(), "InMemoryTableScanExec")
 def test_persist_with_groupby_join_version_specific(enable_vectorized_conf):
     """
     Expected behavior:
@@ -433,7 +431,6 @@ def test_persist_with_groupby_join_version_specific(enable_vectorized_conf):
 # Ensure base allow list is a tuple to satisfy pytest hook concatenation
 @allow_non_gpu("")
 @pytest.mark.parametrize('enable_vectorized_conf', enable_vectorized_confs, ids=idfn)
-@allow_non_gpu_conditional(is_spark_350_or_351(), "InMemoryTableScanExec")
 def test_cached_groupby_sum_version_specific(enable_vectorized_conf):
     """
     Validate aggregation on a cached query works without errors across Spark versions.


### PR DESCRIPTION
Fixes #15237.

### Description

Three cache tests carry `@allow_non_gpu_conditional(is_spark_350_or_351(), "InMemoryTableScanExec")`, but the test-mode plan checker already tolerates a CPU cache scan on Spark 3.5.0/3.5.1 independent of this marker — the allowance is never consulted, so it does nothing.

- Removed the three dead decorator lines (`test_aqe_cache_version_specific_behavior`, `test_persist_with_groupby_join_version_specific`, `test_cached_groupby_sum_version_specific`).
- Removed the now-unused `is_spark_350_or_351` and `allow_non_gpu_conditional` imports, verified with a grep across the file that neither has any remaining call site after the above removal (`allow_non_gpu`, the plain unconditional marker, is still used elsewhere in the file and was left alone).

This is a test-only change with no functional or user-facing impact — the markers being removed were never actually consulted by the plan checker, so removing them changes no test outcome on any Spark version, per the linked issue's own analysis.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`test_aqe_cache_version_specific_behavior`, `test_persist_with_groupby_join_version_specific`, `test_cached_groupby_sum_version_specific` — these three tests already exercise the exact code path the removed markers no-op on. `python3 -m ast` confirms the modified file parses cleanly; I don't have the GPU/Spark integration environment this change doesn't touch to run the suite live, so I can't attach a run result beyond that static check.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
