### PR TITLE
[fast-ut] [reduced-it] Remove dead regex line-anchor backref state [databricks]

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -370,13 +370,10 @@ def test_re_replace_backrefs():
             'REGEXP_REPLACE(a, "(T)(E)", "$12")',
             'REGEXP_REPLACE(a, "(T)(E)", "x$12y")',
             'REGEXP_REPLACE(a, "(T)(E)", "$123$2")',
-            # 12 user groups plus a trailing line-anchor `$`. Two distinct boundary
-            # checks:
-            # 1. User `$123$2` -> `$12` + literal `3` + `$2`; the user count being 12
-            #    (not the transpiled 13) is enough for the greedy-with-backoff to back off.
-            # 2. User `$13` -> `$1` + literal `3` (NOT a reference to the transpiler's
-            #    internally-generated 13th group, which exists only after line-anchor
-            #    rewriting and must stay invisible to user-replacement parsing).
+            # 12 user groups plus a trailing line-anchor `$`. Replacement parsing preserves
+            # raw `$N` tokens, then conversion uses the 12 Java-visible groups:
+            # 1. User `$123$2` -> `$12` + literal `3` + `$2`.
+            # 2. User `$13` -> `$1` + literal `3`.
             'REGEXP_REPLACE(a, "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$", "$123$2")',
             'REGEXP_REPLACE(a, "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$", "$13")'
         ),
@@ -403,6 +400,8 @@ def test_re_replace_anchors():
             'REGEXP_REPLACE(a, "(\ud720[A-Z]+)$", "PROD")',
             'REGEXP_REPLACE(a, "(TEST)$", "$1")',
             'REGEXP_REPLACE(a, "^(TEST)$", "$1")',
+            # Issue #15060: line-anchor rewriting must not mutate replacement backref state.
+            'REGEXP_REPLACE(a, "^(TEST)$", "[$1][$0]")',
             'REGEXP_REPLACE(a, "\\\\ATEST\\\\Z", "PROD")',
             'REGEXP_REPLACE(a, "\\\\ATEST$", "PROD")',
             'REGEXP_REPLACE(a, "^TEST\\\\Z", "PROD")',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -57,9 +57,8 @@ class GpuRegExpReplaceMeta(
                   replacement)
           // Use the user's Java pattern group count for the greedy-with-backoff parse so that
           // user-authored backref tokens (e.g. `$13` on a 12-group pattern) follow Java's
