### PR TITLE
Avoid redundant Shimplify work in Maven builds

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -253,6 +253,10 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>shimplify-shim-sources</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
                         <!-- ensure a phase preceding create-parallel-world and copy-current -->
                         <phase>initialize</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1431,12 +1431,60 @@
                         <configuration>
                             <skip>${rapids.shimplify.skip}</skip>
                             <target xmlns:ac="antlib:net.sf.antcontrib">
-                                <property name="dyn.shim.buildver" value="all.buildvers"/>
-                                <script language="jython" src="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"/>
-                                <scriptdef name="shimplify" language="jython" src="${spark.rapids.source.basedir}/build/shimplify.py">
-                                    <attribute name="if"/>
-                                </scriptdef>
-                                <shimplify if="shimplify"/>
+                                <!-- Most modules have no versioned shim sources. Avoid loading Jython. -->
+                                <resourcecount property="rapids.shimplify.sources.count">
+                                    <fileset dir="${shimplify.src.basedir}">
+                                        <include name="src/main/spark*/**"/>
+                                        <include name="src/test/spark*/**"/>
+                                    </fileset>
+                                </resourcecount>
+                                <ac:if>
+                                    <equals arg1="${rapids.shimplify.sources.count}" arg2="0"/>
+                                    <then>
+                                        <echo>No shim sources: skipping Shimplify</echo>
+                                    </then>
+                                    <else>
+                                        <!-- Include paths, contents, and generator scripts in the cache key.
+                                             Keep checksum sidecars under target. -->
+                                        <checksum totalproperty="rapids.shimplify.sources.checksum"
+                                                  forceOverwrite="true"
+                                                  todir="${project.build.directory}/shimplify-checksums">
+                                            <fileset dir="${shimplify.src.basedir}">
+                                                <include name="src/main/spark*/**"/>
+                                                <include name="src/test/spark*/**"/>
+                                            </fileset>
+                                        </checksum>
+                                        <checksum file="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"
+                                                  property="rapids.shimplify.detection.checksum"/>
+                                        <checksum file="${spark.rapids.source.basedir}/build/shimplify.py"
+                                                  property="rapids.shimplify.generator.checksum"/>
+                                        <property name="rapids.shimplify.cache.marker"
+                                                  value="${spark.shim.dest}/.shimplify-${rapids.shimplify.sources.checksum}-${rapids.shimplify.detection.checksum}-${rapids.shimplify.generator.checksum}"/>
+                                        <available file="${rapids.shimplify.cache.marker}"
+                                                   property="rapids.shimplify.cache.hit"/>
+                                        <property name="dyn.shim.buildver" value="all.buildvers"/>
+                                        <ac:if>
+                                            <or>
+                                                <equals arg1="${shimplify}" arg2="true"/>
+                                                <not><isset property="rapids.shimplify.cache.hit"/></not>
+                                            </or>
+                                            <then>
+                                                <script language="jython" src="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"/>
+                                                <scriptdef name="shimplify" language="jython" src="${spark.rapids.source.basedir}/build/shimplify.py">
+                                                    <attribute name="if"/>
+                                                </scriptdef>
+                                                <shimplify if="shimplify"/>
+                                                <delete quiet="true">
+                                                    <fileset dir="${spark.shim.dest}" includes=".shimplify-*"/>
+                                                </delete>
+                                                <touch file="${rapids.shimplify.cache.marker}"/>
+                                            </then>
+                                            <else>
+                                                <echo>Shim sources unchanged: skipping Shimplify</echo>
+                                            </else>
+                                        </ac:if>
+                                    </else>
+                                </ac:if>
                             </target>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1144,6 +1144,7 @@
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
+        <rapids.shimplify.skip>false</rapids.shimplify.skip>
         <dist.jar.compress>true</dist.jar.compress>
         <!--
         This property is used to in aggregator module to determine the artifactId of iceberg
@@ -1428,6 +1429,7 @@
                         <goals><goal>run</goal></goals>
                         <phase>generate-sources</phase>
                         <configuration>
+                            <skip>${rapids.shimplify.skip}</skip>
                             <target xmlns:ac="antlib:net.sf.antcontrib">
                                 <property name="dyn.shim.buildver" value="all.buildvers"/>
                                 <script language="jython" src="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1458,8 +1458,12 @@
                                                   property="rapids.shimplify.detection.checksum"/>
                                         <checksum file="${spark.rapids.source.basedir}/build/shimplify.py"
                                                   property="rapids.shimplify.generator.checksum"/>
