### PR TITLE
Fix Iceberg scan planning from background threads

### DIFF
--- a/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuSparkBatch.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuSparkBatch.scala
@@ -20,7 +20,7 @@ import java.util.Objects
 
 import org.apache.iceberg.SchemaParser
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -39,7 +39,9 @@ class GpuSparkBatch(
     val expectedSchema = GpuSparkScanAccess.expectedSchema(cpuBatch)
     val expectedSchemaString = SchemaParser.toJson(expectedSchema)
 
-    val sparkContext = SparkSession.getActiveSession.get.sparkContext
+    // Spark can plan a scan from a background thread where the thread-local active
+    // SparkSession is not set. The application SparkContext is not thread-local.
+    val sparkContext = SparkContext.getOrCreate()
     val hadoopConf = sparkContext.broadcast(
       new SerializableConfiguration(sparkContext.hadoopConfiguration))
 

--- a/integration_tests/src/main/python/iceberg/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_test.py
@@ -189,10 +189,16 @@ def test_iceberg_scan_from_background_thread(spark_tmp_table_factory):
     with_cpu_session(setup_iceberg_table)
 
     def scan_iceberg_table(spark):
+        def run_query():
+            df = spark.sql(f"SELECT SUM(id) FROM {full_table}")
+            return df.collect(), df
+
         with ThreadPoolExecutor(max_workers=1) as executor:
-            result = executor.submit(
-                lambda: spark.sql(f"SELECT SUM(id) FROM {full_table}").collect()).result()
-            assert result[0][0] == 6
+            result, df = executor.submit(run_query).result()
+
+        assert result[0][0] == 6
+        callback = spark._sc._jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+        callback.assertContains(df._jdf, "GpuBatchScanExec")
 
     with_gpu_session(scan_iceberg_table)
 

--- a/integration_tests/src/main/python/iceberg/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, \
@@ -174,6 +176,25 @@ def test_iceberg_fallback_not_unsafe_row(spark_tmp_table_factory):
         lambda spark : spark.sql(f"SELECT COUNT(DISTINCT id) from {full_table}"),
         conf={"spark.rapids.sql.format.iceberg.enabled": "false"}
     )
+
+
+@iceberg
+def test_iceberg_scan_from_background_thread(spark_tmp_table_factory):
+    full_table = get_full_table_name(spark_tmp_table_factory)
+
+    def setup_iceberg_table(spark):
+        spark.sql(f"CREATE TABLE {full_table} (id BIGINT) USING ICEBERG {_NO_FANOUT}")
+        spark.sql(f"INSERT INTO {full_table} VALUES (1), (2), (3)")
+
+    with_cpu_session(setup_iceberg_table)
+
+    def scan_iceberg_table(spark):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(
+                lambda: spark.sql(f"SELECT SUM(id) FROM {full_table}").collect()).result()
+            assert result[0][0] == 6
+
+    with_gpu_session(scan_iceberg_table)
 
 @iceberg
 @ignore_order(local=True)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark/issues/15744

### Description

Iceberg GPU scan planning currently assumes the calling thread has an active `SparkSession`. Because that session is thread-local, a scan initiated from a background thread fails with `NoSuchElementException: None.get` even though the application has a valid `SparkContext`.

Use the application `SparkContext` directly when broadcasting the Hadoop configuration, and add an Iceberg integration test that collects a GPU scan from a background thread.

Validation:

- Built the EMR 8 / Spark 4.0.2 / Scala 2.13 distribution jar successfully against EMR's bundled Iceberg 1.10.1 ABI.
- `test_iceberg_scan_from_background_thread`: 1 passed, 135 deselected.
- Built the Iceberg 1.11.103 variant and validated five independent full-scale workloads with GPU `BatchScanExec` enabled; all five passed.

Performance testing is not required because this only changes the Spark context lookup performed once during scan partition planning; it does not alter the per-row or executor data path.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
