### PR TITLE
Fix wrong results in SPJ with reduced partition transforms

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_test.py
@@ -23,8 +23,8 @@ from iceberg import get_full_table_name, iceberg_unsupported_mark, _build_tblpro
     _BASE_TBLPROPS_SQL, create_iceberg_table, supports_iceberg_v3, \
     ICEBERG_V3_UNSUPPORTED_REASON
 from marks import allow_non_gpu, iceberg, ignore_order
-from spark_session import is_databricks_runtime, is_spark_35x, is_spark_40x, is_spark_41x, \
-    spark_version, with_cpu_session, with_gpu_session
+from spark_session import is_databricks_runtime, is_spark_35x, is_spark_400_or_later, \
+    is_spark_40x, is_spark_41x, spark_version, with_cpu_session, with_gpu_session
 
 iceberg_map_gens = [MapGen(f(nullable=False), f()) for f in [
     BooleanGen, ByteGen, ShortGen, IntegerGen, LongGen, FloatGen, DoubleGen, DateGen, TimestampGen ]] + \
@@ -74,29 +74,37 @@ def _collect_plan_nodes(plan):
     return nodes
 
 
-def _assert_partial_clustering_spj_plan(plan):
-    nodes = _collect_plan_nodes(plan)
+def _nodes_of_class(plan, class_name):
+    return [node for node in _collect_plan_nodes(plan)
+            if node.getClass().getSimpleName() == class_name]
 
-    def nodes_of_class(class_name):
-        return [node for node in nodes if node.getClass().getSimpleName() == class_name]
 
-    scans = nodes_of_class("GpuBatchScanExec")
-    joins = nodes_of_class("GpuShuffledSymmetricHashJoinExec")
-    exchanges = nodes_of_class("GpuShuffleExchangeExec")
+def _assert_spj_join_shape(plan, expect_spj):
+    """Two GPU scans feeding one GPU join. `expect_spj` requires the join's own inputs to be
+    shuffle-free, which is what separates a storage-partitioned join from a shuffled one."""
+    scans = _nodes_of_class(plan, "GpuBatchScanExec")
+    joins = _nodes_of_class(plan, "GpuShuffledSymmetricHashJoinExec")
 
     assert len(scans) == 2, f"Expected two GPU batch scans, found {len(scans)}:\n{plan}"
-    assert len(joins) == 1, f"Expected one GPU SPJ join, found {len(joins)}:\n{plan}"
+    assert len(joins) == 1, f"Expected one GPU join, found {len(joins)}:\n{plan}"
+
+    join_exchanges = _nodes_of_class(joins[0], "GpuShuffleExchangeExec")
+    if expect_spj:
+        assert not join_exchanges, f"Expected shuffle-free SPJ inputs:\n{plan}"
+    else:
+        assert join_exchanges, f"Expected shuffled join inputs without SPJ:\n{plan}"
+
+    return scans
+
+
+def _assert_partial_clustering_spj_plan(plan):
+    scans = _assert_spj_join_shape(plan, expect_spj=True)
+
+    exchanges = _nodes_of_class(plan, "GpuShuffleExchangeExec")
     assert len(exchanges) == 1, \
         f"Expected one post-join GPU shuffle, found {len(exchanges)}:\n{plan}"
     assert any(scan.outputPartitioning().isPartiallyClustered() for scan in scans), \
         f"Expected at least one partially clustered GPU batch scan:\n{plan}"
-
-    join_nodes = _collect_plan_nodes(joins[0])
-    join_exchanges = [
-        node for node in join_nodes
-        if node.getClass().getSimpleName() == "GpuShuffleExchangeExec"
-    ]
-    assert not join_exchanges, f"Expected shuffle-free SPJ inputs:\n{plan}"
 
 
 @iceberg
@@ -159,6 +167,86 @@ def test_iceberg_spj_partial_clustering_distinct(spark_tmp_table_factory):
         conf=conf,
         require_non_empty=True,
         gpu_plan_assertion=_assert_partial_clustering_spj_plan)
