### PR TITLE
[FEA] Support dynamic expressions in IN [fast-ut] [databricks]

### DIFF
--- a/docs/additional-functionality/advanced_configs.md
+++ b/docs/additional-functionality/advanced_configs.md
@@ -294,7 +294,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.Hour"></a>spark.rapids.sql.expression.Hour|`hour`|Returns the hour component of the string/timestamp|true|None|
 <a name="sql.expression.Hypot"></a>spark.rapids.sql.expression.Hypot|`hypot`|Pythagorean addition (Hypotenuse) of real numbers|true|None|
 <a name="sql.expression.If"></a>spark.rapids.sql.expression.If|`if`|IF expression|true|None|
-<a name="sql.expression.In"></a>spark.rapids.sql.expression.In|`in`|IN operator|true|None|
+<a name="sql.expression.In"></a>spark.rapids.sql.expression.In|`in`|IN operator|true|Non-literal list expressions must be deterministic and side-effect-free|
 <a name="sql.expression.InSet"></a>spark.rapids.sql.expression.InSet| |INSET operator|true|None|
 <a name="sql.expression.InitCap"></a>spark.rapids.sql.expression.InitCap|`initcap`|Returns str with the first letter of each word in uppercase. All other letters are in lowercase|true|This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.|
 <a name="sql.expression.InputFileBlockLength"></a>spark.rapids.sql.expression.InputFileBlockLength|`input_file_block_length`|Returns the length of the block being read, or -1 if not available|true|None|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -9518,17 +9518,17 @@ are limited.
 </tr>
 <tr>
 <td>list</td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP;<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
-<td><em>PS<br/>Literal value only</em></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -9492,7 +9492,7 @@ are limited.
 <td rowSpan="3">In</td>
 <td rowSpan="3">`in`</td>
 <td rowSpan="3">IN operator</td>
-<td rowSpan="3">None</td>
+<td rowSpan="3">Non-literal list expressions must be deterministic and side-effect-free</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td>S</td>

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from decimal import Decimal
+
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, \
+    assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
 from conftest import is_not_utc
 from data_gen import *
 from spark_session import with_cpu_session, is_before_spark_313
@@ -328,6 +331,85 @@ def test_in(data_gen):
     scalars = with_cpu_session(lambda spark: list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen))))
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)))
+
+@pytest.mark.parametrize('data_type, rows', [
+    ('int', [
+        (1, 1, 7),
+        (2, 1, 2),
+        (3, None, 4),
+        (3, None, None),
+        (None, 1, 2),
+    ]),
+    ('float', [
+        (float('nan'), 1.0, float('nan')),
+        (1.0, float('nan'), 2.0),
+        (3.0, None, 4.0),
+        (None, 1.0, 2.0),
+    ]),
+    ('double', [
+        (float('nan'), float('nan'), 1.0),
+        (2.0, 1.0, 2.0),
+        (3.0, None, 4.0),
+        (None, 1.0, 2.0),
+    ]),
+    ('decimal(10, 2)', [
+        (Decimal('1.00'), Decimal('1.00'), Decimal('7.00')),
+        (Decimal('2.00'), Decimal('1.00'), Decimal('2.00')),
+        (Decimal('3.00'), None, Decimal('4.00')),
+        (None, Decimal('1.00'), Decimal('2.00')),
+    ]),
+], ids=['int', 'float', 'double', 'decimal'])
+def test_dynamic_in(data_type, rows):
+    def do_it(spark):
+        return spark.createDataFrame(rows, f'a {data_type}, b {data_type}, c {data_type}') \
+            .selectExpr(
+                'a IN (b) AS single_result',
+                'a IN (b, c) AS dynamic_result',
+                'a IN (-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 1, b, NULL, c) '
+                'AS mixed_result')
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuIn')
+
+
+def test_dynamic_in_mixed_ast_support():
+    def do_it(spark):
+        return spark.createDataFrame([
+            (1, 1, 7, 1.0, 1.0, 7.0),
+            (2, 1, 2, float('nan'), 1.0, float('nan')),
+            (3, None, 4, 3.0, None, 4.0),
+            (None, 1, 2, None, 1.0, 2.0),
+        ], 'a int, b int, c int, x float, y float, z float').selectExpr(
+            'a IN (b, c) AS ast_result',
+            'x IN (y, z) AS regular_result')
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuIn')
+
+
+@allow_non_gpu('ProjectExec')
+def test_nondeterministic_dynamic_in_fallback():
+    def do_it(spark):
+        return spark.createDataFrame([(1.0, 2.0)], 'a double, b double') \
+            .selectExpr('a IN (b, rand(1)) AS result')
+
+    assert_gpu_fallback_collect(
+        do_it,
+        'ProjectExec')
+
+
+@allow_non_gpu('In', 'Cast')
+def test_ansi_side_effecting_dynamic_in_fallback():
+    def do_it(spark):
+        return spark.createDataFrame([(1, 1, 'invalid')], 'a int, b int, c string') \
+            .selectExpr('a IN (b, CAST(c AS INT)) AS result')
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuCpuBridgeExpression',
+        conf={'spark.sql.ansi.enabled': 'true'})
 
 # We avoid testing inset with NaN in Spark < 3.1.3 since it has issue with NaN comparisons.
 # See https://github.com/NVIDIA/spark-rapids/issues/9687.

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -374,6 +374,8 @@ def test_dynamic_in(data_type, rows):
 
 
 def test_dynamic_in_mixed_ast_support():
