### PR TITLE
[BUG] Restrict Delta provider test to Spark 4.1.1

### DIFF
--- a/tests/src/test/spark411/scala/com/nvidia/spark/rapids/DeltaLakeQuerySuite.scala
+++ b/tests/src/test/spark411/scala/com/nvidia/spark/rapids/DeltaLakeQuerySuite.scala
@@ -16,8 +16,6 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "411"}
-{"spark": "412"}
-{"spark": "413"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids
 


### PR DESCRIPTION
Fixes #15677.

### Description

Spark 4.1.2 and 4.1.3 intentionally use the Delta stub because Delta Lake 4.1.0 is binary-incompatible with those Spark patch releases. However, `DeltaLakeQuerySuiteSpark411` was still selected for all three Spark 4.1 shims and asserted that the provider was a real `Delta41xProvider`.

This change restricts the suite's shim metadata to Spark 4.1.1. It preserves provider-discovery coverage for the supported Spark/Delta combination and prevents the invalid assertion from running on Spark 4.1.2 and 4.1.3.

There is no production or user-facing behavior change.

### Validation

- Spark 4.1.1 / Scala 2.13 targeted `DeltaLakeQuerySuiteSpark411`: passed (1 test, 0 failures)
- Spark 4.1.3 test-source generation: passed; suite excluded
- Generated-source selection: suite present for 411 and absent for 412/413
- `git diff --check`

The Spark 4.1.2 Maven generation attempt was blocked by unavailable snapshot artifacts and HTTP 401 responses from the configured NVIDIA repository.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Covered by `DeltaLakeQuerySuiteSpark411`.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
