### PR TITLE
[DOC] Clarify PR submission and draft PR guidelines [skip ci]

### DIFF
--- a/CODE_REVIEW_GUIDELINES.md
+++ b/CODE_REVIEW_GUIDELINES.md
@@ -68,6 +68,13 @@ When reviewing code, ensure that:
 * Make sure follow-up issues have been filed for non-blocking improvements and link them where helpful.  
 * Prefer a quick conversation (chat, call) over a long comment thread when it can resolve ambiguity faster.  
 * Use AI tools to improve review thoroughness and reduce the number of passes needed.
+* Common queries to filter PR queue:
+  ```
+  Real review queue:        is:pr is:open draft:false review:required sort:updated-asc
+  Excluding test refactors: is:pr is:open draft:false review:required -label:test sort:updated-asc
+  Parked drafts:            is:pr is:open draft:true sort:updated-asc
+  Overlap check:            is:pr is:open <path or filename>
+  ```
 
 ---
 
@@ -82,6 +89,8 @@ When reviewing code, ensure that:
 * Write clear, structured PR descriptions:  
   * A comprehensive overview of the change.  
   * Highlights of important areas that need extra attention.  
+  * Do not paste code diffs into the description. They duplicate the Files changed tab and go stale as soon as another commit is pushed.
+  * Describe intent and rationale, not line-level specifics that new commits invalidate. A description that disagrees with the diff is worse than no description.
   * Use AI tools to help draft the description, and review and refine it. Make them digestible and concise.
 
 ---
@@ -91,6 +100,9 @@ When reviewing code, ensure that:
 * Minimize code quality issues upfront. Code quality issues distract reviewers from more important concerns. Use linters and AI tools to clean these up before requesting review, so reviewers can focus on what matters most.  
 * Keep code easy to read — reviewability is a feature.  
 * Split large changes into smaller, focused PRs when possible.  
+* Splitting small is right, but do not open the whole batch at once. Open a few, and open the next only as earlier ones land or receive review.
+* The same applies when converting drafts to ready for review: convert in small batches. Moving twenty drafts into the review queue at once relocates the backlog rather than reducing it.
+* These pacing rules apply to independent PRs. Stacked PRs — where each change depends on the one below it — are not limited by the rule above, since the chain has to exist to be reviewable. Note the dependency in the description (`Stacked on #NNNN`) so reviewers can see the order.
 * For complex changes, write and review a design doc before implementation.
 
 ---
@@ -101,6 +113,8 @@ When reviewing code, ensure that:
 * Communicate the urgency and timeline of your PR upfront so reviewers can prioritize accordingly.  
 * Reach out to your reviewer directly when a quick discussion can save a round-trip.  
 * Use AI tools to self-review and catch issues before requesting review.
+* Review AI-generated changes yourself before opening the PR. The PR queue is not a staging area for work you have not read.
+* Note in the description that a change was AI-generated.
 
 ### **Recommended Readings**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -598,22 +598,39 @@ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 
 Here are some guidelines to follow when creating a pull request:
 
-1. If your pull request is not ready for review but you want to make use of the
-   continuous integration testing facilities, please make it as a draft and label it with `[WIP]`.
+1. Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md): Fill it in rather than replacing it
+   with another format.
 
-2. If your pull request is ready to be reviewed without requiring additional
-   work on top of it, then convert it to a regular pull request and remove the `[WIP]` label
-   (if applicable).
+2. Label your PR. Labels are what make the queue filterable. Changes that touch only tests get the
+   `test` label so reviewers know no production logic changed.
 
-3. Once the review has taken place, please do not add features or make changes
-   out of the scope of those even if the reviewer requests them. Instead, please
-   consider filing new issues for those changes.
+3. If your pull request is not ready for review but you want to make use of the
+   continuous integration testing facilities, please make it as a draft and prefix the title with
+   `[WIP]`. Please do not use other title prefixes that mean the same thing as `[WIP]` such as
+   `[DO NOT REVIEW]` and `[DRAFT]`.
 
-4. Please avoid rebasing your branch during the review process, as this causes the context
-   of any comments made by reviewers to be lost. If conflicts occur during
-   review, then they should be resolved by merging into the branch used for
-   making the pull request.
+   - When the PR is ready to be reviewed without requiring additional work on top of it,
+     then convert it to a regular pull request and remove the `[WIP]` prefix from the title.
 
+   - **Bound draft lifetime**. A draft is for CI runs and early feedback, not for parking work
+     indefinitely: state in the description what makes it a draft (a TODO checklist is preferred,
+     since it also shows how far along the work is), and if it stops progressing,
+     close it and open a new PR when the work resumes.
+
+4. Once the review has taken place:
+
+   - Please do not add features or make changes out of the scope of those even if the reviewer
+     requests them. Instead, please consider filing new issues for those changes.
+
+   - Please avoid rebasing your branch during the review process, as this causes the context
+     of any comments made by reviewers to be lost. If conflicts occur during
+     review, then they should be resolved by merging into the branch used for
+     making the pull request.
+
+5. **Closing a PR**. When closing an unmerged PR, leave a comment saying why, covering which case
+   applies: `superseded` (link the replacement), `abandoned` (say what ruled out the approach),
+   or `deferred` (link the tracking issue). A closed PR with no explanation is a dead end for
+   anyone who reaches it from a design doc or issue link months later.
 
 ### Pull request status checks
 A pull request should pass all status checks before being merged.


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>


### Description

Improve the PR guidelines to clarify the `WIP` and the draft lifetime.

**Why** 

CODE_REVIEW_GUIDELINES.md already states the premise: with AI assistants we write far more code than before, human review is still essential, and review has become a concrete bottleneck. This change adds the missing author-side rules that keep the PR queue legible.

Observed problems:

- The queue reached 109 open PRs (71 at time of writing). A single author can have a big portion of open PRs, dozens of them drafts, with a more than a dozen opened in a single day, AI-generated, with no human review yet. The queue was being used as a staging area for work the author had not read.

- Drafts carry no statement of what makes them drafts, and closed PRs carry no reason. PRs referenced from design docs turn out to be closed unmerged with no explanation, leaving readers unable to tell whether the work was rejected, deferred, or landed elsewhere.

- PRs are submitted with descriptions that bypass the template, paste full diffs into the body, or describe changes that no longer match the diff.

- Reviewers cannot scan concurrent PRs for file overlap at this depth, so parallel merges risk conflicts premerge would otherwise catch.

**Changes** 

CONTRIBUTING.md, "Creating a Pull Request":
- Use the PR template; label PRs, with `test` for test-only changes.
- Bound draft lifetime: say what makes a PR a draft, and close it if it stops progressing.
- Closing an unmerged PR requires a reason: superseded, abandoned, or deferred.
- Correct `[WIP]` from a label to a title prefix, consistent with `[skip ci]` and `[databricks]`, and drop equivalent prefixes such as `[DO NOT REVIEW]`.

CODE_REVIEW_GUIDELINES.md:
- Authors: no diffs in PR descriptions, and no line-level detail that new commits invalidate.
- Authors: open batches gradually rather than all at once; stacked PRs are exempt.
- Authors: review AI-generated changes before opening the PR.
- Reviewers: common queries for filtering the PR queue.


### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