+    # Integral equality can be fused into the AST, while floating-point equality must be
+    # materialized first to preserve Spark's NaN semantics.
     def do_it(spark):
         return spark.createDataFrame([
             (1, 1, 7, 1.0, 1.0, 7.0),
@@ -391,6 +393,8 @@ def test_dynamic_in_mixed_ast_support():
 
 @allow_non_gpu('ProjectExec')
 def test_nondeterministic_dynamic_in_fallback():
+    # GpuIn groups literals and eagerly projects dynamic candidates, so it cannot preserve
+    # Spark's evaluation order for nondeterministic expressions.
     def do_it(spark):
         return spark.createDataFrame([(1.0, 2.0)], 'a double, b double') \
             .selectExpr('a IN (b, rand(1)) AS result')

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -394,9 +394,10 @@ def test_dynamic_in_mixed_ast_support():
 
 def test_dynamic_in_allows_nondeterministic_value():
     # The value is evaluated once before the list, so its nondeterminism does not affect ordering.
+    # Keep the list side-effect-free even when ANSI mode is enabled by default.
     def do_it(spark):
         return spark.range(10).selectExpr(
-            'rand(1) IN (id + 2, id + 3) AS result')
+            'rand(1) IN (CAST(id AS DOUBLE), CAST(id AS FLOAT)) AS result')
 
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         do_it,

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -479,6 +479,20 @@ def test_ansi_decimal_side_effecting_dynamic_in_fallback():
         do_it,
         conf={'spark.sql.ansi.enabled': 'true'})
 
+
+@allow_non_gpu('ProjectExec', 'In', 'Multiply', 'Cast')
+def test_ansi_decimal_multiply_side_effecting_dynamic_in_fallback():
+    def do_it(spark):
+        # Spark stops after b matches; eager evaluation of c * d would overflow in ANSI mode.
+        rows = [(Decimal('1'), Decimal('1'), Decimal('9' * 38), Decimal('9'))]
+        schema = 'a decimal(38, 0), b decimal(38, 0), c decimal(38, 0), d decimal(38, 0)'
+        return spark.createDataFrame(rows, schema).selectExpr(
+            'a IN (b, c * d) AS result')
+
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it,
+        conf={'spark.sql.ansi.enabled': 'true'})
+
 # We avoid testing inset with NaN in Spark < 3.1.3 since it has issue with NaN comparisons.
 # See https://github.com/NVIDIA/spark-rapids/issues/9687.
 test_inset_data_gen = [gen for gen in eq_gens_with_decimal_gen if gen != float_gen if gen != double_gen] + \

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -392,6 +392,28 @@ def test_dynamic_in_mixed_ast_support():
         exist_classes='GpuIn')
 
 
+def test_dynamic_in_allows_nondeterministic_value():
+    # The value is evaluated once before the list, so its nondeterminism does not affect ordering.
+    def do_it(spark):
+        return spark.range(10).selectExpr(
+            'rand(1) IN (id + 2, id + 3) AS result')
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuIn')
+
+
+def test_dynamic_in_allows_side_effecting_value():
+    def do_it(spark):
+        return spark.createDataFrame([(1, 1, '1')], 'a int, b int, c string') \
+            .selectExpr('CAST(c AS INT) IN (b, a) AS result')
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuIn',
+        conf={'spark.sql.ansi.enabled': 'true'})
+
+
 @allow_non_gpu('ProjectExec')
 def test_nondeterministic_dynamic_in_fallback():
     # GpuIn groups literals and eagerly projects dynamic candidates, so it cannot preserve
@@ -414,6 +436,33 @@ def test_ansi_side_effecting_dynamic_in_fallback():
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         do_it,
         exist_classes='GpuCpuBridgeExpression',
+        conf={'spark.sql.ansi.enabled': 'true'})
+
+
+@allow_non_gpu('In', 'Cast')
+def test_bridge_only_dynamic_in_candidate_fallback():
+    def do_it(spark):
+        return spark.createDataFrame([(1, 1, 'invalid')], 'a int, b int, c string') \
+            .selectExpr('a IN (b, CAST(c AS INT)) AS result')
+
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it,
+        conf={
+            'spark.sql.ansi.enabled': 'true',
+            'spark.rapids.sql.expression.Cast': 'false'
+        })
+
+
+@allow_non_gpu('ProjectExec', 'In', 'Divide', 'Cast')
+def test_ansi_decimal_side_effecting_dynamic_in_fallback():
+    def do_it(spark):
+        rows = [(Decimal('1.00'), Decimal('1.00'), Decimal('1.00'), Decimal('0.00'))]
+        schema = 'a decimal(10, 2), b decimal(10, 2), c decimal(10, 2), d decimal(10, 2)'
+        return spark.createDataFrame(rows, schema).selectExpr(
+            'a IN (b, c / d) AS result')
+
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it,
         conf={'spark.sql.ansi.enabled': 'true'})
 
 # We avoid testing inset with NaN in Spark < 3.1.3 since it has issue with NaN comparisons.

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -348,6 +348,8 @@ def test_in(data_gen):
     ]),
     ('double', [
         (float('nan'), float('nan'), 1.0),
+        # In returns NULL when NaN misses every candidate but the list contains NULL.
+        (float('nan'), 2.0, 3.0),
         (2.0, 1.0, 2.0),
         (3.0, None, 4.0),
         (None, 1.0, 2.0),
@@ -365,12 +367,11 @@ def test_dynamic_in(data_type, rows):
             .selectExpr(
                 'a IN (b) AS single_result',
                 'a IN (b, c) AS dynamic_result',
+                'a IN (NULL, 1) AS literal_result',
                 'a IN (-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 1, b, NULL, c) '
                 'AS mixed_result')
 
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
-        do_it,
-        exist_classes='GpuIn')
+    assert_gpu_and_cpu_are_equal_collect(do_it)
 
 
 def test_dynamic_in_mixed_ast_support():

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -427,6 +427,20 @@ def test_nondeterministic_dynamic_in_fallback():
         'ProjectExec')
 
 