+
+
+# Enough rows that every bucket of the wider bucket(4) side is populated, so reducing it to
+# gcd(4, 2) = 2 buckets moves rows into partition values the raw-keyed lookup cannot find.
+_SPJ_REDUCIBLE_ROWS = 64
+
+# Iceberg supplies the Reducer implementations that make these pairs compatible:
+# BucketFunction.BucketReducer reduces bucket(4) to bucket(2), and HoursFunction.HourToDaysReducer
+# reduces hours(ts) to days(ts). Hours against days is the harsher case because day numbers and
+# hour numbers share no range, so every raw lookup misses and the join returns nothing.
+_spj_reducible_transforms = [
+    pytest.param("k INT", "CAST(id AS INT)", "bucket(4, k)", "bucket(2, k)",
+                 id="bucket4_bucket2"),
+    pytest.param("k TIMESTAMP",
+                 "TIMESTAMP'2024-01-01 00:00:00' + MAKE_DT_INTERVAL(0, CAST(id AS INT), 0, 0)",
+                 "hours(k)", "days(k)", id="hours_days"),
+]
+
+
+@iceberg
+@ignore_order(local=True)
+@pytest.mark.skipif(
+    not is_spark_400_or_later(),
+    reason="spark.sql.sources.v2.bucketing.allowCompatibleTransforms.enabled was added in "
+           "Spark 4.0.0")
+@pytest.mark.parametrize("allow_compatible_transforms", [True, False],
+                         ids=["reduced", "control"])
+@pytest.mark.parametrize("key_ddl, key_value_sql, left_transform, right_transform",
+                         _spj_reducible_transforms)
+def test_iceberg_spj_reducible_transforms(spark_tmp_table_factory, key_ddl, key_value_sql,
+                                          left_transform, right_transform,
+                                          allow_compatible_transforms):
+    left_table = get_full_table_name(spark_tmp_table_factory)
+    right_table = get_full_table_name(spark_tmp_table_factory)
+
+    def setup_iceberg_tables(spark):
+        spark.sql(
+            f"CREATE TABLE {left_table} ({key_ddl}, price DOUBLE) USING ICEBERG "
+            f"PARTITIONED BY ({left_transform}) {_NO_FANOUT}")
+        spark.sql(
+            f"CREATE TABLE {right_table} ({key_ddl}, value STRING) USING ICEBERG "
+            f"PARTITIONED BY ({right_transform}) {_NO_FANOUT}")
+        spark.sql(
+            f"INSERT INTO {left_table} SELECT {key_value_sql}, CAST(id AS DOUBLE) "
+            f"FROM range({_SPJ_REDUCIBLE_ROWS})")
+        spark.sql(
+            f"INSERT INTO {right_table} SELECT {key_value_sql}, CAST(id AS STRING) "
+            f"FROM range({_SPJ_REDUCIBLE_ROWS})")
+
+    with_cpu_session(setup_iceberg_tables)
+
+    conf = {
+        "spark.sql.adaptive.enabled": "false",
+        "spark.sql.autoBroadcastJoinThreshold": "-1",
+        "spark.sql.sources.v2.bucketing.enabled": "true",
+        "spark.sql.sources.v2.bucketing.pushPartValues.enabled": "true",
+        "spark.sql.sources.v2.bucketing.allowCompatibleTransforms.enabled":
+            str(allow_compatible_transforms).lower(),
+        # Must stay off: with partial clustering on, key compatibility degrades to
+        # isSameFunction, which rejects these transform pairs, so SPJ never engages at all.
+        "spark.sql.sources.v2.bucketing.partiallyClusteredDistribution.enabled": "false",
+        "spark.sql.iceberg.planning.preserve-data-grouping": "true",
+    }
+
+    def join_on_reducible_transforms(spark):
+        return spark.sql(
+            f"""
+            SELECT l.k, l.price, r.value
+            FROM {left_table} l
+            JOIN {right_table} r ON l.k = r.k
+            """)
+
+    # With compatible transforms disabled the same tables join through a shuffle instead, which
+    # is the control: it must stay correct whether or not the reduced grouping works.
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        join_on_reducible_transforms,
+        conf=conf,
+        require_non_empty=True,
+        gpu_plan_assertion=lambda plan: _assert_spj_join_shape(
+            plan, allow_compatible_transforms))
 
 
 @allow_non_gpu("BatchScanExec")

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -35,7 +35,7 @@ import com.nvidia.spark.rapids.GpuScan
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, DynamicPruningExpression, Expression, Literal, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, DynamicPruningExpression, Expression, Literal, RowOrdering, SortOrder}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
@@ -177,6 +177,19 @@ case class GpuBatchScanExec(
               (groupedParts, expressions)
           }
 