+                                        <checksum file="${spark.rapids.source.basedir}/build/get_buildvers.py"
+                                                  property="rapids.shimplify.buildvers.checksum"/>
+                                        <checksum file="${spark.rapids.project.basedir}/pom.xml"
+                                                  property="rapids.shimplify.pom.checksum"/>
                                         <property name="rapids.shimplify.cache.marker"
-                                                  value="${spark.shim.dest}/.shimplify-${rapids.shimplify.sources.checksum}-${rapids.shimplify.detection.checksum}-${rapids.shimplify.generator.checksum}"/>
+                                                  value="${spark.shim.dest}/.shimplify-${rapids.shimplify.sources.checksum}-${rapids.shimplify.detection.checksum}-${rapids.shimplify.generator.checksum}-${rapids.shimplify.buildvers.checksum}-${rapids.shimplify.pom.checksum}"/>
                                         <available file="${rapids.shimplify.cache.marker}"
                                                    property="rapids.shimplify.cache.hit"/>
                                         <property name="dyn.shim.buildver" value="all.buildvers"/>

--- a/scala2.13/dist/pom.xml
+++ b/scala2.13/dist/pom.xml
@@ -253,6 +253,10 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>shimplify-shim-sources</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
                         <!-- ensure a phase preceding create-parallel-world and copy-current -->
                         <phase>initialize</phase>
                         <goals>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1431,12 +1431,60 @@
                         <configuration>
                             <skip>${rapids.shimplify.skip}</skip>
                             <target xmlns:ac="antlib:net.sf.antcontrib">
-                                <property name="dyn.shim.buildver" value="all.buildvers"/>
-                                <script language="jython" src="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"/>
-                                <scriptdef name="shimplify" language="jython" src="${spark.rapids.source.basedir}/build/shimplify.py">
-                                    <attribute name="if"/>
-                                </scriptdef>
-                                <shimplify if="shimplify"/>
+                                <!-- Most modules have no versioned shim sources. Avoid loading Jython. -->
+                                <resourcecount property="rapids.shimplify.sources.count">
+                                    <fileset dir="${shimplify.src.basedir}">
+                                        <include name="src/main/spark*/**"/>
+                                        <include name="src/test/spark*/**"/>
+                                    </fileset>
+                                </resourcecount>
+                                <ac:if>
+                                    <equals arg1="${rapids.shimplify.sources.count}" arg2="0"/>
+                                    <then>
+                                        <echo>No shim sources: skipping Shimplify</echo>
+                                    </then>
+                                    <else>
+                                        <!-- Include paths, contents, and generator scripts in the cache key.
+                                             Keep checksum sidecars under target. -->
+                                        <checksum totalproperty="rapids.shimplify.sources.checksum"
+                                                  forceOverwrite="true"
+                                                  todir="${project.build.directory}/shimplify-checksums">
+                                            <fileset dir="${shimplify.src.basedir}">
+                                                <include name="src/main/spark*/**"/>
+                                                <include name="src/test/spark*/**"/>
+                                            </fileset>
+                                        </checksum>
+                                        <checksum file="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"
+                                                  property="rapids.shimplify.detection.checksum"/>
+                                        <checksum file="${spark.rapids.source.basedir}/build/shimplify.py"
+                                                  property="rapids.shimplify.generator.checksum"/>
+                                        <property name="rapids.shimplify.cache.marker"
+                                                  value="${spark.shim.dest}/.shimplify-${rapids.shimplify.sources.checksum}-${rapids.shimplify.detection.checksum}-${rapids.shimplify.generator.checksum}"/>
+                                        <available file="${rapids.shimplify.cache.marker}"
+                                                   property="rapids.shimplify.cache.hit"/>
+                                        <property name="dyn.shim.buildver" value="all.buildvers"/>
+                                        <ac:if>
+                                            <or>
+                                                <equals arg1="${shimplify}" arg2="true"/>
+                                                <not><isset property="rapids.shimplify.cache.hit"/></not>
+                                            </or>
+                                            <then>
+                                                <script language="jython" src="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"/>
+                                                <scriptdef name="shimplify" language="jython" src="${spark.rapids.source.basedir}/build/shimplify.py">
+                                                    <attribute name="if"/>
+                                                </scriptdef>
+                                                <shimplify if="shimplify"/>
+                                                <delete quiet="true">
+                                                    <fileset dir="${spark.shim.dest}" includes=".shimplify-*"/>
+                                                </delete>
+                                                <touch file="${rapids.shimplify.cache.marker}"/>
+                                            </then>
+                                            <else>
+                                                <echo>Shim sources unchanged: skipping Shimplify</echo>
+                                            </else>
+                                        </ac:if>
+                                    </else>
+                                </ac:if>
                             </target>
                         </configuration>
                     </execution>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1144,6 +1144,7 @@
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
+        <rapids.shimplify.skip>false</rapids.shimplify.skip>
         <dist.jar.compress>true</dist.jar.compress>
         <!--
         This property is used to in aggregator module to determine the artifactId of iceberg
