### PR TITLE
Optimize dist packaging hot paths

### DIFF
--- a/dist/build/package-parallel-worlds.py
+++ b/dist/build/package-parallel-worlds.py
@@ -15,7 +15,6 @@
 import fnmatch
 import os
 import re
-import shutil
 import subprocess
 import zipfile
 
@@ -79,7 +78,7 @@ for bv in buildver_list:
         art_jar = '-'.join([art_id, project_version, classifier]) + '.jar'
         art_jar_path = os.sep.join([build_dir, art_jar])
         if os.path.isfile(art_jar_path):
-            shutil.copy(art_jar_path, deps_dir)
+            resolved_art_jar_path = art_jar_path
         else:
             mvn_home = project.getProperty('maven.home')
             mvn_cmd = [
@@ -102,8 +101,9 @@ for bv in buildver_list:
             if repo_local:
                 mvn_cmd.append('='.join(['-Dmaven.repo.local', repo_local]))
             shell_exec(mvn_cmd)
+            resolved_art_jar_path = os.sep.join([deps_dir, art_jar])
 
-        with zipfile.ZipFile(os.sep.join([deps_dir, art_jar]), 'r') as zip_handle:
+        with zipfile.ZipFile(resolved_art_jar_path, 'r') as zip_handle:
             if project.getProperty('should.build.conventional.jar'):
                 zip_handle.extractall(path=top_dist_jar_dir)
             else:

--- a/dist/scripts/binary-dedupe.sh
+++ b/dist/scripts/binary-dedupe.sh
@@ -330,9 +330,22 @@ function copy_unshimmed_from_spark_shared() {
   local sorted_copy_list="$UNSHIMMED_FROM_SPARK_SHARED_COPY_LIST.sorted"
 
   : > "$raw_copy_list"
-  write_root_safe_spark_shared_classes
+  local promote_default_spark_shared=0
   if [[ "${UNSHIM_PROMOTE_DEFAULT_SPARK_SHARED_CLASSES:-0}" == "1" ||
         "${UNSHIM_PROMOTE_DEFAULT_SPARK_SHARED_CLASSES:-0}" == "true" ]]; then
+    promote_default_spark_shared=1
+  fi
+
+  # The dependency analysis is diagnostic-only. Keep it for fast unshim analysis
+  # and promotion experiments, but do not put it on the normal packaging hot path.
+  if [[ "$promote_default_spark_shared" == "1" || "${UNSHIM_FAST:-0}" == "1" ]]; then
+    write_root_safe_spark_shared_classes
+  else
+    echo "$((++STEP))/ skipping diagnostic spark-shared dependency analysis"
+    : > "$ROOT_SAFE_SPARK_SHARED_TXT"
+  fi
+
+  if [[ "$promote_default_spark_shared" == "1" ]]; then
     write_default_unshimmed_spark_shared_classes
     cat "$DEFAULT_UNSHIMMED_SPARK_SHARED_TXT" >> "$raw_copy_list"
   else


### PR DESCRIPTION
### Description

The dist packaging hot path performs two pieces of redundant work for every shim: it copies locally built dependency JARs before extracting them, and it performs diagnostic spark-shared dependency analysis even during normal packaging.

This change:

- extracts locally built aggregator and SQL plugin API artifacts directly from their module `target` directories
- retains the Maven dependency-download fallback when a local artifact is unavailable
- skips diagnostic spark-shared dependency analysis during normal packaging
- retains that analysis for `UNSHIM_FAST=1` workflows and default spark-shared promotion experiments

There is no distribution-content or layout change.

### Validation

- `bash -n dist/scripts/binary-dedupe.sh`
- `python3 -m py_compile dist/build/package-parallel-worlds.py`
- default compressed Spark 3.5.8 distribution build with native-library chunking enabled
- verified `UNSHIM_FAST=1` and `UNSHIM_PROMOTE_DEFAULT_SPARK_SHARED_CLASSES=1` still generate `root-safe-spark-shared.txt`
- `git diff --check`

### Performance

On identical extracted two-shim trees, the normal binary-dedupe path improved from 5.41 seconds to 1.96 seconds, saving 3.45 seconds (64%). Both variants reached the same expected revision-mismatch validation after the measured section.

Direct extraction of local build artifacts also avoids approximately 17 MB of redundant I/O per shim with the tested artifacts.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