+          // Also re-group the partitions if we are reducing compatible partition expressions
+          val finalGroupedPartitions =
+            StoragePartitionJoinShims.partitionValueReducer(spjParams, partExpressions) match {
+              case Some(reducePartitionValue) =>
+                val result = groupedPartitions.groupBy { case (row, _) =>
+                  reducePartitionValue(row)
+                }.map { case (wrapper, splits) => (wrapper.row, splits.flatMap(_._2)) }.toSeq
+                val rowOrdering = RowOrdering.createNaturalAscendingOrdering(
+                  partExpressions.map(_.dataType))
+                result.sorted(rowOrdering.on((t: (InternalRow, _)) => t._1))
+              case _ => groupedPartitions
+            }
+
           // When partially clustered, the input partitions are not grouped by partition
           // values. Here we'll need to check `commonPartitionValues` and decide how to group
           // and replicate splits within a partition.
@@ -187,7 +200,7 @@ case class GpuBatchScanExec(
                 .get
                 .map(t => (InternalRowComparableWrapper(t._1, partExpressions), t._2))
                 .toMap
-            val nestGroupedPartitions = groupedPartitions.map { case (partValue, splits) =>
+            val nestGroupedPartitions = finalGroupedPartitions.map { case (partValue, splits) =>
               // `commonPartValuesMap` should contain the part value since it's the super set.
               val numSplits = commonPartValuesMap
                   .get(InternalRowComparableWrapper(partValue, partExpressions))
@@ -220,7 +233,7 @@ case class GpuBatchScanExec(
           } else {
             // either `commonPartitionValues` is not defined, or it is defined but
             // `applyPartialClustering` is false.
-            val partitionMapping = groupedPartitions.map { case (partValue, splits) =>
+            val partitionMapping = finalGroupedPartitions.map { case (partValue, splits) =>
               InternalRowComparableWrapper(partValue, partExpressions) -> splits
             }.toMap
 

--- a/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/StoragePartitionJoinShims.scala
+++ b/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/StoragePartitionJoinShims.scala
@@ -15,15 +15,19 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "350db143"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
 spark-rapids-shim-json-lines ***/
 
 package com.nvidia.spark.rapids.shims
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedShuffleSpec
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
-// Spark 3.5.0-db143: StoragePartitionJoinParams is in the datasources.v2 package
 import org.apache.spark.sql.execution.datasources.v2.StoragePartitionJoinParams
 
 /**
@@ -39,10 +43,15 @@ object StoragePartitionJoinShims {
   def fromBatchScan(spjParams: StoragePartitionJoinParams): SpjParams = spjParams
 
   /**
-   * Reducible partition transforms (SPARK-47094) landed in Spark 4.0, so this build carries no
-   * reducers and scan partition keys are already final.
+   * Maps a scan partition key into the reduced key space that `outputPartitioning` reports when
+   * the join sides use compatible but unequal partition transforms (SPARK-47094). Absent when no
+   * reduction applies, in which case partition keys are already final.
    */
   def partitionValueReducer(
       spjParams: SpjParams,
-      partExpressions: Seq[Expression]): Option[InternalRow => InternalRowComparableWrapper] = None
+      partExpressions: Seq[Expression]): Option[InternalRow => InternalRowComparableWrapper] =
+    spjParams.reducers.map { reducers =>
+      (row: InternalRow) =>
+        KeyGroupedShuffleSpec.reducePartitionValue(row, partExpressions, reducers)
+    }
 }

--- a/sql-plugin/src/main/spark400db173/scala/com/nvidia/spark/rapids/shims/StoragePartitionJoinShims.scala
+++ b/sql-plugin/src/main/spark400db173/scala/com/nvidia/spark/rapids/shims/StoragePartitionJoinShims.scala
@@ -22,6 +22,10 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedShuffleSpec
+import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 // Spark 4.1.0+: StoragePartitionJoinParams moved to joins package
 import org.apache.spark.sql.execution.joins.StoragePartitionJoinParams
 
@@ -34,4 +38,17 @@ object StoragePartitionJoinShims {
   type SpjParams = StoragePartitionJoinParams
 
   def default(): SpjParams = StoragePartitionJoinParams()
+
+  /**
+   * Maps a scan partition key into the reduced key space that `outputPartitioning` reports when
+   * the join sides use compatible but unequal partition transforms (SPARK-47094). Absent when no
+   * reduction applies, in which case partition keys are already final.
+   */
+  def partitionValueReducer(
+      spjParams: SpjParams,
+      partExpressions: Seq[Expression]): Option[InternalRow => InternalRowComparableWrapper] =
+    spjParams.reducers.map { reducers =>
+      (row: InternalRow) =>
+        KeyGroupedShuffleSpec.reducePartitionValue(row, partExpressions, reducers)
+    }
 }


### PR DESCRIPTION
Fixes #15721

### Description

With `spark.sql.sources.v2.bucketing.allowCompatibleTransforms.enabled=true`, a
storage-partitioned join between two DSv2 tables whose partition transforms are compatible but
not identical silently returned incomplete results on the GPU. There was no error and no
fallback, just missing rows: `bucket(4, k)` joined against `bucket(2, k)` returned 35 of 64
expected rows, and `hours(ts)` against `days(ts)` returned 0 of 64. CPU Spark 4.0.2 returns all
64 in both cases.

When Spark plans an SPJ over compatible transforms it supplies reducers, and the scan's
`outputPartitioning` then reports partition values in the *reduced* key space.
`GpuBatchScanExec.inputRDD` kept the raw scan partition keys, so every lookup against the
reduced key space missed and the corresponding splits were dropped from the join. Spark's own
`BatchScanExec.inputRDD` guards against this with a `finalGroupedPartitions` step — group the
partitions by `KeyGroupedShuffleSpec.reducePartitionValue`, merge the splits that share a
reduced key, then re-sort with a natural ascending `RowOrdering` — which the GPU shim never
ported. This change ports that step and feeds its result to both downstream branches, the
partial-clustering nesting and the ordinary partition mapping.

The reducers API only exists in Spark 4.0 and later, so the version-specific part sits behind
`StoragePartitionJoinShims.partitionValueReducer`, which returns an optional key-reducing
function; `GpuBatchScanExec` holds the grouping and sorting mechanics once. That required
splitting the shim object, whose previous coverage mixed Databricks 14.3 with Spark 4.0.x:

- `spark350db143` — narrowed to `350db143` alone and returns `None`. DBR 14.3 is Spark
  3.5.0-based and has no `reducers` field, so the defect is unreachable there.
- `spark400` — new, covering `400` through `404`.
- `spark400db173` — unchanged coverage of `400db173` and `411` through `413`.

Affected builds are therefore Spark 4.0.0-4.0.4, 4.1.1-4.1.3, and DBR 17.3. Neither
`350db143` nor the `spark340` shim is affected, since neither Spark version carries the field.

There are no new or changed configurations. The path is reachable only with
`allowCompatibleTransforms.enabled=true`, which defaults to false, so default configurations
execute exactly the code they do today; where the flag is enabled, a previously wrong-result
path now returns correct results.

`test_iceberg_spj_reducible_transforms` covers this in
`integration_tests/src/main/python/iceberg/iceberg_test.py`, parameterized over the two
transform pairs (`bucket4_bucket2`, `hours_days`) with the flag both on and off (`reduced`,
`control`), for four cases. Each compares GPU results against CPU and asserts the plan shape,
requiring shuffle-free SPJ inputs in the `reduced` cases and a shuffled join in the controls.
The test is gated on Spark 4.0 or later because the config does not exist earlier. Before the
fix the two `reduced` cases returned 35 of 64 and 0 of 64 rows; all four pass after it. The
new plan assertion and the pre-existing `_assert_partial_clustering_spj_plan` were refactored
onto shared `_nodes_of_class` and `_assert_spj_join_shape` helpers rather than duplicating the
checks.

Verified locally on `buildver=402` (Spark 4.0.2, Scala 2.13, Iceberg 1.10.1, RTX A5000): the
four cases pass, and the wider `-k spj` selection is 4 passed with 1 skipped, the skip being
the pre-existing `test_iceberg_spj_partial_clustering_distinct`. Databricks coverage comes from
pre-merge, which exercises the `350db143` and `400db173` shims.

On performance: the added work is driver-side planning over distinct partition keys, not over
data, and it runs only when reducers are present. It is the same grouping and sorting that CPU
`BatchScanExec` already performs on this path, so the change removes an inconsistency rather
than adding cost, and the alternative to doing it is returning wrong results.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