-          // `Matcher.appendReplacement` spec. Backrefs already emitted in braced `${N}` form
-          // are treated as resolved by the replacement AST and do not need to be covered by
-          // the user pattern's group count.
+          // `Matcher.appendReplacement` spec. Replacement parsing preserves raw `$N` tokens;
+          // this is the single boundary that resolves them against the user-visible group count.
           val userNumCaptureGroups =
             java.util.regex.Pattern.compile(s.toString).matcher("").groupCount()
           repl.map { r =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -794,8 +794,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
       extractIndex: Option[Int],
       repl: Option[String]): (RegexAST, Option[RegexReplacement]) = {
 
-    // if we have a replacement, parse the replacement string using the regex parser to account
-    // for backrefs
+    // Validate Java Matcher.appendReplacement syntax while preserving raw backreference tokens.
+    // GpuRegExpUtils.backrefConversion translates them to cuDF syntax later.
     val replacement = repl.map(s => new RegexParser(s).parseReplacement())
 
     // validate that the regex is supported by cuDF

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -70,8 +70,8 @@ class RegexParser(pattern: String) {
     ast
   }
 
-  def parseReplacement(numCaptureGroups: Int): RegexReplacement = {
-    val sequence = RegexReplacement(new ListBuffer(), numCaptureGroups)
+  def parseReplacement(): RegexReplacement = {
+    val sequence = RegexReplacement(new ListBuffer())
     while (!eof()) {
       sequence.parts ++= parseReplacementBase()
     }
@@ -772,15 +772,6 @@ class CudfRegexTranspiler(mode: RegexMode) {
   private val escapeChars = Map('n' -> '\n', 'r' -> '\r', 't' -> '\t', 'f' -> '\f', 'a' -> '\u0007',
       'b' -> '\b', 'e' -> '\u001b')
 
-  private def countCaptureGroups(regex: RegexAST): Int = {
-    regex match {
-      case RegexSequence(parts) => parts.foldLeft(0)((c, re) => c + countCaptureGroups(re))
-      case RegexGroup(groupType, base) =>
-        (if (groupType == RegexGroup.Capturing) 1 else 0) + countCaptureGroups(base)
-      case _ => 0
-    }
-  }
-
   /**
    * Parse Java regular expression and translate into cuDF regular expression.
    *
@@ -805,10 +796,10 @@ class CudfRegexTranspiler(mode: RegexMode) {
 
     // if we have a replacement, parse the replacement string using the regex parser to account
     // for backrefs
-    val replacement = repl.map(s => new RegexParser(s).parseReplacement(countCaptureGroups(regex)))
+    val replacement = repl.map(s => new RegexParser(s).parseReplacement())
 
     // validate that the regex is supported by cuDF
-    val cudfRegex = transpile(regex, extractIndex, replacement, None)
+    val cudfRegex = transpile(regex, extractIndex, None)
 
     (cudfRegex, replacement)
   }
@@ -976,7 +967,6 @@ class CudfRegexTranspiler(mode: RegexMode) {
   }
 
   private def transpile(regex: RegexAST, extractIndex: Option[Int],
-      replacement: Option[RegexReplacement],
       previous: Option[RegexAST]): RegexAST = {
 
     def containsBeginAnchor(regex: RegexAST): Boolean = {
@@ -1143,7 +1133,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
       case _ => regex
     }
 
-    rewrite(withUpdatedGroups, replacement, previous, RegexRewriteFlags(isEmptyRepetition(regex)))
+    rewrite(withUpdatedGroups, previous, RegexRewriteFlags(isEmptyRepetition(regex)))
   }
 
   private def applyInlineFlags(
@@ -1199,8 +1189,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
         Seq(component)
     }
 
-  private def rewrite(regex: RegexAST, replacement: Option[RegexReplacement],
-      previous: Option[RegexAST], flags: RegexRewriteFlags): RegexAST = {
+  private def rewrite(regex: RegexAST, previous: Option[RegexAST],
+      flags: RegexRewriteFlags): RegexAST = {
 
     regex match {
 
@@ -1344,7 +1334,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
             case Some(RegexEscaped('Z')) =>
               RegexEmpty()
             case _ =>
-              rewrite(RegexChar('$'), replacement, previous, flags)
+              rewrite(RegexChar('$'), previous, flags)
           }
         case 's' | 'S' =>
           // whitespace characters
@@ -1421,7 +1411,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
         val rewrittenComponents = ListBuffer(characters.toSeq
           .map {
             case r @ RegexChar(ch) if "^$.".contains(ch) => r
-            case ch => rewrite(ch, replacement, None, flags.copy(caseInsensitive = false)) match {
+            case ch => rewrite(ch, None, flags.copy(caseInsensitive = false)) match {
               case valid: RegexCharacterClassComponent => valid
               case _ =>
                 // this can happen when a character class contains a meta-sequence such as
@@ -1477,16 +1467,6 @@ class CudfRegexTranspiler(mode: RegexMode) {
             "Sequences that only contain '^' or '$' are not supported", sequence.position)
         }
 
-        def popBackrefIfNecessary(capture: Boolean): Unit = {
-          if (mode == RegexReplaceMode && !capture) {
-            replacement match {
-              case Some(repl) =>
-                repl.popBackref()
-              case _ =>
-            }
-          }
-        }
-
         // Special handling for line anchor ($)
         // This code is implemented here because to make it work in cuDF, we have to reorder
         // the items in the regex.
@@ -1522,16 +1502,19 @@ class CudfRegexTranspiler(mode: RegexMode) {
                         throw new RegexUnsupportedException(
                           "Regex sequence $ followed by a lookaround, independent, or named " +
                           "capture group is not supported", part.position)
-                      case RegexGroup(groupType, RegexSequence(
+                      // These cases intentionally omit the current part. The replacement-side
+                      // backref mutation that used to accompany the drop became dead when the
+                      // synthetic line-anchor capture group was removed by #15023.
+                      case RegexGroup(_, RegexSequence(
                           ListBuffer(RegexCharacterClass(true, parts))))
                           if parts.forall(!isBeginOrEndLineAnchor(_)) =>
-                        popBackrefIfNecessary(groupType == RegexGroup.Capturing)
-                      case RegexGroup(groupType, RegexCharacterClass(true, parts))
+                        ()
+                      case RegexGroup(_, RegexCharacterClass(true, parts))
                           if parts.forall(!isBeginOrEndLineAnchor(_)) =>
-                        popBackrefIfNecessary(groupType == RegexGroup.Capturing)
+                        ()
                       case RegexCharacterClass(true, parts)
                           if parts.forall(!isBeginOrEndLineAnchor(_)) =>
-                        popBackrefIfNecessary(false)
+                        ()
                       case RegexChar(ch) if lineTerminatorChars.contains(ch) =>
                         // what's really needed here is negative lookahead, but that is not
                         // supported by cuDF
@@ -1549,10 +1532,10 @@ class CudfRegexTranspiler(mode: RegexMode) {
                           s"Regex sequences with \\$a are not supported around end-of-line " +
                             "markers like $ or \\Z at position", part.position)
                       case _ =>
-                        r.append(rewrite(part, replacement, last, currentFlags))
+                        r.append(rewrite(part, last, currentFlags))
                     }
                   case _ =>
-                    r.append(rewrite(part, replacement, last, currentFlags))
+                    r.append(rewrite(part, last, currentFlags))
                 }
                 r.last match {
                   case RegexEmpty() =>
@@ -1612,7 +1595,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
               // (\A)+ can be transpiled to (\A) (dropping the repetition)
               // we use rewrite(...) here to handle logic regarding modes
               // (\A is not supported in RegexSplitMode)
-              RegexGroup(groupType, rewrite(term, replacement, previous, flags))
+              RegexGroup(groupType, rewrite(term, previous, flags))
             // NOTE: (\A)* can be transpiled to (\A)?
             // however, (\A)? is not supported in libcudf yet
             case _ =>
@@ -1630,7 +1613,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
               // (\A){1,} can be transpiled to (\A) (dropping the repetition)
               // we use rewrite(...) here to handle logic regarding modes
               // (\A is not supported in RegexSplitMode)
-              RegexGroup(groupType, rewrite(term, replacement, previous, flags))
+              RegexGroup(groupType, rewrite(term, previous, flags))
             // NOTE: (\A)* can be transpiled to (\A)?
             // however, (\A)? is not supported in libcudf yet
             case _ =>
@@ -1648,7 +1631,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
               // (\A){1,} can be transpiled to (\A) (dropping the repetition)
               // we use rewrite(...) here to handle logic regarding modes
               // (\A is not supported in RegexSplitMode)
-              RegexGroup(groupType, rewrite(term, replacement, previous, flags))
+              RegexGroup(groupType, rewrite(term, previous, flags))
             // NOTE: (\A)* can be transpiled to (\A)?
             // however, (\A)? is not supported in libcudf yet
             case _ =>
@@ -1662,30 +1645,30 @@ class CudfRegexTranspiler(mode: RegexMode) {
             throw new RegexUnsupportedException(
                 s"cuDF does not support repetition of: ${term.toRegexString}", term.position)
           }
-          RegexRepetition(rewrite(base, replacement, None, flags), quantifier)
+          RegexRepetition(rewrite(base, None, flags), quantifier)
         case (RegexEscaped(ch), SimpleQuantifier('+')) if "AZ".contains(ch) =>
           // \A+ can be transpiled to \A (dropping the repetition)
           // \Z+ can be transpiled to \Z (dropping the repetition)
           // we use rewrite(...) here to handle logic regarding modes
           // (\A and \Z are not supported in RegexSplitMode)
-          rewrite(base, replacement, previous, flags)
+          rewrite(base, previous, flags)
         // NOTE: \A* can be transpiled to \A?
         // however, \A? is not supported in libcudf yet
         case (RegexEscaped(ch), QuantifierFixedLength(n)) if n > 0 && "AZ".contains(ch) =>
           // \A{2} can be transpiled to \A (dropping the repetition)
           // \Z{2} can be transpiled to \Z (dropping the repetition)
-          rewrite(base, replacement, previous, flags)
+          rewrite(base, previous, flags)
         case (RegexEscaped(ch), QuantifierVariableLength(n,_)) if n > 0 && "AZ".contains(ch) =>
           // \A{1,5} can be transpiled to \A (dropping the repetition)
           // \Z{1,} can be transpiled to \Z (dropping the repetition)
-          rewrite(base, replacement, previous, flags)
+          rewrite(base, previous, flags)
         case _ if isSupportedRepetitionBase(base) =>
-          RegexRepetition(rewrite(base, replacement, None, flags), quantifier)
+          RegexRepetition(rewrite(base, None, flags), quantifier)
         case (RegexRepetition(_, SimpleQuantifier('*')), SimpleQuantifier('+')) =>
           throw new RegexUnsupportedException("Possessive quantifier *+ not supported",
             quantifier.position)
         case (RegexRepetition(_, SimpleQuantifier('?' | '*' | '+')), SimpleQuantifier('?')) =>
-          RegexRepetition(rewrite(base, replacement, None, flags), quantifier)
+          RegexRepetition(rewrite(base, None, flags), quantifier)
         case _ =>
           throw new RegexUnsupportedException("Preceding token cannot be quantified",
             quantifier.position)
@@ -1696,8 +1679,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
         // The left branch has the right branch as a following alternative, so an inline flag
         // toggle there would (in Java) also apply across the `|`. The right branch only has a
         // following alternative if this whole choice does, so it inherits the current flag.
-        val ll = rewrite(l, replacement, None, flags.copy(choiceAltFollows = true))
-        val rr = rewrite(r, replacement, None, flags)
+        val ll = rewrite(l, None, flags.copy(choiceAltFollows = true))
+        val rr = rewrite(r, None, flags)
 
         // cuDF does not support zero-length repetition in replace or split mode
         // cuDF does support +, fixed-length, and variable length with min > 0
@@ -1782,13 +1765,13 @@ class CudfRegexTranspiler(mode: RegexMode) {
         // group cannot leak out to an alternative of an enclosing choice) while inheriting the
         // case state.
         RegexGroup(g.groupType,
-          rewrite(term, replacement, None, flags.copy(choiceAltFollows = false)))
+          rewrite(term, None, flags.copy(choiceAltFollows = false)))
 
       case g @ RegexGroup(RegexGroup.ScopedFlags(flagSet), term) =>
         val innerFlags = applyInlineFlags(flags, flagSet, g.position)
         // a scoped-flags group becomes a non-capturing group with the case state applied to
         // its contents; the flag can't leak out of the group, so no choice-crossing concern
-        rewrite(RegexGroup(RegexGroup.NonCapturing, term), replacement, previous, innerFlags)
+        rewrite(RegexGroup(RegexGroup.NonCapturing, term), previous, innerFlags)
 
       case g @ RegexGroup(_, _) =>
         val msg = g.groupType match {
@@ -2205,44 +2188,9 @@ sealed case class RegexCharacterClass(
   }
 }
 
-sealed case class RegexBackref(num: Int, isNew: Boolean = false) extends RegexAST {
-  def this(num: Int, isNew: Boolean, position: Int) = {
-    this(num, isNew)
-    this.position = Some(position)
-  }
-  override def children(): Seq[RegexAST] = Seq.empty
-  // Backrefs marked as internally generated are emitted in braced `${N}` form so
-  // `backrefConversion` can tell them apart from user-authored `$N` tokens and pass them
-  // through verbatim. User-authored backrefs keep the raw `$N` form so the
-  // greedy-with-backoff parser in `backrefConversion` honors the user's pattern group count.
-  override def toRegexString: String = if (isNew) s"$${$num}" else s"$$$num"
-}
-
-sealed case class RegexReplacement(parts: ListBuffer[RegexAST],
-    var numCaptureGroups: Int = 0) extends RegexAST {
-  def this(parts: ListBuffer[RegexAST], numCaptureGroups: Int, position: Int) = {
-    this(parts, numCaptureGroups)
-    this.position = Some(position)
-  }
+sealed case class RegexReplacement(parts: ListBuffer[RegexAST]) extends RegexAST {
   override def children(): Seq[RegexAST] = parts.toSeq
   override def toRegexString: String = parts.map(_.toRegexString).mkString
-
-  def appendBackref(num: Int): Unit = {
-    numCaptureGroups += 1
-    parts += RegexBackref(num, true)
-  }
-
-  def popBackref(): Unit = {
-    parts.last match {
-      case RegexBackref(_, true) => {
-        numCaptureGroups -= 1
-        parts.trimEnd(1)
-      }
-      case _ =>
-    }
-  }
-
-  def hasBackrefs: Boolean = numCaptureGroups > 0
 }
 
 class RegexUnsupportedException(message: String, index: Option[Int])

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1089,30 +1089,14 @@ object GpuRegExpUtils {
    * @param rep replacement string
    * @param numCaptureGroups number of capturing groups in the corresponding pattern; pass a
    *                         negative value to disable greedy-with-backoff
-   * @return A pair consists of a boolean indicating whether containing any backref and the
-   *         converted replacement.
+   * @return A pair containing a boolean that indicates whether a raw numbered `$N`
+   *         back-reference was converted, and the converted replacement.
    */
   def backrefConversion(rep: String, numCaptureGroups: Int): (Boolean, String) = {
     val b = new StringBuilder
     var i = 0
-    var hasBracedBackref = false
     while (i < rep.length) {
-      // Pass through already-braced `${N}` tokens unchanged. The replacement AST uses this
-      // form for backrefs that have already been resolved by the transpiler, so re-parsing
-      // them against the caller-provided group count could change their meaning.
-      if (rep.charAt(i) == '$' && i + 2 < rep.length && rep.charAt(i + 1) == '{') {
-        val close = rep.indexOf('}', i + 2)
-        val allDigits = close > i + 2 &&
-          (i + 2 until close).forall(k => rep.charAt(k).isDigit)
-        if (allDigits) {
-          b.append(rep.substring(i, close + 1))
-          hasBracedBackref = true
-          i = close + 1
-        } else {
-          b.append(rep.charAt(i))
-          i += 1
-        }
-      } else if (rep.charAt(i) == '$' && i + 1 < rep.length && rep.charAt(i + 1).isDigit) {
+      if (rep.charAt(i) == '$' && i + 1 < rep.length && rep.charAt(i + 1).isDigit) {
 
         // Consume digits one at a time. If the running group index would exceed the actual
         // capture-group count, stop and leave the remaining digits as literals. When no digit
@@ -1161,9 +1145,7 @@ object GpuRegExpUtils {
     }
 
     val converted = b.toString
-    // A pass-through `${N}` token does not modify the string, so equality alone would miss
-    // it; treat it as a backref so the caller routes through `stringReplaceWithBackrefs`.
-    (hasBracedBackref || !rep.equals(converted)) -> converted
+    !rep.equals(converted) -> converted
   }
 
   /**

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -428,46 +428,46 @@ class RegularExpressionParserSuite extends AnyFunSuite {
   }
   
   test("\\1 in replacement is a literal backslash+digit, not a group backref") {
-    val repl = new RegexParser(raw"\1").parseReplacement(numCaptureGroups = 1)
+    val repl = new RegexParser(raw"\1").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('\\'), RegexChar('1')))
   }
 
   test("\\a in replacement is the literal character a") {
-    val repl = new RegexParser(raw"\a").parseReplacement(numCaptureGroups = 0)
+    val repl = new RegexParser(raw"\a").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('\\'), RegexChar('a')))
   }
 
   test("backslash plus non-ASCII Unicode digit is literal in replacement") {
     for (digit <- Seq('١', '१', '۱')) {
-      val repl = new RegexParser(raw"\$digit").parseReplacement(numCaptureGroups = 1)
+      val repl = new RegexParser(raw"\$digit").parseReplacement()
       assert(repl.parts.toList === List(RegexChar('\\'), RegexChar(digit)))
     }
   }
 
   test("trailing \\ in replacement throws") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("""abc\""").parseReplacement(numCaptureGroups = 0)
+      new RegexParser("""abc\""").parseReplacement()
     }
     assert(ex.getMessage.contains("character to be escaped is missing"))
   }
 
   test("bare $X for non-digit X throws") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("$x").parseReplacement(numCaptureGroups = 0)
+      new RegexParser("$x").parseReplacement()
     }
     assert(ex.getMessage.contains("Illegal group reference"))
   }
 
   test("trailing bare $ throws") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("abc$").parseReplacement(numCaptureGroups = 0)
+      new RegexParser("abc$").parseReplacement()
     }
     assert(ex.getMessage.contains("Illegal group reference"))
   }
 
   test("dollar-brace-digit-brace throws") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("""${1}""").parseReplacement(numCaptureGroups = 1)
+      new RegexParser("""${1}""").parseReplacement()
     }
     assert(ex.getMessage.contains("Illegal group reference"))
     assert(ex.getMessage.contains("digit"))
@@ -476,7 +476,7 @@ class RegularExpressionParserSuite extends AnyFunSuite {
   test("non-ASCII Unicode digit in braced group reference triggers GPU fallback") {
     for (rep <- Seq("""${١}""", """${१}""", """${۱}""")) {
       val e = intercept[RegexUnsupportedException] {
-        new RegexParser(rep).parseReplacement(numCaptureGroups = 4)
+        new RegexParser(rep).parseReplacement()
       }
       assert(e.getMessage.startsWith("Illegal group reference"),
         s"unexpected message for replacement '$rep': ${e.getMessage}")
@@ -485,64 +485,64 @@ class RegularExpressionParserSuite extends AnyFunSuite {
 
   test("dollar-brace-name-brace for named group is not supported on GPU") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("""${name}""").parseReplacement(numCaptureGroups = 1)
+      new RegexParser("""${name}""").parseReplacement()
     }
     assert(ex.getMessage.contains("Named-group reference"))
   }
 
   test("dollar-brace-name with missing closing brace throws") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("""${name""").parseReplacement(numCaptureGroups = 0)
+      new RegexParser("""${name""").parseReplacement()
     }
     assert(ex.getMessage.contains("Illegal group reference"))
   }
 
   test("dollar-brace with empty body throws") {
     val ex = intercept[RegexUnsupportedException] {
-      new RegexParser("""${}""").parseReplacement(numCaptureGroups = 0)
+      new RegexParser("""${}""").parseReplacement()
     }
     assert(ex.getMessage.contains("Illegal group reference"))
   }
 
   test("numbered backref $0 still works") {
-    val repl = new RegexParser("$0").parseReplacement(numCaptureGroups = 0)
+    val repl = new RegexParser("$0").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('$'), RegexChar('0')))
   }
 
   test("numbered backref $1 still works") {
-    val repl = new RegexParser("$1").parseReplacement(numCaptureGroups = 1)
+    val repl = new RegexParser("$1").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('$'), RegexChar('1')))
   }
 
   test("numbered backref $12 preserves raw digits for conversion") {
-    val repl = new RegexParser("$12").parseReplacement(numCaptureGroups = 12)
+    val repl = new RegexParser("$12").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('$'), RegexChar('1'), RegexChar('2')))
   }
 
   test("numbered backref with leading zero preserves raw digits for conversion") {
-    val repl = new RegexParser("$09").parseReplacement(numCaptureGroups = 1)
+    val repl = new RegexParser("$09").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('$'), RegexChar('0'), RegexChar('9')))
   }
 
   test("escaped metachar \\$ in replacement keeps the \\ pair") {
-    val repl = new RegexParser("""\$""").parseReplacement(numCaptureGroups = 0)
+    val repl = new RegexParser("""\$""").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('\\'), RegexChar('$')))
   }
 
   test("escaped backslash \\\\ in replacement keeps the \\ pair") {
-    val repl = new RegexParser("""\\""").parseReplacement(numCaptureGroups = 0)
+    val repl = new RegexParser("""\\""").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('\\'), RegexChar('\\')))
   }
 
   test("escaped dollar before digit \\$1 keeps the \\ pair as literals (not a backref)") {
     // Java appendReplacement: `\` escapes the `$`, so `\$1` is the literal text `$1`.
-    val repl = new RegexParser("""\$1""").parseReplacement(numCaptureGroups = 1)
+    val repl = new RegexParser("""\$1""").parseReplacement()
     assert(repl.parts.toList === List(RegexChar('\\'), RegexChar('$'), RegexChar('1')))
   }
 
   test("double backslash before dollar \\\\$1 does NOT escape the $ (real backref)") {
     // `\\` is an escaped backslash; the following `$1` is a genuine group-1 backref.
-    val repl = new RegexParser("""\\$1""").parseReplacement(numCaptureGroups = 1)
+    val repl = new RegexParser("""\\$1""").parseReplacement()
     assert(repl.parts.toList ===
       List(RegexChar('\\'), RegexChar('\\'), RegexChar('$'), RegexChar('1')))
   }
@@ -550,7 +550,7 @@ class RegularExpressionParserSuite extends AnyFunSuite {
   test("non-ASCII Unicode digit after `$` triggers GPU fallback") {
     for (rep <- Seq("$٢", "$१", "$۱")) {
       val e = intercept[RegexUnsupportedException] {
-        new RegexParser(rep).parseReplacement(numCaptureGroups = 4)
+        new RegexParser(rep).parseReplacement()
       }
       assert(e.getMessage.startsWith("Illegal group reference"),
         s"unexpected message for replacement '$rep': ${e.getMessage}")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
@@ -129,9 +129,8 @@ class RegularExpressionSuite extends SparkQueryCompareTestSuite {
       frame.selectExpr("regexp_replace(strings,'\\(foo\\)','D')")
   }
 
-  // #14856 / revans2: anchored alternation with a backref. With the old (\r\n)? workaround the
-  // synthetic group shifted (E) to group 2, so [$1] referenced the wrong group; once the
-  // workaround is dropped (cudf #22763) (E) stays group 1 and GPU must match CPU here.
+  // #14856 / revans2: anchored alternation with a backref. The line-anchor rewrite must not
+  // change Java-visible capture numbering, so (E) remains group 1 and GPU must match CPU here.
   testSparkResultsAreEqual("regexp_replace anchored alternation backref T$|(E)",
     spark => {
       import spark.implicits._

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -294,22 +294,31 @@ class RegExpUtilsSuite extends AnyFunSuite {
     }
   }
 
-  test("line-anchor `$` no longer injects a synthetic capture group or generated backref " +
-      "(#15006, cuDF #22763)") {
+  test("issue-15060: replacement conversion only resolves raw user backrefs") {
+    val open = "$" + "{"
+    val raw = GpuRegExpUtils.backrefConversion("$1", 1)
+    val alreadyBraced = GpuRegExpUtils.backrefConversion(open + "1}", 1)
+
+    assert(raw._1)
+    assert(raw._2 == open + "1}")
+    assert(!alreadyBraced._1)
+    assert(alreadyBraced._2 == open + "1}")
+  }
+
+  test("issue-15060: line-anchor replacement has no generated backref state") {
     // cuDF #22763 makes EXT_NEWLINE treat `\r\n` as a single line terminator for `$`, so the
-    // transpiler emits a bare `$` instead of the old synthetic `(\r\n)?$` capture group. With no
-    // synthetic group there is no internally-generated backref appended to the replacement, and a
-    // user pattern ending in `$` no longer shifts backref numbering: user `$N` parses against the
-    // real user group count (Java spec).
+    // transpiler emits a bare `$`. Replacement parsing therefore preserves only the user's raw
+    // `$N` tokens, and conversion resolves them once against the Java-visible group count.
     val open = "$" + "{"
     val userPattern = "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$"
     val userNumCaptureGroups =
       java.util.regex.Pattern.compile(userPattern).matcher("").groupCount()
     assert(userNumCaptureGroups == 12)
 
-    // user replacement `$123$2` -> `$12` + literal `3` + `$2`, with no trailing generated group.
+    // user replacement `$123$2` -> `$12` + literal `3` + `$2`, unchanged by transpilation.
     val (_, repl1) = new CudfRegexTranspiler(RegexReplaceMode)
       .getTranspiledAST(userPattern, None, Some("$123$2"))
+    assert(repl1.get.parts.forall(_.isInstanceOf[RegexChar]))
     val (has1, conv1) =
       GpuRegExpUtils.backrefConversion(repl1.get.toRegexString, userNumCaptureGroups)
     assert(has1)


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +23 lines** (fix-line coverage, Spark 3.3; `RegexParser` +21, `stringFunctions` +2, `GpuRegExpReplaceMeta` +0)

Closes #15060
Contributes to #14733

## What this fixes

Removes replacement-side line-anchor backref machinery that became unreachable after #15023 dropped the synthetic `(\r\n)?$` capture group:

- removes `RegexBackref` and `RegexReplacement` capture-group state/mutation helpers;
- stops threading replacement state through the recursive regex rewrite pipeline;
- removes the unreachable already-braced `${N}` pass-through in `backrefConversion`;
- preserves the existing control-flow drops after `$` for supported negated character classes.

User-authored `$N` handling remains centralized in `GpuRegExpUtils.backrefConversion`, using the Java pattern's real group count.

## Approach

No deviation from the issue scope. Current replacement parsing emits raw `RegexChar('$')` plus digit nodes, so the former typed backref node has no producer. The cleanup removes that dead planning-time state instead of adding a downstream workaround.

## Whole-system design assessment

Disposition: `ALIGNED_REFACTOR`

`RegexParser.parseReplacement` validates and preserves raw user `$N` tokens. `GpuRegExpReplaceMeta` computes the user-visible Java capture-group count, and `GpuRegExpUtils.backrefConversion` is the single boundary that resolves greedy-with-backoff semantics and emits cuDF `${N}` syntax. Keeping generated-backref AST state in the rewrite layer would duplicate ownership of that invariant.

Open PR #15478 refactors quantifier parsing in the same parser file but does not use or replace these dead backref symbols. The changes are semantically independent; because both touch `RegexParser.scala`, whichever PR lands second may require a textual rebase.

## Tests added

- Scala unit: `RegExpUtilsSuite` -> `issue-15060: replacement conversion only resolves raw user backrefs`; `issue-15060: line-anchor replacement has no generated backref state`
- Python IT: extended existing `test_re_replace_anchors` with a `$1`/`$0` anchored replacement case

## Local validation

Scala suite:

```text
Tests: succeeded 188, failed 0, canceled 8, ignored 0, pending 0
```

Python IT:

```text
5 passed, 89 deselected, 2 warnings in 8.36s
```

End-to-end reproduction on the patched dist JAR:

```text
RAPIDS Enabled = YES
Plugins Loaded = YES
GPU_PLAN_CONFIRMED=true
CPU_GPU_PARITY=true
```

## Performance impact

Cold-path cleanup only. It removes an unused AST node, replacement-side state, a dead generated-backref branch, and a recursively threaded option. It adds no per-row work, GPU kernel, device allocation, host/device copy, JNI call, or regex program operation; planning-time allocation and branching are slightly reduced.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