@@ -1428,6 +1429,7 @@
                         <goals><goal>run</goal></goals>
                         <phase>generate-sources</phase>
                         <configuration>
+                            <skip>${rapids.shimplify.skip}</skip>
                             <target xmlns:ac="antlib:net.sf.antcontrib">
                                 <property name="dyn.shim.buildver" value="all.buildvers"/>
                                 <script language="jython" src="${spark.rapids.source.basedir}/build/dyn_shim_detection.py"/>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1458,8 +1458,12 @@
                                                   property="rapids.shimplify.detection.checksum"/>
                                         <checksum file="${spark.rapids.source.basedir}/build/shimplify.py"
                                                   property="rapids.shimplify.generator.checksum"/>
+                                        <checksum file="${spark.rapids.source.basedir}/build/get_buildvers.py"
+                                                  property="rapids.shimplify.buildvers.checksum"/>
+                                        <checksum file="${spark.rapids.project.basedir}/pom.xml"
+                                                  property="rapids.shimplify.pom.checksum"/>
                                         <property name="rapids.shimplify.cache.marker"
-                                                  value="${spark.shim.dest}/.shimplify-${rapids.shimplify.sources.checksum}-${rapids.shimplify.detection.checksum}-${rapids.shimplify.generator.checksum}"/>
+                                                  value="${spark.shim.dest}/.shimplify-${rapids.shimplify.sources.checksum}-${rapids.shimplify.detection.checksum}-${rapids.shimplify.generator.checksum}-${rapids.shimplify.buildvers.checksum}-${rapids.shimplify.pom.checksum}"/>
                                         <available file="${rapids.shimplify.cache.marker}"
                                                    property="rapids.shimplify.cache.hit"/>
                                         <property name="dyn.shim.buildver" value="all.buildvers"/>


### PR DESCRIPTION
### Description

Shimplify currently loads Jython during `generate-sources` even when a module has no versioned shim sources or when its generated source layout is already current. This adds avoidable latency to cached Maven builds.

This change:

- disables the inherited Shimplify execution in the source-free `dist` modules
- adds `rapids.shimplify.skip`, defaulting to `false`, as an explicit fast-build override
- avoids loading Jython automatically in modules with no versioned shim sources
- fingerprints versioned shim source paths and contents, the generator and detection scripts, `build/get_buildvers.py`, and the active project POM
- reuses a build-version-specific generated layout until any layout-defining input changes
- stores fingerprints and markers under `target`, so `mvn clean` forces regeneration
- preserves `-Dshimplify=true` as an unconditional regeneration override

There is no runtime or distribution-layout change. The Scala 2.12 and generated Scala 2.13 POMs remain synchronized.

### Validation

- Scala 2.12 root `generate-sources` reports `No shim sources: skipping Shimplify`
- Scala 2.12 and Scala 2.13 `datagen` generate shim links on the first pass and report `Shim sources unchanged: skipping Shimplify` on the second pass
- `-Drapids.shimplify.skip=true` skips the Antrun execution
- `-Dshimplify=true` forces Shimplify even after a cache hit
- reversible content edits to a shim source, `build/get_buildvers.py`, and the active project POM each invalidated the fingerprint and regenerated the layout
- checksum sidecars and cache markers remain under `target`; no source-tree files are created
- `git diff --check`

### Performance

On controlled cached `sql-plugin` builds, the normal lifecycle improved from 6.87 seconds to 5.39 seconds, saving 1.48 seconds (22%). Source generation alone improved from 3.86 seconds on the generating pass to 1.85 seconds on the unchanged pass, saving 2.01 seconds (52%).

The explicit skip path remains slightly faster because it bypasses fingerprint calculation as well. On the current `main` validation run, Scala 2.12 `datagen` took 2.48 seconds to generate and 1.14 seconds on the cache hit; Scala 2.13 took 2.58 seconds and 1.16 seconds respectively.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
