### PR TITLE
Xfail Delta REORG tests for Delta 4.0.1 and 4.1.0 [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_reorg_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_reorg_liquid_clustering_test.py
@@ -16,6 +16,7 @@ import pytest
 
 from asserts import assert_equal
 from conftest import is_apache_runtime, spark_jvm
+from delta_lake_utils import delta_reorg_xfail
 from delta_lake_reorg_table_test import (
     _reorg_conf,
     _reorg_metadata_allow,
@@ -59,6 +60,7 @@ def clustering_columns(spark, path):
 @ignore_order(local=True)
 @delta_lake
 @allow_non_gpu(*_reorg_metadata_allow)
+@delta_reorg_xfail
 def test_delta_reorg_table_purge_liquid_clustered(spark_tmp_path):
     if not is_apache_runtime():
         pytest.skip("GPU REORG TABLE currently supports Apache Delta Lake only")

--- a/integration_tests/src/main/python/delta_lake_reorg_table_test.py
+++ b/integration_tests/src/main/python/delta_lake_reorg_table_test.py
@@ -22,6 +22,7 @@ from conftest import is_apache_runtime, spark_jvm
 from data_gen import copy_and_update
 from delta_lake_utils import (
     delta_meta_allow,
+    delta_reorg_xfail,
     delta_writes_enabled_conf,
 )
 from marks import allow_non_gpu, delta_lake, ignore_order
@@ -267,6 +268,7 @@ def parquet_field_names(spark, files):
 @ignore_order(local=True)
 @delta_lake
 @allow_non_gpu(*_reorg_metadata_allow)
+@delta_reorg_xfail
 def test_delta_reorg_table_purge(spark_tmp_path, partitioned):
     if not is_apache_runtime():
         pytest.skip("GPU REORG TABLE currently supports Apache Delta Lake only")
@@ -353,6 +355,7 @@ def test_delta_reorg_table_purge(spark_tmp_path, partitioned):
 
 @delta_lake
 @allow_non_gpu(*_reorg_metadata_allow)
+@delta_reorg_xfail
 def test_delta_reorg_table_purge_physically_dropped_column(spark_tmp_path):
     if not is_apache_runtime():
         pytest.skip("GPU REORG TABLE currently supports Apache Delta Lake only")
@@ -403,6 +406,7 @@ def test_delta_reorg_table_purge_physically_dropped_column(spark_tmp_path):
 
 @delta_lake
 @allow_non_gpu(*_reorg_metadata_allow)
+@delta_reorg_xfail
 def test_delta_reorg_table_row_tracking_fallback(spark_tmp_path):
     if not is_apache_runtime():
         pytest.skip("GPU REORG TABLE currently supports Apache Delta Lake only")
@@ -520,6 +524,7 @@ def test_delta_reorg_table_unsupported_version_fallback(spark_tmp_path):
 
 @delta_lake
 @allow_non_gpu(*_reorg_metadata_allow)
+@delta_reorg_xfail
 def test_delta_reorg_table_iceberg_compatible_table_fallback(spark_tmp_path):
     if not is_apache_runtime():
         pytest.skip("GPU REORG TABLE currently supports Apache Delta Lake only")

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -17,7 +17,8 @@ from pyspark.sql import Row
 from asserts import assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_collect, \
     assert_cpu_and_gpu_are_equal_collect_with_capture
 from data_gen import *
-from delta_lake_utils import delta_meta_allow, setup_delta_dest_table, deletion_vector_values_with_xfail_reasons, read_delta_path_with_cdf
+from delta_lake_utils import delta_meta_allow, setup_delta_dest_table, \
+    deletion_vector_values_with_xfail_reasons, read_delta_path_with_cdf, delta_reorg_xfail
 from marks import allow_non_gpu, delta_lake, ignore_order
 from parquet_test import reader_opt_confs_no_native
 from parquet_test_utils import parquet_row_group_midpoints
@@ -853,6 +854,7 @@ def test_delta_scan_split_with_DV_disabled_with_DVs(spark_tmp_path, pushdown_dv_
                     reason="Deletion vector scan is not supported on Databricks")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
+@delta_reorg_xfail
 def test_delta_scan_split_with_DV_enabled_after_DVs_materialized(spark_tmp_path):
     def do_delete_and_reorg(spark, data_path):
         num_deleted = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a = 0").collect()[0][0]

--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -60,6 +60,27 @@ if is_databricks173_or_later():
 
 delta_write = ["RapidsDeltaWrite"]
 
+
+def _loaded_delta_lake_version():
+    try:
+        context_class_loader = (
+            spark_jvm().java.lang.Thread.currentThread().getContextClassLoader())
+        delta_log_class = context_class_loader.loadClass(
+            "org.apache.spark.sql.delta.DeltaLog")
+        return delta_log_class.getPackage().getImplementationVersion()
+    except Exception:
+        # Delta Lake is optional for most integration test runs.
+        return None
+
+
+delta_reorg_xfail = pytest.mark.xfail(
+    not is_databricks_runtime()
+    and _loaded_delta_lake_version() in ("4.0.1", "4.1.0"),
+    reason="Delta Lake REORG in 4.0.1 and 4.1.0 calls SparkSession.active on "
+           "executors in distributed mode: "
+           "https://github.com/delta-io/delta/pull/5697#discussion_r2695998447")
+
+
 # Parameterize Deletion Vectors only on runtimes that expose the feature in these tests.
 def deletion_vector_values_with_xfail_reasons(enabled_xfail_reason=None, disabled_xfail_reason=None):
     # Always include the DV-disabled case. On supported Databricks runtimes it can be marked xfail

--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -18,7 +18,7 @@ import pytest
 import re
 
 from spark_session import is_databricks122_or_later, supports_delta_lake_deletion_vectors, \
-    is_databricks173_or_later, with_cpu_session, with_gpu_session
+    is_databricks173_or_later, is_spark_local_mode, with_cpu_session, with_gpu_session
 from asserts import assert_equal
 from conftest import is_databricks_runtime, spark_jvm
 
@@ -75,7 +75,8 @@ def _loaded_delta_lake_version():
 
 delta_reorg_xfail = pytest.mark.xfail(
     not is_databricks_runtime()
-    and _loaded_delta_lake_version() in ("4.0.1", "4.1.0"),
+    and _loaded_delta_lake_version() in ("4.0.1", "4.1.0")
+    and not is_spark_local_mode(),
     reason="Delta Lake REORG in 4.0.1 and 4.1.0 calls SparkSession.active on "
            "executors in distributed mode: "
            "https://github.com/delta-io/delta/pull/5697#discussion_r2695998447")

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -363,6 +363,9 @@ def is_spark_testing_enabled():
     return (_spark.sparkContext._jvm.System.getProperty("spark.testing") is not None
             or _spark.sparkContext._jvm.System.getenv("SPARK_TESTING") is not None)
 
+def is_spark_local_mode():
+    return _spark.sparkContext._jsc.sc().isLocal()
+
 def get_java_major_version():
     ver = _spark.sparkContext._jvm.System.getProperty("java.version")
     # Allow these formats:


### PR DESCRIPTION
Fixes #15719.

### Description

Fixes the Delta REORG integration-test failures seen with Spark 4.0.4 in distributed mode.

Delta 4.0.1 and 4.1.0 call `SparkSession.active` from executor code, where no Spark session is available:

Upstream delta issue: https://github.com/delta-io/delta/pull/5697#discussion_r2695998447

This change uses `SparkContext.isLocal()` to mark the affected tests as expected failures only for Delta 4.0.1 and 4.1.0 in distributed mode. Local runs remain unmarked.

The affected test runs now complete successfully:

- `local[4,1]`: 7 PASS
- Distributed `local-cluster[1,1,4096]`: 7 XFAIL

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required