### PR TITLE
[fast-ut] [reduced-it] Xfail Iceberg V3 COW DELETE on Spark 3.5

### DIFF
--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -25,17 +25,25 @@ import pytest
 
 from conftest import is_iceberg_rest_catalog, spark_jvm
 from data_gen import *
-from spark_session import is_iceberg_supported_spark, with_cpu_session
-
-iceberg_unsupported_mark = pytest.mark.skipif(
-    not is_iceberg_supported_spark(),
-    reason="Iceberg acceleration requires Spark 3.5.x, 4.0.x, or 4.1.x")
-
+from spark_session import is_iceberg_supported_spark, is_spark_35x, with_cpu_session
 
 runtime_iceberg_version = os.environ.get("EXPECTED_ICEBERG_VERSION")
+runtime_iceberg_major_minor = (
+    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2])
+    if runtime_iceberg_version is not None else None)
+spark_35x_unsupported_iceberg_version = (
+    is_spark_35x() and
+    runtime_iceberg_major_minor is not None and
+    runtime_iceberg_major_minor >= (1, 11))
+
+iceberg_unsupported_mark = pytest.mark.skipif(
+    not is_iceberg_supported_spark() or spark_35x_unsupported_iceberg_version,
+    reason="Unsupported Spark and Iceberg version combination")
+
+
 supports_iceberg_v3 = (
-    runtime_iceberg_version is not None and
-    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 9) and
+    runtime_iceberg_major_minor is not None and
+    runtime_iceberg_major_minor >= (1, 9) and
     not is_iceberg_rest_catalog())
 ICEBERG_V3_UNSUPPORTED_REASON = (
     "Iceberg v3 requires Iceberg 1.9.0 or later and a catalog backend with v3 support")

--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -25,25 +25,17 @@ import pytest
 
 from conftest import is_iceberg_rest_catalog, spark_jvm
 from data_gen import *
-from spark_session import is_iceberg_supported_spark, is_spark_35x, with_cpu_session
-
-runtime_iceberg_version = os.environ.get("EXPECTED_ICEBERG_VERSION")
-runtime_iceberg_major_minor = (
-    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2])
-    if runtime_iceberg_version is not None else None)
-spark_35x_unsupported_iceberg_version = (
-    is_spark_35x() and
-    runtime_iceberg_major_minor is not None and
-    runtime_iceberg_major_minor >= (1, 11))
+from spark_session import is_iceberg_supported_spark, with_cpu_session
 
 iceberg_unsupported_mark = pytest.mark.skipif(
-    not is_iceberg_supported_spark() or spark_35x_unsupported_iceberg_version,
-    reason="Unsupported Spark and Iceberg version combination")
+    not is_iceberg_supported_spark(),
+    reason="Iceberg acceleration requires Spark 3.5.x, 4.0.x, or 4.1.x")
 
 
+runtime_iceberg_version = os.environ.get("EXPECTED_ICEBERG_VERSION")
 supports_iceberg_v3 = (
-    runtime_iceberg_major_minor is not None and
-    runtime_iceberg_major_minor >= (1, 9) and
+    runtime_iceberg_version is not None and
+    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 9) and
     not is_iceberg_rest_catalog())
 ICEBERG_V3_UNSUPPORTED_REASON = (
     "Iceberg v3 requires Iceberg 1.9.0 or later and a catalog backend with v3 support")

--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -21,8 +21,7 @@ from iceberg import (create_iceberg_table, get_full_table_name, iceberg_write_en
                      iceberg_base_table_cols, iceberg_gens_list, iceberg_nested_write_gens_list,
                      iceberg_unsupported_mark, delete_partition_transforms_distributed,
                      _build_tblprops, assert_iceberg_files_use_codec,
-                     supports_iceberg_v3, runtime_iceberg_version,
-                     ICEBERG_V3_UNSUPPORTED_REASON)
+                     supports_iceberg_v3, ICEBERG_V3_UNSUPPORTED_REASON)
 from marks import allow_non_gpu, allow_non_gpu_conditional, iceberg, ignore_order, datagen_overrides
 from spark_session import is_spark_35x, is_spark_400_or_later, with_cpu_session, with_gpu_session
 
