### PR TITLE
Fix Delta Lake REORG test failures on Spark 3.5.9 and 4.0.4 [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_reorg_table_test.py
+++ b/integration_tests/src/main/python/delta_lake_reorg_table_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+from urllib.parse import unquote, urlparse
 
 import pytest
 
@@ -249,9 +250,17 @@ def active_file_names(spark, path, predicate=None):
                df.selectExpr("input_file_name() AS file").distinct().collect())
 
 
+def spark_readable_file_name(file_name):
+    parsed = urlparse(file_name)
+    if parsed.scheme == "file" and not parsed.netloc:
+        return unquote(parsed.path)
+    return file_name
+
+
 def parquet_field_names(spark, files):
     assert files
-    return set(spark.read.parquet(*sorted(files)).schema.fieldNames())
+    readable_files = sorted(spark_readable_file_name(file_name) for file_name in files)
+    return set(spark.read.parquet(*readable_files).schema.fieldNames())
 
 
 @pytest.mark.parametrize("partitioned", [False, True], ids=["unpartitioned", "partitioned"])

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -22,8 +22,8 @@ from marks import allow_non_gpu, delta_lake, ignore_order
 from parquet_test import reader_opt_confs_no_native
 from parquet_test_utils import parquet_row_group_midpoints
 from spark_session import with_cpu_session, with_gpu_session, is_databricks_runtime, \
-    is_spark_320_or_later, is_spark_340_or_later, is_spark_40x, \
-    supports_delta_lake_deletion_vectors, is_spark_401_or_later, \
+    is_spark_320_or_later, is_spark_340_or_later, \
+    supports_delta_lake_deletion_vectors, is_spark_412_or_later, \
     gpu_supports_delta_dv_scan, is_before_spark_353, is_databricks173_or_later
 
 _conf = {'spark.rapids.sql.explain': 'ALL'}
@@ -853,9 +853,6 @@ def test_delta_scan_split_with_DV_disabled_with_DVs(spark_tmp_path, pushdown_dv_
                     reason="Deletion vector scan is not supported on Databricks")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
-@pytest.mark.skipif(is_spark_40x() and is_spark_401_or_later(),
-                    reason="Delta 4.0.0 REORG is incompatible with Spark 4.0.1+ in Spark 4.0.x "
-                           "profiles (https://github.com/delta-io/delta/issues/5690)")
 def test_delta_scan_split_with_DV_enabled_after_DVs_materialized(spark_tmp_path):
     def do_delete_and_reorg(spark, data_path):
         num_deleted = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a = 0").collect()[0][0]
