### PR TITLE
[fast-ut] [reduced-it] [SkipRecovery] Narrow JSON array overflow xfails [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -1549,8 +1549,30 @@ def test_from_json_string_structs(std_input_path, input_file):
         lambda spark : read_json_as_text(spark, std_input_path + '/' + input_file, "json").select(f.col('json'), f.from_json(f.col('json'), schema)),
         conf =_enable_json_to_structs_conf)
 
-@pytest.mark.parametrize('dt', [DecimalType(38,0), DecimalType(10,2)], ids=idfn)
-@pytest.mark.parametrize('input_file', [
+_JSON_DEC_ARRAY_OVERFLOW_XFAILS = {
+    "int_array_formatted.json": pytest.mark.xfail(
+        reason='https://github.com/NVIDIA/spark-rapids/issues/10573'),
+    "int_mixed_array_struct_formatted.json": pytest.mark.xfail(
+        reason='https://github.com/NVIDIA/spark-rapids/issues/11491')
+}
+
+
+def _json_dec_array_params(input_files, overflow_xfails):
+    decimal_types = [DecimalType(38, 0), DecimalType(10, 2)]
+    return [
+        pytest.param(
+            input_file,
+            dt,
+            marks=[overflow_xfails[input_file]]
+                if dt == DecimalType(10, 2) and input_file in overflow_xfails
+                else [],
+            id=f"{input_file}-{idfn(dt)}")
+        for input_file in input_files
+        for dt in decimal_types
+    ]
+
+
+_JSON_DEC_ARRAY_SCAN_PARAMS = _json_dec_array_params([
     "int_formatted.json",
     "float_formatted.json",
     "sci_formatted.json",
@@ -1560,17 +1582,20 @@ def test_from_json_string_structs(std_input_path, input_file):
     "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json",
-    pytest.param("int_array_formatted.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10573')), # This does not fail on 38,0
+    "int_array_formatted.json",
     "int_struct_formatted.json",
     "int_struct_formatted_problematic_rows.json",
-    pytest.param("int_mixed_array_struct_formatted.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11491')),
+    "int_mixed_array_struct_formatted.json",
     "bad_whitespace.json",
     "escaped_strings.json",
     "repeated_columns.json",
     "mixed_objects.json",
     "timestamp_formatted_strings.json",
     "timestamp_tz_formatted_strings.json",
-    "scan_emtpy_lines.json"])
+    "scan_emtpy_lines.json"], _JSON_DEC_ARRAY_OVERFLOW_XFAILS)
+
+
+@pytest.mark.parametrize('input_file,dt', _JSON_DEC_ARRAY_SCAN_PARAMS)
 @pytest.mark.parametrize('read_func', [read_json_df]) # we have done so many tests already that we don't need both read func. They are the same
 def test_scan_json_dec_arrays(std_input_path, read_func, spark_tmp_table_factory, input_file, dt):
     assert_gpu_and_cpu_are_equal_collect(
@@ -1579,8 +1604,7 @@ def test_scan_json_dec_arrays(std_input_path, read_func, spark_tmp_table_factory
         spark_tmp_table_factory),
         conf=_enable_all_types_json_scan_conf)
 
-@pytest.mark.parametrize('dt', [DecimalType(38,0), DecimalType(10,2)], ids=idfn)
-@pytest.mark.parametrize('input_file', [
+_JSON_DEC_ARRAY_FROM_JSON_PARAMS = _json_dec_array_params([
     "int_formatted.json",
     "float_formatted.json",
     "sci_formatted.json",
@@ -1590,17 +1614,20 @@ def test_scan_json_dec_arrays(std_input_path, read_func, spark_tmp_table_factory
     "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json",
-    pytest.param("int_array_formatted.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10573')), # This does not fail on 38,0
+    "int_array_formatted.json",
     "int_struct_formatted.json",
     "int_struct_formatted_problematic_rows.json",
-    pytest.param("int_mixed_array_struct_formatted.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11491')),
+    "int_mixed_array_struct_formatted.json",
     "bad_whitespace.json",
     "escaped_strings.json",
     "nested_escaped_strings.json",
     "repeated_columns.json",
     "mixed_objects.json",
     "timestamp_formatted_strings.json",
-    "timestamp_tz_formatted_strings.json"])
+    "timestamp_tz_formatted_strings.json"], _JSON_DEC_ARRAY_OVERFLOW_XFAILS)
+
+
+@pytest.mark.parametrize('input_file,dt', _JSON_DEC_ARRAY_FROM_JSON_PARAMS)
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
 def test_from_json_dec_arrays(std_input_path, input_file, dt):
     schema = StructType([StructField("data", ArrayType(dt))])


### PR DESCRIPTION
**JaCoCo sql-plugin line coverage: +0 lines** (shim350 nightly b23, anchor 01ad3b33; recovered JSON Decimal(38,0) paths were already covered)

## Summary

- pair each decimal JSON input with its decimal type so xfail markers can be applied at the exact parameter boundary
- enable the scan and `from_json` `DecimalType(38, 0)` controls for both affected input files
- retain the `DecimalType(10, 2)` and Long overflow xfails because the CPU/GPU correctness divergence still reproduces

Contributes to #10573
Contributes to #11491

The two issues share the same root behavior: Spark invalidates the whole array when a numeric element overflows, while the GPU path currently nulls only the overflowing element. This PR narrows over-broad decimal markers; it does not claim to fix or close that production defect.

## Validation

- Spark 3.3 build: `BUILD SUCCESS`; 13/13 reactor modules; 05:33
- Spark 3.3 focused connected matrix: `4 passed, 8 xfailed, 1023 deselected, 2 warnings in 11.94s`
- Spark 3.3 four affected functions: `113 passed, 8 xfailed, 914 deselected, 2 warnings in 27.97s`
- Spark 3.3 complete `json_matrix_test.py`: `959 passed, 76 xfailed, 44 warnings in 167.69s`
- Spark 4.0 build: `BUILD SUCCESS`; 11/11 reactor modules; 04:25
- Spark 4.0 final focused connected matrix: `4 passed, 8 xfailed, 1023 deselected, 2 warnings in 11.95s`
- Spark 4.0 four affected functions: `113 passed, 8 xfailed, 914 deselected, 2 warnings in 28.32s`
- intended GPU plans observed: `GpuScan json` for scan and `gpujsontostructs` for `from_json`
- reduced-IT collect preserved all 121 nodes in the four affected functions, including all 12 connected risk nodes
- final exemption scan: `errors=[]`; all eight connected issue markers retained with stable IDs
- NT local review: six valid-scope reviews, zero final actionable findings
- static checks: `git diff --check` and `python3 -m py_compile` passed

The current Maven matrix rejects `buildver=411` before compilation; Spark 4.0/Scala 2.13 was used as the supported newer-runtime representative.

## Coverage provenance

Measured against shim350 nightly b23 (2026-08-18), anchor `01ad3b33ff93c3a069aec12caad5dedac39eca7c`. Baseline and merged coverage were both 56,475/69,552 lines; the CSVs were byte-identical and there was no `MemoryCheckerImpl` adjustment. The exact 12-node coverage run completed with 4 passed and 8 expected xfails.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