@@ -39,7 +38,6 @@ iceberg_delete_mor_enabled_conf = copy_and_update(iceberg_write_enabled_conf, {}
 # would be DeleteFromTableExec.
 DELETE_TEST_SEED = 42
 DELETE_TEST_SEED_OVERRIDE_REASON = "Ensure reproducible test data for DELETE operations"
-ICEBERG_V3_COW_DELETE_XFAIL_VERSIONS = ("1.10.0", "1.10.1", "1.10.2", "1.11.0")
 
 def create_iceberg_table_with_data(table_name: str, 
                                    partition_col_sql=None,
@@ -139,8 +137,7 @@ def test_iceberg_delete_unpartitioned_table(spark_tmp_table_factory, delete_mode
         'copy-on-write',
         'ReplaceDataExec',
         marks=pytest.mark.xfail(
-            condition=(is_spark_35x() and
-                       runtime_iceberg_version in ICEBERG_V3_COW_DELETE_XFAIL_VERSIONS),
+            condition=is_spark_35x(),
             reason="https://github.com/NVIDIA/cudf-spark/issues/15680"),
         id='cow'),
     pytest.param('merge-on-read', 'WriteDeltaExec', id='mor')

--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -21,9 +21,10 @@ from iceberg import (create_iceberg_table, get_full_table_name, iceberg_write_en
                      iceberg_base_table_cols, iceberg_gens_list, iceberg_nested_write_gens_list,
                      iceberg_unsupported_mark, delete_partition_transforms_distributed,
                      _build_tblprops, assert_iceberg_files_use_codec,
-                     supports_iceberg_v3, ICEBERG_V3_UNSUPPORTED_REASON)
+                     supports_iceberg_v3, runtime_iceberg_version,
+                     ICEBERG_V3_UNSUPPORTED_REASON)
 from marks import allow_non_gpu, allow_non_gpu_conditional, iceberg, ignore_order, datagen_overrides
-from spark_session import is_spark_400_or_later, with_cpu_session, with_gpu_session
+from spark_session import is_spark_35x, is_spark_400_or_later, with_cpu_session, with_gpu_session
 
 pytestmark = iceberg_unsupported_mark
 
@@ -38,6 +39,7 @@ iceberg_delete_mor_enabled_conf = copy_and_update(iceberg_write_enabled_conf, {}
 # would be DeleteFromTableExec.
 DELETE_TEST_SEED = 42
 DELETE_TEST_SEED_OVERRIDE_REASON = "Ensure reproducible test data for DELETE operations"
+ICEBERG_V3_COW_DELETE_XFAIL_VERSIONS = ("1.10.0", "1.10.1", "1.10.2", "1.11.0")
 
 def create_iceberg_table_with_data(table_name: str, 
                                    partition_col_sql=None,
@@ -133,7 +135,14 @@ def test_iceberg_delete_unpartitioned_table(spark_tmp_table_factory, delete_mode
 @pytest.mark.skipif(not supports_iceberg_v3, reason=ICEBERG_V3_UNSUPPORTED_REASON)
 @ignore_order(local=True)
 @pytest.mark.parametrize('delete_mode,fallback_exec', [
-    pytest.param('copy-on-write', 'ReplaceDataExec', id='cow'),
+    pytest.param(
+        'copy-on-write',
+        'ReplaceDataExec',
+        marks=pytest.mark.xfail(
+            condition=(is_spark_35x() and
+                       runtime_iceberg_version in ICEBERG_V3_COW_DELETE_XFAIL_VERSIONS),
+            reason="https://github.com/NVIDIA/cudf-spark/issues/15680"),
+        id='cow'),
     pytest.param('merge-on-read', 'WriteDeltaExec', id='mor')
 ])
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")


### PR DESCRIPTION
Fixes #15680.

### Description

The Iceberg V3 copy-on-write DELETE fallback test can fail during the CPU baseline on Spark 3.5 because Spark rejects the Iceberg `ReplaceData` plan while validating row-lineage metadata attributes. This change conditionally marks that COW case as a non-strict xfail on Spark 3.5 for all Iceberg versions that support V3, while preserving merge-on-read coverage.

The change is confined to the DELETE test and has no runtime impact.

No exact Apache Spark or Apache Iceberg issue was found. Related upstream work includes Apache Iceberg PR #12736, which added Spark 3.5 row-lineage support, and Apache Spark PR #49493 / SPARK-50820, which changed row-level metadata attribute handling for Spark 4.x. The affected Spark 3.5 planning rule is unchanged through Spark 3.5.9.

- https://github.com/apache/iceberg/pull/12736
- https://github.com/apache/spark/pull/49493

Verification:

- Spark RAPIDS build: Spark 3.5.8, Scala 2.13 — 15/15 modules passed
- Spark 3.5.8 + Iceberg 1.10.1 after the review changes — 398 passed, 19 skipped, 1 xfailed, 3 xpassed
- Spark 3.5.8 + Iceberg 1.11.0 was attempted but is not a supported build combination because the Spark 3.5 build omits the Iceberg 1.11 provider; no compatibility workaround is included in this PR

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required