@@ -904,8 +901,8 @@ def test_delta_read_column_mapping(spark_tmp_path, reader_confs, mapping, enable
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.skipif(is_spark_401_or_later(), \
-    reason="Delta Lake 4.0.0 incompatible with Spark 4.0.1 - ParquetToSparkSchemaConverter API changed")
+@pytest.mark.skipif(is_spark_412_or_later(), \
+    reason="Delta Lake 4.1.0 incompatible with Spark 4.1.2+ - ParquetToSparkSchemaConverter API changed")
 @pytest.mark.skipif(not (is_databricks_runtime() or is_spark_340_or_later()), \
                     reason="ParquetToSparkSchemaConverter changes not compatible with Delta Lake")
 @pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_xfail_reasons(

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -307,7 +307,11 @@ run_delta_lake_tests() {
   if [[ $SPARK_VER =~ $SPARK_40X_PATTERN ]]; then
     # Delta 4.0.x only supports Scala 2.13 (Spark 4.0 requirement)
     if [[ "$SCALA_BINARY_VER" == "2.13" ]]; then
-      DELTA_LAKE_VERSIONS="4.0.0"
+      if [[ "$SPARK_VER" == "4.0.0" ]]; then
+        DELTA_LAKE_VERSIONS="4.0.0"
+      else
+        DELTA_LAKE_VERSIONS="4.0.1"
+      fi
     else
       echo "Skipping Delta Lake 4.0.x tests for Scala $SCALA_BINARY_VER (requires Scala 2.13)"
     fi
@@ -329,7 +333,8 @@ run_delta_lake_tests() {
       echo "Running Delta Lake tests for Delta Lake version $v"
       if [[ "$v" == "4.1.0" ]]; then
         DELTA_MAIN_JAR="io.delta:delta-spark_4.1_${SCALA_BINARY_VER}:$v"
-      elif [[ "$v" == "3.3.0" || "$v" == "4.0.0" ]]; then
+      elif [[ "$v" == "3.3.0" || "$v" == "4.0.0" || \
+          "$v" == "4.0.1" ]]; then
         DELTA_MAIN_JAR="io.delta:delta-spark_${SCALA_BINARY_VER}:$v"
       else
         DELTA_MAIN_JAR="io.delta:delta-core_${SCALA_BINARY_VER}:$v"

--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,7 @@
             </activation>
             <properties>
                 <buildver>400</buildver>
+                <delta40x.version>4.0.0</delta40x.version>
                 <spark.version>${spark400.version}</spark.version>
                 <spark.test.version>${spark400.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
@@ -1016,7 +1017,7 @@
 
     <properties>
         <delta33x.version>3.3.0</delta33x.version>
-        <delta40x.version>4.0.0</delta40x.version>
+        <delta40x.version>4.0.1</delta40x.version>
         <delta40x.spark.artifactId>delta-spark_${scala.binary.version}</delta40x.spark.artifactId>
         <delta41x.version>4.1.0</delta41x.version>
         <delta41x.spark.artifactId>delta-spark_4.1_${scala.binary.version}</delta41x.spark.artifactId>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -602,6 +602,7 @@
             </activation>
             <properties>
                 <buildver>400</buildver>
+                <delta40x.version>4.0.0</delta40x.version>
                 <spark.version>${spark400.version}</spark.version>
                 <spark.test.version>${spark400.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
@@ -1016,7 +1017,7 @@
 
     <properties>
         <delta33x.version>3.3.0</delta33x.version>
-        <delta40x.version>4.0.0</delta40x.version>
+        <delta40x.version>4.0.1</delta40x.version>
         <delta40x.spark.artifactId>delta-spark_${scala.binary.version}</delta40x.spark.artifactId>
         <delta41x.version>4.1.0</delta41x.version>
         <delta41x.spark.artifactId>delta-spark_4.1_${scala.binary.version}</delta41x.spark.artifactId>


### PR DESCRIPTION
Fixes #15719.

### Description

The Delta Lake REORG coverage added in #15500 exposed two separate compatibility issues on Spark 4.0.4 and Spark 3.5.9.

#### Spark 4.0.x Delta Lake compatibility

Delta Lake 4.0.0 was compiled against Spark 4.0.0 and invokes the five-argument `ParquetToSparkSchemaConverter` constructor. Spark 4.0.1 changed this internal API to six arguments, and the six-argument signature remains in Spark 4.0.4.

As a result, Delta Lake 4.0.0 fails with `NoSuchMethodError` on the affected REORG and conversion paths when used with Spark 4.0.1–4.0.4.

Delta Lake 4.0.1 is built against Spark 4.0.1 and includes the upstream fix for the REORG `NoSuchMethodError`. 
This PR:
- Keeps Spark 4.0.0 on Delta Lake 4.0.0.
- Uses Delta Lake 4.0.1 for Spark 4.0.1–4.0.4.
- Narrows the remaining Delta 4.1.0 compatibility skip to Spark 4.1.2+.

See the [Delta Lake 4.0.1 release notes](https://github.com/delta-io/delta/releases/tag/v4.0.1) and [delta-io/delta#5732](https://github.com/delta-io/delta/pull/5732).

#### Spark 3.5.9 local path handling

`test_delta_reorg_table_purge_physically_dropped_column` collects active Parquet filenames using `input_file_name()` and then reads those files directly.

When the local temporary path contains a literal `%`, passing its `file:` URI back to `spark.read.parquet()` encodes `%` again as `%25`. Spark then looks for a different path and fails with `PATH_NOT_FOUND`.

The test helper now converts only authority-free local `file:` URIs into filesystem paths before reading them.

### Testing

Spark 4.0.4, Scala 2.13, Delta Lake 4.0.1:

- `delta_lake_reorg_table_test.py`: 8 passed, 1 expected skip.

Spark 3.5.9, Scala 2.12, Delta Lake 3.3.0:

- `test_delta_reorg_table_purge_physically_dropped_column` passed after the fix.
- `delta_lake_reorg_table_test.py`: 8 passed, 1 expected skip.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