+@allow_non_gpu('In', 'Add')
+def test_large_dynamic_in_fallback():
+    def do_it(spark):
+        # One candidate past the stack-safety limit must remain on CPU.
+        candidate_count = 257
+        candidates = ', '.join(f'id + {i}' for i in range(1, candidate_count + 1))
+        return spark.range(1).selectExpr(f'id IN ({candidates}) AS result')
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuCpuBridgeExpression',
+        non_exist_classes='GpuIn')
+
+
 @allow_non_gpu('In', 'Cast')
 def test_ansi_side_effecting_dynamic_in_fallback():
     def do_it(spark):

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -459,8 +459,10 @@ def test_bridge_only_dynamic_in_candidate_fallback():
         return spark.createDataFrame([(1, 1, 'invalid')], 'a int, b int, c string') \
             .selectExpr('a IN (b, CAST(c AS INT)) AS result')
 
-    assert_gpu_and_cpu_are_equal_collect(
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
         do_it,
+        exist_classes='GpuCpuBridgeExpression',
+        non_exist_classes='GpuIn',
         conf={
             'spark.sql.ansi.enabled': 'true',
             'spark.rapids.sql.expression.Cast': 'false'

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -208,6 +208,7 @@ def test_array_heterogeneous_elementwise_hof_mixed_project():
             'transform(a, item -> item + b) as plus_b',
             'transform(a, item -> item + c) as plus_c',
             'filter(a, item -> item is not null and item + b >= c) as filtered_b_ge_c',
+            'filter(a, item -> item IN (1, b)) as in_one_or_b',
             'exists(a, item -> item is not null and item + c < b) as has_c_less_b')
 
     assert_gpu_and_cpu_are_equal_collect(do_it)

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -38,25 +38,6 @@ def test_tiered_project_with_complex_transform():
     assert_gpu_and_cpu_are_equal_collect(do_project, conf=confs)
 
 
-def test_array_filter_with_dynamic_in():
-    def do_it(spark):
-        return spark.createDataFrame(
-            [('a|b|c',), ('a|b|c|d',), ('a',), (None,)],
-            'input_text string').selectExpr("""
-                filter(
-                  arrays_zip(
-                    sequence(1, size(split(input_text, '[|]'))),
-                    split(input_text, '[|]')),
-                  x -> x["0"] IN (
-                    1,
-                    2,
-                    3,
-                    size(split(input_text, '[|]')))) AS result
-                """)
-
-    assert_cpu_and_gpu_are_equal_collect_with_capture(do_it, exist_classes='GpuIn')
-
-
 @pytest.mark.parametrize('data_gen, lambda_sql, init_sql', [
     (ArrayGen(IntegerGen(min_val=-100, max_val=100), max_length=8),
         '(acc, x) -> acc + CAST(x as BIGINT)', '0L'),

--- a/integration_tests/src/main/python/higher_order_functions_test.py
+++ b/integration_tests/src/main/python/higher_order_functions_test.py
@@ -38,6 +38,25 @@ def test_tiered_project_with_complex_transform():
     assert_gpu_and_cpu_are_equal_collect(do_project, conf=confs)
 
 
+def test_array_filter_with_dynamic_in():
+    def do_it(spark):
+        return spark.createDataFrame(
+            [('a|b|c',), ('a|b|c|d',), ('a',), (None,)],
+            'input_text string').selectExpr("""
+                filter(
+                  arrays_zip(
+                    sequence(1, size(split(input_text, '[|]'))),
+                    split(input_text, '[|]')),
+                  x -> x["0"] IN (
+                    1,
+                    2,
+                    3,
+                    size(split(input_text, '[|]')))) AS result
+                """)
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(do_it, exist_classes='GpuIn')
+
+
 @pytest.mark.parametrize('data_gen, lambda_sql, init_sql', [
     (ArrayGen(IntegerGen(min_val=-100, max_val=100), max_length=8),
         '(acc, x) -> acc + CAST(x as BIGINT)', '0L'),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,12 +114,12 @@ object GpuCanonicalize {
     case GpuNot(GpuLessThanOrEqual(l, r)) => GpuGreaterThan(l, r)
 
     // order the list in the In operator
-    case GpuInSet(value, list) if list.length > 1 =>
+    case GpuInSet(value, list, useInSetSemantics) if list.length > 1 =>
       val orderedList = list.sortBy {
         case null => 0
         case nonNull => nonNull.hashCode()
       }
-      GpuInSet(value, orderedList)
+      GpuInSet(value, orderedList, useInSetSemantics)
 
     case g: GpuGreatest =>
       val newChildren = orderCommutative(g, { case GpuGreatest(children) => children })

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -42,6 +42,11 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
  *  This is essentially a copy of the Spark `Canonicalize` class but updated for GPU operators
  */
 object GpuCanonicalize {
+
+  private def orderLiteralValues(list: Seq[Any]): Seq[Any] = list.sortBy {
+    case null => 0
+    case nonNull => nonNull.hashCode()
+  }
   def execute(e: Expression): Expression = {
     expressionReorder(ignoreTimeZoneInCast(ignoreNamesTypes(e)))
   }
@@ -115,11 +120,11 @@ object GpuCanonicalize {
 
     // order the list in the In operator
     case GpuInSet(value, list, useInSetSemantics) if list.length > 1 =>
-      val orderedList = list.sortBy {
-        case null => 0
-        case nonNull => nonNull.hashCode()
-      }
-      GpuInSet(value, orderedList, useInSetSemantics)
+      GpuInSet(value, orderLiteralValues(list), useInSetSemantics)
+
+    case GpuIn(value, literals, dynamicList)
+        if literals.length + dynamicList.length > 1 =>
+      GpuIn(value, orderLiteralValues(literals), dynamicList.sortBy(_.hashCode()))
 
     case g: GpuGreatest =>
       val newChildren = orderCommutative(g, { case GpuGreatest(children) => children })

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
@@ -25,6 +25,11 @@ import org.apache.spark.sql.rapids.GpuEqualTo
 import org.apache.spark.sql.types.{BooleanType, DataType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+object GpuIn {
+  // The left-deep OR AST is stack-sensitive during both JVM conversion and native compilation.
+  private[rapids] val MAX_DYNAMIC_LIST_SIZE: Int = 256
+}
+
 case class GpuIn(value: Expression, literals: Seq[Any], dynamicList: Seq[Expression])
     extends GpuExpression with Predicate with ShimExpression {
   require(dynamicList.nonEmpty, "dynamic list should not be empty")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
@@ -37,6 +37,9 @@ case class GpuIn(value: Expression, literals: Seq[Any], dynamicList: Seq[Express
 
   private val resultCount = dynamicList.length + (if (literals.nonEmpty) 1 else 0)
 
+  // AST OR avoids materializing intermediate OR columns and benchmarks faster than chaining GpuOr.
+  // Fuse supported equalities too, but keep one dynamic comparison on GpuEqualTo to avoid AST
+  // compilation overhead.
   private val shouldFuseEqualities =
     TypeSig.comparisonAstTypes.isSupportedByPlugin(value.dataType) &&
       (literals.nonEmpty || dynamicList.length > 1)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
@@ -103,7 +103,8 @@ case class GpuIn(value: Expression, literals: Seq[Any], dynamicList: Seq[Express
     withResource(GpuProjectExec.project(batch, children)) { projected =>
       val valueColumn = projected.column(0).asInstanceOf[GpuColumnVector]
       val literalComparison = if (literals.nonEmpty) {
-        Some(closeOnExcept(GpuInSet(value, literals).doColumnar(valueColumn)) { result =>
+        Some(closeOnExcept(
+          GpuInSet(value, literals, useInSetSemantics = false).doColumnar(valueColumn)) { result =>
           GpuColumnVector.from(result, BooleanType)
         })
       } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuIn.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.shims.ShimExpression
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, NamedExpression, Predicate}
+import org.apache.spark.sql.rapids.GpuEqualTo
+import org.apache.spark.sql.types.{BooleanType, DataType}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+case class GpuIn(value: Expression, literals: Seq[Any], dynamicList: Seq[Expression])
+    extends GpuExpression with Predicate with ShimExpression {
+  require(dynamicList.nonEmpty, "dynamic list should not be empty")
+
+  override def children: Seq[Expression] = value +: dynamicList
+
+  override def nullable: Boolean = children.exists(_.nullable) || literals.contains(null)
+
+  override def dataType: DataType = BooleanType
+
+  private val resultCount = dynamicList.length + (if (literals.nonEmpty) 1 else 0)
+
+  private val shouldFuseEqualities =
+    TypeSig.comparisonAstTypes.isSupportedByPlugin(value.dataType) &&
+      (literals.nonEmpty || dynamicList.length > 1)
+
+  @transient private lazy val orAst = {
+    val references = (0 until resultCount).map { index =>
+      GpuBoundReference(index, BooleanType, nullable = true)(
+        NamedExpression.newExprId, s"in_$index")
+    }
+    val orExpression = references.tail.foldLeft(references.head: GpuExpression) {
+      case (left, right) => org.apache.spark.sql.rapids.GpuOr(left, right)
+    }
+    GpuProjectAstExpression(orExpression)
+  }
+
+  @transient private lazy val fusedAst = {
+    val valueIndex = if (literals.nonEmpty) 1 else 0
+    val valueReference = GpuBoundReference(valueIndex, value.dataType, value.nullable)(
+      NamedExpression.newExprId, "in_value")
+    val dynamicComparisons = dynamicList.indices.map { index =>
+      val candidate = dynamicList(index)
+      val candidateReference = GpuBoundReference(
+        valueIndex + index + 1, candidate.dataType, candidate.nullable)(
+        NamedExpression.newExprId, s"in_candidate_$index")
+      GpuEqualTo(valueReference, candidateReference)
+    }
+    val comparisons = if (literals.nonEmpty) {
+      val literalReference = GpuBoundReference(0, BooleanType, nullable)(
+        NamedExpression.newExprId, "in_literals")
+      literalReference +: dynamicComparisons
+    } else {
+      dynamicComparisons
+    }
+    val expression = comparisons.tail.foldLeft(comparisons.head: GpuExpression) {
+      case (left, right) => org.apache.spark.sql.rapids.GpuOr(left, right)
+    }
+    GpuProjectAstExpression(expression)
+  }
+
+  private def reduceComparisons(
+      comparisons: Seq[GpuColumnVector],
+      numRows: Int): GpuColumnVector = {
+    if (comparisons.length == 1) {
+      comparisons.head.incRefCount()
+    } else {
+      val comparisonBatch = new ColumnarBatch(comparisons.toArray, numRows)
+      orAst.columnarEval(comparisonBatch)
+    }
+  }
+
+  private def evaluateFusedAst(
+      projected: ColumnarBatch,
+      literalResult: Option[GpuColumnVector]): GpuColumnVector = {
+    val inputs = literalResult.toSeq ++
+      (0 until projected.numCols()).map(projected.column)
+    val astBatch = new ColumnarBatch(inputs.toArray, projected.numRows())
+    fusedAst.columnarEval(astBatch)
+  }
+
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(GpuProjectExec.project(batch, children)) { projected =>
+      val valueColumn = projected.column(0).asInstanceOf[GpuColumnVector]
+      val literalComparison = if (literals.nonEmpty) {
+        Some(closeOnExcept(GpuInSet(value, literals).doColumnar(valueColumn)) { result =>
+          GpuColumnVector.from(result, BooleanType)
+        })
+      } else {
+        None
+      }
+      withResource(literalComparison) { literalResult =>
+        if (shouldFuseEqualities) {
+          evaluateFusedAst(projected, literalResult)
+        } else {
+          withResource(dynamicList.indices.safeMap { index =>
+            val left = projected.column(0).asInstanceOf[GpuColumnVector]
+            val right = projected.column(index + 1).asInstanceOf[GpuColumnVector]
+            closeOnExcept(GpuEqualTo(value, dynamicList(index)).doColumnar(left, right)) { result =>
+              GpuColumnVector.from(result, BooleanType)
+            }
+          }) { dynamicComparisons =>
+            reduceComparisons(literalResult.toSeq ++ dynamicComparisons, batch.numRows())
+          }
+        }
+      }
+    }
+  }
+
+  private def listString: String = {
+    val literalExpressions = literals.map(Literal(_, value.dataType))
+    (literalExpressions ++ dynamicList).mkString(", ")
+  }
+
+  override def toString: String = s"$value IN ($listString)"
+
+  override def sql: String = {
+    val literalSql = literals.map(Literal(_, value.dataType).sql)
+    val dynamicSql = dynamicList.map(_.sql)
+    s"(${value.sql} IN (${(literalSql ++ dynamicSql).mkString(", ")}))"
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ import org.apache.spark.sql.types.{DoubleType, FloatType}
 
 case class GpuInSet(
     child: Expression,
-    list: Seq[Any]) extends GpuUnaryExpression with Predicate {
+    list: Seq[Any],
+    useInSetSemantics: Boolean = true) extends GpuUnaryExpression with Predicate {
   require(list != null, "list should not be null")
 
   @transient private[this] lazy val hasNull: Boolean = list.contains(null)
@@ -52,7 +53,8 @@ case class GpuInSet(
         val toReplaceFalseFlags = closeOnExcept(ret) { _ =>
           withResource(Scalar.fromBool(false)) { falseS =>
             val falseFlags = ret.equalTo(falseS)
-            if (checkNaN) {
+            // Spark InSet resolves an unmatched NaN before checking for NULL, unlike In.
+            if (checkNaN && useInSetSemantics) {
               withResource(falseFlags) { _ =>
                 withResource(haystack.getBase.isNotNan) { isNotNaNFlags =>
                   falseFlags.and(isNotNaNFlags)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2085,6 +2085,8 @@ object GpuOverrides extends Logging {
         private lazy val dynamicListItems = in.list.zip(childExprs.tail).filterNot {
           case (expression, _) => expression.isInstanceOf[Literal]
         }
+        private lazy val gpuDynamicExpressions =
+          dynamicListItems.map(_._2.convertToGpu())
 
         override def tagExprForGpu(): Unit = {
           if (!allListItemsAreLiterals) {
@@ -2098,7 +2100,7 @@ object GpuOverrides extends Logging {
               // CPU bridges are inserted after tagging, so verify the entire expression tree
               // before converting it to inspect side effects.
               willNotWorkOnGpu("dynamic IN list expressions must run entirely on GPU")
-            } else if (dynamicListItems.iterator.map(_._2.convertToGpu()).exists {
+            } else if (gpuDynamicExpressions.exists {
                   case gpuExpression: GpuExpression => gpuExpression.hasSideEffects
                   case _ => false
                 }) {
@@ -2115,8 +2117,7 @@ object GpuOverrides extends Logging {
               useInSetSemantics = false)
           } else {
             val literalValues = in.list.collect { case literal: Literal => literal.value }
-            val dynamicExpressions = dynamicListItems.map(_._2.convertToGpu())
-            GpuIn(gpuValue, literalValues, dynamicExpressions)
+            GpuIn(gpuValue, literalValues, gpuDynamicExpressions)
           }
         }
       }).note("Non-literal list expressions must be deterministic and side-effect-free"),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2078,11 +2078,37 @@ object GpuOverrides extends Logging {
         Seq(ParamCheck("value", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
           TypeSig.comparable)),
         Some(RepeatingParamCheck("list",
-          (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128).withAllLit(),
+          TypeSig.commonCudfTypes + TypeSig.DECIMAL_128,
           TypeSig.comparable))),
       (in, conf, p, r) => new ExprMeta[In](in, conf, p, r) {
-        override def convertToGpuImpl(): GpuExpression =
-          GpuInSet(childExprs.head.convertToGpu(), in.list.asInstanceOf[Seq[Literal]].map(_.value))
+        private val allListItemsAreLiterals = in.list.forall(_.isInstanceOf[Literal])
+
+        override def tagExprForGpu(): Unit = {
+          if (!allListItemsAreLiterals) {
+            if (!in.deterministic) {
+              willNotWorkOnGpu("dynamic IN expressions must be deterministic")
+            } else if (childExprs.forall(_.canExprTreeBeReplaced) &&
+                childExprs.iterator.map(_.convertToGpu()).exists {
+                  case gpuExpression: GpuExpression => gpuExpression.hasSideEffects
+                  case _ => false
+                }) {
+              willNotWorkOnGpu("dynamic IN expressions with side effects are not supported")
+            }
+          }
+        }
+
+        override def convertToGpuImpl(): GpuExpression = {
+          val gpuChildren = childExprs.map(_.convertToGpu())
+          if (allListItemsAreLiterals) {
+            GpuInSet(gpuChildren.head, in.list.asInstanceOf[Seq[Literal]].map(_.value))
+          } else {
+            val literalValues = in.list.collect { case literal: Literal => literal.value }
+            val dynamicExpressions = in.list.zip(gpuChildren.tail).collect {
+              case (expression, gpuExpression) if !expression.isInstanceOf[Literal] => gpuExpression
+            }
+            GpuIn(gpuChildren.head, literalValues, dynamicExpressions)
+          }
+        }
       }),
     expr[InSet](
       "INSET operator",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2082,32 +2082,35 @@ object GpuOverrides extends Logging {
           TypeSig.comparable))),
       (in, conf, p, r) => new ExprMeta[In](in, conf, p, r) {
         private val allListItemsAreLiterals = in.list.forall(_.isInstanceOf[Literal])
+        private lazy val dynamicListItems = in.list.zip(childExprs.tail).filterNot {
+          case (expression, _) => expression.isInstanceOf[Literal]
+        }
 
         override def tagExprForGpu(): Unit = {
           if (!allListItemsAreLiterals) {
-            if (!in.deterministic) {
-              willNotWorkOnGpu("dynamic IN expressions must be deterministic")
-            } else if (childExprs.forall(_.canExprTreeBeReplaced) &&
-                childExprs.iterator.map(_.convertToGpu()).exists {
+            if (!dynamicListItems.forall(_._1.deterministic)) {
+              willNotWorkOnGpu("dynamic IN list expressions must be deterministic")
+            } else if (!dynamicListItems.forall(_._2.canExprTreeBeReplaced)) {
+              willNotWorkOnGpu("dynamic IN list expressions must run entirely on GPU")
+            } else if (dynamicListItems.iterator.map(_._2.convertToGpu()).exists {
                   case gpuExpression: GpuExpression => gpuExpression.hasSideEffects
                   case _ => false
                 }) {
-              willNotWorkOnGpu("dynamic IN expressions with side effects are not supported")
+              willNotWorkOnGpu(
+                "dynamic IN list expressions with side effects are not supported")
             }
           }
         }
 
         override def convertToGpuImpl(): GpuExpression = {
-          val gpuChildren = childExprs.map(_.convertToGpu())
+          val gpuValue = childExprs.head.convertToGpu()
           if (allListItemsAreLiterals) {
-            GpuInSet(gpuChildren.head, in.list.asInstanceOf[Seq[Literal]].map(_.value),
+            GpuInSet(gpuValue, in.list.asInstanceOf[Seq[Literal]].map(_.value),
               useInSetSemantics = false)
           } else {
             val literalValues = in.list.collect { case literal: Literal => literal.value }
-            val dynamicExpressions = in.list.zip(gpuChildren.tail).collect {
-              case (expression, gpuExpression) if !expression.isInstanceOf[Literal] => gpuExpression
-            }
-            GpuIn(gpuChildren.head, literalValues, dynamicExpressions)
+            val dynamicExpressions = dynamicListItems.map(_._2.convertToGpu())
+            GpuIn(gpuValue, literalValues, dynamicExpressions)
           }
         }
       }).note("Non-literal list expressions must be deterministic and side-effect-free"),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2088,9 +2088,15 @@ object GpuOverrides extends Logging {
 
         override def tagExprForGpu(): Unit = {
           if (!allListItemsAreLiterals) {
-            if (!dynamicListItems.forall(_._1.deterministic)) {
+            if (dynamicListItems.length > GpuIn.MAX_DYNAMIC_LIST_SIZE) {
+              willNotWorkOnGpu(
+                s"dynamic IN lists with more than ${GpuIn.MAX_DYNAMIC_LIST_SIZE} " +
+                  "non-literal expressions are not supported")
+            } else if (!dynamicListItems.forall(_._1.deterministic)) {
               willNotWorkOnGpu("dynamic IN list expressions must be deterministic")
             } else if (!dynamicListItems.forall(_._2.canExprTreeBeReplaced)) {
+              // CPU bridges are inserted after tagging, so verify the entire expression tree
+              // before converting it to inspect side effects.
               willNotWorkOnGpu("dynamic IN list expressions must run entirely on GPU")
             } else if (dynamicListItems.iterator.map(_._2.convertToGpu()).exists {
                   case gpuExpression: GpuExpression => gpuExpression.hasSideEffects

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2100,7 +2100,8 @@ object GpuOverrides extends Logging {
         override def convertToGpuImpl(): GpuExpression = {
           val gpuChildren = childExprs.map(_.convertToGpu())
           if (allListItemsAreLiterals) {
-            GpuInSet(gpuChildren.head, in.list.asInstanceOf[Seq[Literal]].map(_.value))
+            GpuInSet(gpuChildren.head, in.list.asInstanceOf[Seq[Literal]].map(_.value),
+              useInSetSemantics = false)
           } else {
             val literalValues = in.list.collect { case literal: Literal => literal.value }
             val dynamicExpressions = in.list.zip(gpuChildren.tail).collect {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2109,7 +2109,7 @@ object GpuOverrides extends Logging {
             GpuIn(gpuChildren.head, literalValues, dynamicExpressions)
           }
         }
-      }),
+      }).note("Non-literal list expressions must be deterministic and side-effect-free"),
     expr[InSet](
       "INSET operator",
       ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -416,6 +416,8 @@ trait GpuDecimalMultiplyBase extends GpuExpression {
   def right: Expression
   def useLongMultiply: Boolean
 
+  override def hasSideEffects: Boolean = super.hasSideEffects || failOnError
+
   override def toString: String = s"($left * $right)"
 
   override def sql: String = s"(${left.sql} * ${right.sql})"
@@ -907,6 +909,9 @@ trait GpuDecimalDivideBase extends GpuExpression {
   def failOnError: Boolean
   def failOnDivideByZero: Boolean
   def integerDivide: Boolean
+
+  override def hasSideEffects: Boolean =
+    super.hasSideEffects || failOnError || failOnDivideByZero
 
   // For all decimal128 output we will use the long division version.
   protected lazy val useLongDivision: Boolean = decimalType.precision > Decimal.MAX_LONG_DIGITS

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 
 package org.apache.spark.sql.rapids
 
+import com.nvidia.spark.rapids.GpuIn
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal}
+import org.apache.spark.sql.types.IntegerType
 
 class CanonicalizeSuite extends AnyFunSuite {
   /* In the future, if we decide to implement the Spark 3.3 algorithm to perform canonicalization
@@ -33,5 +35,15 @@ class CanonicalizeSuite extends AnyFunSuite {
         assert(bc(GpuAdd($"a", $"b", true)(), Literal(10))
             .semanticEquals(bc(GpuAdd($"b", $"a", true)(), Literal(10))))
       })
+  }
+
+  test("GpuIn list order") {
+    val a = AttributeReference("a", IntegerType)()
+    val b = AttributeReference("b", IntegerType)()
+    val c = AttributeReference("c", IntegerType)()
+    val left = GpuIn(a, Seq(1, 2), Seq(b, c))
+    val right = GpuIn(a, Seq(2, 1), Seq(c, b))
+
+    assert(left.semanticEquals(right))
   }
 }

--- a/tools/generated_files/330/supportedExprs.csv
+++ b/tools/generated_files/330/supportedExprs.csv
@@ -296,9 +296,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/330/supportedExprs.csv
+++ b/tools/generated_files/330/supportedExprs.csv
@@ -297,7 +297,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/331/supportedExprs.csv
+++ b/tools/generated_files/331/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/331/supportedExprs.csv
+++ b/tools/generated_files/331/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/332/supportedExprs.csv
+++ b/tools/generated_files/332/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/332/supportedExprs.csv
+++ b/tools/generated_files/332/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/333/supportedExprs.csv
+++ b/tools/generated_files/333/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/333/supportedExprs.csv
+++ b/tools/generated_files/333/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/334/supportedExprs.csv
+++ b/tools/generated_files/334/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/334/supportedExprs.csv
+++ b/tools/generated_files/334/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/340/supportedExprs.csv
+++ b/tools/generated_files/340/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/340/supportedExprs.csv
+++ b/tools/generated_files/340/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/341/supportedExprs.csv
+++ b/tools/generated_files/341/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/341/supportedExprs.csv
+++ b/tools/generated_files/341/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/342/supportedExprs.csv
+++ b/tools/generated_files/342/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/342/supportedExprs.csv
+++ b/tools/generated_files/342/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/343/supportedExprs.csv
+++ b/tools/generated_files/343/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/343/supportedExprs.csv
+++ b/tools/generated_files/343/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/344/supportedExprs.csv
+++ b/tools/generated_files/344/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/344/supportedExprs.csv
+++ b/tools/generated_files/344/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/350/supportedExprs.csv
+++ b/tools/generated_files/350/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/350/supportedExprs.csv
+++ b/tools/generated_files/350/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/351/supportedExprs.csv
+++ b/tools/generated_files/351/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/351/supportedExprs.csv
+++ b/tools/generated_files/351/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/352/supportedExprs.csv
+++ b/tools/generated_files/352/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/352/supportedExprs.csv
+++ b/tools/generated_files/352/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/353/supportedExprs.csv
+++ b/tools/generated_files/353/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/353/supportedExprs.csv
+++ b/tools/generated_files/353/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/354/supportedExprs.csv
+++ b/tools/generated_files/354/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/354/supportedExprs.csv
+++ b/tools/generated_files/354/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/355/supportedExprs.csv
+++ b/tools/generated_files/355/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/355/supportedExprs.csv
+++ b/tools/generated_files/355/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/356/supportedExprs.csv
+++ b/tools/generated_files/356/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/356/supportedExprs.csv
+++ b/tools/generated_files/356/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/357/supportedExprs.csv
+++ b/tools/generated_files/357/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/357/supportedExprs.csv
+++ b/tools/generated_files/357/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/358/supportedExprs.csv
+++ b/tools/generated_files/358/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/358/supportedExprs.csv
+++ b/tools/generated_files/358/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/359/supportedExprs.csv
+++ b/tools/generated_files/359/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/359/supportedExprs.csv
+++ b/tools/generated_files/359/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/400/supportedExprs.csv
+++ b/tools/generated_files/400/supportedExprs.csv
@@ -299,7 +299,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/400/supportedExprs.csv
+++ b/tools/generated_files/400/supportedExprs.csv
@@ -298,9 +298,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/401/supportedExprs.csv
+++ b/tools/generated_files/401/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/401/supportedExprs.csv
+++ b/tools/generated_files/401/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/402/supportedExprs.csv
+++ b/tools/generated_files/402/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/402/supportedExprs.csv
+++ b/tools/generated_files/402/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/403/supportedExprs.csv
+++ b/tools/generated_files/403/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/403/supportedExprs.csv
+++ b/tools/generated_files/403/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/404/supportedExprs.csv
+++ b/tools/generated_files/404/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/404/supportedExprs.csv
+++ b/tools/generated_files/404/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/411/supportedExprs.csv
+++ b/tools/generated_files/411/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/411/supportedExprs.csv
+++ b/tools/generated_files/411/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/412/supportedExprs.csv
+++ b/tools/generated_files/412/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/412/supportedExprs.csv
+++ b/tools/generated_files/412/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/413/supportedExprs.csv
+++ b/tools/generated_files/413/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/413/supportedExprs.csv
+++ b/tools/generated_files/413/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/420/supportedExprs.csv
+++ b/tools/generated_files/420/supportedExprs.csv
@@ -303,7 +303,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/420/supportedExprs.csv
+++ b/tools/generated_files/420/supportedExprs.csv
@@ -302,9 +302,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/supportedExprs.csv
+++ b/tools/generated_files/supportedExprs.csv
@@ -296,9 +296,9 @@ If,S,`if`,None,project,predicate,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,
 If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
-In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,Non-literal list expressions must be deterministic and side-effect-free,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InitCap,S,`initcap`,This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ; resulting in some corner-case characters not changing case correctly.,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/supportedExprs.csv
+++ b/tools/generated_files/supportedExprs.csv
@@ -297,7 +297,7 @@ If,S,`if`,None,project,trueValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,falseValue,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 If,S,`if`,None,project,result,S,S,S,S,S,S,S,S,PS,S,S,S,S,NS,PS,PS,PS,NS,S,S
 In,S,`in`,None,project,value,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
-In,S,`in`,None,project,list,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,PS,NS,NS,NS,NS,NA,NS,NS,NA,NA
+In,S,`in`,None,project,list,S,S,S,S,S,S,S,S,PS,S,S,NS,NS,NS,NS,NA,NS,NS,NA,NA
 In,S,`in`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 InSet,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NA,NS,NS,NA,NA
 InSet,S, ,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA


### PR DESCRIPTION
Fixes #82.

### Description

Spark's `In` expression currently requires every list item to be a literal, so expressions such as `value IN (candidate_column, ...)` fall back to the CPU. This change adds GPU support for deterministic dynamic list expressions while preserving the existing `GpuInSet` path for literal-only lists.

The new `GpuIn` expression evaluates the value and dynamic candidates once. Literal candidates are grouped through `GpuInSet`, while dynamic equality comparisons are combined with an internal cuDF AST OR expression. Equality and OR are fused into one AST expression for AST-compatible types; float, double, and decimal equality retain the existing materialized equality semantics before the boolean AST reduction. A single dynamic candidate uses the existing `GpuEqualTo` implementation directly.

Non-deterministic expressions and expressions with side effects continue to fall back to the CPU. Tests cover dynamic, mixed literal/dynamic, null, NaN, decimal, non-deterministic, and ANSI side-effecting cases.

Validation:

- `mvn package -Dbuildver=352 -DskipTests -Dmaven.scaladoc.skip=true -Dspark-rapids-jni.version=26.10.0-astbench -pl dist -am`
- Spark 3.3.0 and Spark 3.5.2 Scala compilation passed.
- The focused integration tests passed during development. A final post-cleanup rerun was blocked before test execution by a local JNI/cuDF version-label mismatch (`26.10.0-astbench` vs `26.10.0-SNAPSHOT`).

Performance was measured end-to-end in `spark-shell` with 20 million Parquet rows, 8 approximately 305-334 MiB input batches, pinned memory enabled, 16 projected `IN` expressions, an aggregation to force materialization, and three warmed runs.

| Literals | Dynamic candidates | CPU E2E | AST E2E | GPU regular OR E2E | CPU / AST | AST Project task time / batch | Regular OR Project task time / batch |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 3 | 1 | 1337.09 ms | 1093.80 ms | 1101.49 ms | 1.22x | 6.40 ms | 8.73 ms |
| 0 | 1 | 1275.58 ms | 1059.00 ms | 1053.26 ms | 1.20x | 2.50 ms | 4.13 ms |
| 0 | 4 | 1425.57 ms | 1141.40 ms | 1159.13 ms | 1.25x | 7.69 ms | 17.61 ms |
| 32 | 1 | 28374.75 ms | 1060.92 ms | 1055.14 ms | 26.75x | 7.25 ms | 9.83 ms |

The regular OR column records a temporary benchmark-only implementation that is not included in this PR. For one dynamic candidate, both GPU measurements use the same direct equality path, so their difference is measurement noise.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
