### PR TITLE
Reuse unpacked native dependencies in dist builds

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -438,21 +438,19 @@ self.log("... OK")
                         <configuration>
                             <skip>${rapids.jni.unpack.skip}</skip>
                             <artifactItems>
-                                <!-- if add new artifacts, should set `overWrite` as true -->
+                                <!-- Per-artifact markers refresh unpacked files when a source JAR is newer. -->
                                 <artifactItem>
                                     <groupId>com.nvidia</groupId>
                                     <artifactId>spark-rapids-jni</artifactId>
                                     <classifier>${jni.classifier}</classifier>
                                     <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/jni-deps</outputDirectory>
-                                    <overWrite>true</overWrite>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.openucx</groupId>
                                     <artifactId>jucx</artifactId>
                                     <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/jni-deps</outputDirectory>
-                                    <overWrite>true</overWrite>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/scala2.13/dist/pom.xml
+++ b/scala2.13/dist/pom.xml
@@ -438,21 +438,19 @@ self.log("... OK")
                         <configuration>
                             <skip>${rapids.jni.unpack.skip}</skip>
                             <artifactItems>
-                                <!-- if add new artifacts, should set `overWrite` as true -->
+                                <!-- Per-artifact markers refresh unpacked files when a source JAR is newer. -->
                                 <artifactItem>
                                     <groupId>com.nvidia</groupId>
                                     <artifactId>spark-rapids-jni</artifactId>
                                     <classifier>${jni.classifier}</classifier>
                                     <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/jni-deps</outputDirectory>
-                                    <overWrite>true</overWrite>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.openucx</groupId>
                                     <artifactId>jucx</artifactId>
                                     <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/jni-deps</outputDirectory>
-                                    <overWrite>true</overWrite>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>


### PR DESCRIPTION
### Description

The dist module configures the Maven dependency plugin to overwrite unpacked JNI and UCX archives on every build. That defeats the plugin's incremental unpack markers and repeats extraction during cached builds.

This change removes `overWriteReleases=true` and `overWriteSnapshots=true` from both dist POMs. The plugin's default `overWriteIfNewer=true` behavior still refreshes an unpacked archive when its source JAR changes. Developers can use `mvn clean` when they require an unconditional fresh extraction.

There is no dependency, runtime, or distribution-layout change.

### Validation

- Scala 2.12 and Scala 2.13 dist POM validation
- Spark 3.5.8 dist reactor package build from a fresh `dist/target`; both native archives were unpacked and the distribution JAR was verified
- repeated Spark 3.5.8 dist package build reported the JNI and UCX archives as already unpacked
- `git diff --check`

### Performance

This removes two unchanged native-archive extractions from cached dist builds. In the broader controlled dist benchmark where this cache was enabled, Maven reported both archives as already unpacked and the complete cached dist lifecycle improved from 23.33 seconds to 10.91 seconds. That measurement also included separate packaging optimizations, so the 12.42-second improvement is not attributed to this change alone.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
