### PR TITLE
[BUG] Correct partial-clustering DISTINCT plan assertion [databricks]

### DIFF
--- a/integration_tests/src/main/python/group_partitions_test.py
+++ b/integration_tests/src/main/python/group_partitions_test.py
@@ -52,6 +52,7 @@ def _assert_partial_clustering_spj_plan(plan):
     scans = nodes_of_class("BatchScanExec")
     joins = nodes_of_class("GpuShuffledSymmetricHashJoinExec")
     group_partitions = nodes_of_class("GpuGroupPartitionsExec")
+    shuffle_exchanges = nodes_of_class("GpuShuffleExchangeExec")
 
     assert len(scans) == 2, f"Expected two CPU batch scans, found {len(scans)}:\n{plan}"
     assert len(joins) == 1, f"Expected one GPU SPJ join, found {len(joins)}:\n{plan}"
@@ -62,11 +63,11 @@ def _assert_partial_clustering_spj_plan(plan):
         if node.getClass().getSimpleName() == "GpuShuffleExchangeExec"
     ]
     assert not join_exchanges, f"Expected shuffle-free SPJ inputs:\n{plan}"
-    assert not nodes_of_class("GpuShuffleExchangeExec"), \
-        f"Expected keyed partitioning to remain shuffle-free through DISTINCT:\n{plan}"
     assert nodes_of_class("GpuRowToColumnarExec"), \
         f"Expected transitions above the CPU batch scans:\n{plan}"
     if is_spark_420_or_later():
+        assert not shuffle_exchanges, \
+            f"Expected keyed partitioning to remain shuffle-free through DISTINCT:\n{plan}"
         join_group_partitions = [
             node for node in join_nodes
             if node.getClass().getSimpleName() == "GpuGroupPartitionsExec"
@@ -76,6 +77,8 @@ def _assert_partial_clustering_spj_plan(plan):
         assert len(group_partitions) == 3, \
             f"Expected a third GPU group-partitions node below distinct:\n{plan}"
     else:
+        assert len(shuffle_exchanges) == 1, \
+            f"Expected DISTINCT to shuffle partially clustered output once:\n{plan}"
         assert not group_partitions, \
             f"GroupPartitionsExec is not expected before Spark 4.2:\n{plan}"
 
@@ -114,8 +117,8 @@ def test_group_partitions_partial_clustering_distinct():
         "spark.sql.sources.v2.bucketing.partiallyClusteredDistribution.enabled": "true",
     }
 
-    # The SPJ is shuffle-free, and distinct reuses its keyed partitioning. On Spark 4.2 this
-    # exercises GroupPartitionsExec both below the join and below the aggregate.
+    # The SPJ inputs are shuffle-free. SPARK-55848 requires DISTINCT to shuffle partially
+    # clustered output before Spark 4.2. Spark 4.2 groups matching keys below the aggregate instead.
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         distinct_after_spj,
         conf=conf,


### PR DESCRIPTION
Fixes #15653.

### Description
- Correct the cross-version plan assertion so Spark 3.5.9, 4.0.3+, and 4.1.2+ require one post-join GPU shuffle for `DISTINCT`, because SPARK-55848 intentionally redistributes partially clustered output for deduplication correctness.
- Keep SPJ inputs shuffle-free on every supported version and retain Spark 4.2's end-to-end no-shuffle assertion, because Spark 4.2 can group matching keys below the aggregate with `GroupPartitionsExec`.
- Validate the Scala 2.13 Spark 4.0.4, 4.1.3, and 4.2 integration artifacts with `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=404 -Dcuda.version=cuda13 -DskipTests -pl integration_tests -am install`, the same command with `-Dbuildver=413`, and the same command with `-Dbuildver=420`; all three builds succeeded and ensure both assertion branches compile.
- Validate `test_group_partitions_partial_clustering_distinct` with Spark 4.0.4 and 4.1.3 using `SPARK_HOME=~/work/tools/spark-4.0.4-bin-hadoop3 TEST=group_partitions_partial_clustering_distinct TEST_PARALLEL=1 ./run_pyspark_from_build.sh` and the corresponding Spark 4.1.3 command; both passed and confirm the required single post-join shuffle before Spark 4.2.
- Validate the same test with Spark 4.2 using `SPARK_HOME=~/work/tools/spark-4.2.0-bin-hadoop3 TEST=group_partitions_partial_clustering_distinct TEST_PARALLEL=1 ./run_pyspark_from_build.sh`; it passed and confirms three `GpuGroupPartitionsExec` nodes preserve the no-shuffle path.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required