### PR TITLE
Avoid oversized Hadoop vectored-read buffer allocations

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/hadoop/HadoopInputFile.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/hadoop/HadoopInputFile.java
@@ -87,7 +87,19 @@ public class HadoopInputFile implements RapidsInputFile {
         if (copyRanges.isEmpty()) {
             return;
         }
-        byte[] copyBuffer = new byte[copyBufferSize];
+        byte[] copyBuffer = new byte[getCopyBufferAllocationSize(copyRanges, copyBufferSize)];
         RapidsInputFile.readVectoredUsingCopyBuffer(this, output, copyRanges, copyBuffer);
+    }
+
+    static int getCopyBufferAllocationSize(
+            List<RapidsInputFile.CopyRange> copyRanges, int copyBufferSize) {
+        long maxRangeLength = 0;
+        for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+            maxRangeLength = Math.max(maxRangeLength, copyRange.getLength());
+            if (maxRangeLength >= copyBufferSize) {
+                return copyBufferSize;
+            }
+        }
+        return (int) maxRangeLength;
     }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/fileio/hadoop/HadoopInputFileSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/fileio/hadoop/HadoopInputFileSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.fileio.hadoop
+
+import java.util.{Arrays, Collections}
+
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile.CopyRange
+import org.scalatest.funsuite.AnyFunSuite
+
+class HadoopInputFileSuite extends AnyFunSuite {
+  test("copy buffer allocation is capped by the largest range") {
+    val allocationSize = HadoopInputFile.getCopyBufferAllocationSize(
+      Arrays.asList(new CopyRange(0, 1024, 0), new CopyRange(4096, 2048, 1024)),
+      8 * 1024 * 1024)
+
+    assertResult(2048)(allocationSize)
+  }
+
+  test("configured copy buffer size still limits large ranges") {
+    val allocationSize = HadoopInputFile.getCopyBufferAllocationSize(
+      Collections.singletonList(new CopyRange(0, 16 * 1024 * 1024, 0)),
+      8 * 1024 * 1024)
+
+    assertResult(8 * 1024 * 1024)(allocationSize)
+  }
+}


### PR DESCRIPTION
Fixes #15707.

### Description

`HadoopInputFile.readVectored` currently allocates a new byte array at the full configured `parquet.read.allocation.size` for every call. The default is 8 MiB, even when every requested range is much smaller. This creates substantial short-lived heap allocation for local and small-file Parquet scans.

This change caps the temporary copy-buffer allocation at the largest requested range while preserving the configured buffer size as the upper bound. Large ranges therefore retain the existing 8 MiB chunking behavior needed by remote Hadoop filesystems, while small ranges no longer allocate unused buffer capacity. There are no configuration or user-facing behavior changes.

Unit tests cover both sides of the bound:

- ranges smaller than the configured buffer allocate only the largest range size;
- ranges larger than the configured buffer remain capped at the configured size.

#### Performance

Both benchmarks used Spark 3.5.2 in `local[*]` mode on the local `file:` filesystem. They held `parquet.read.allocation.size` at 8 MiB and switched only between the uncapped and capped allocation implementations within the same JVM. Runs were warmed up, order was interleaved, and each scan verified the decoded byte count.

| Dataset | Uncapped mean | Capped mean | Effect |
|---|---:|---:|---:|
| 32 files, approximately 16 MiB each (513.3 MiB total) | 0.470531 s | 0.452702 s | 3.8% lower elapsed time |
| 1,024 files, approximately 516 KiB each (515.6 MiB total) | 1.307163 s | 0.507419 s | 61.18% lower elapsed time; 2.576x speedup |

For the 32-file case, 15 of 20 pairs favored the cap, with a paired mean improvement of 17.829 ms (`t = 3.195`). For the small-file stress case, all 12 pairs favored the cap, with a paired mean improvement of 799.744 ms (`t = 90.51`). Spark combined the 1,024 small files into 18 scan tasks, so the larger improvement is not due to creating one Spark task per file.

JFR on the 32-file case also showed allocation at this call site falling from 4.01 GiB to 2.01 GiB across eight scans. Nsight Systems showed identical primary GPU operation counts, indicating that the improvement comes from avoiding oversized CPU-side allocations rather than reducing GPU work.

#### S3A validation

To check the impact on remote Hadoop filesystems, NDS `query28` was run against the SF3000 decimal Parquet dataset on S3A using Spark 3.5.2, one `c7i.4xlarge` driver, and six `g6.4xlarge` workers. The RAPIDS file cache and PerfIO S3 reader were disabled. Each pair used the same cluster and JAR and changed only whether the copy buffer was capped.

| Pair | Uncapped | Capped | Capped delta |
|---|---:|---:|---:|
| 1 | 82.317 s | 84.069 s | +2.13% |
| 2 | 82.266 s | 82.624 s | +0.44% |
| 3 | 79.319 s | 79.630 s | +0.39% |
| Mean | 81.301 s | 82.108 s | +0.99% |
| Median | 82.266 s | 82.624 s | +0.44% |

All six runs processed the same 301.7 GB of input across 2,418 tasks and 10,944 logical file reads, with no failed task attempts. The mean paired delta was +807 ms, with a 95% paired confidence interval of approximately -1.23 s to +2.84 s. Scan-time differences were not directionally stable across pairs, so the experiment did not identify a statistically reliable S3A regression. A small approximately 0.4% to 1.0% effect cannot be distinguished from cluster and S3 variability with three pairs.

Validation:

- `mvn clean install -Dbuildver=352 -DskipTests`
- `HadoopInputFileSuite`: 2 tests passed
- interleaved local Parquet performance A/B described above

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
