### PR TITLE
Upgrade scala-maven-plugin to 4.9.10 without build regressions [databricks]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -384,7 +384,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        maven-version: [3.6.3, 3.8.8, 3.9.3]
+        maven-version: [3.8.1, 3.8.8, 3.9.3]
     steps:
       - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
 

--- a/build/buildall
+++ b/build/buildall
@@ -487,15 +487,20 @@ time (
         refresh_fast_aggregator_jar "$bv"
       done
     else
-    # Execute initialize to download a massive jar for spark-rapids-jni in a single thread to
-    # avoid repeating this work in parallel. This is unnecessary in unshim-fast modes that skip
-    # JNI unpacking.
-    if [[ "$UNSHIM_FAST" == "1" && "$MVN_FAST_SKIP_OPTS" == *"-Drapids.jni.unpack.skip=true"* ]]; then
-      echo "Unshim fast: skipping serial Maven initialize preflight"
-    else
-      # Initialize sql-plugin-api only to avoid dealing with missing submodule dependencies.
-      $MVN initialize -pl sql-plugin-api -am
-    fi
+    # Run through process-resources before starting independent Maven JVMs. This downloads and
+    # unpacks spark-rapids-jni serially when needed and populates the shared Scala compiler bridge
+    # cache. scala-maven-plugin's bridge installation lock is JVM-local, so a cold cache must be
+    # populated before xargs starts parallel Maven processes.
+    echo "Prewarming Maven dependencies and the Scala compiler bridge"
+    $MVN $MAVEN_REFRESH_OPT process-resources \
+      -DskipTests \
+      -Dbuildver="$BASE_VER" \
+      -Drat.skip=true \
+      -Dmaven.scaladoc.skip=true \
+      -Dmaven.javadoc.skip=true \
+      -Dmaven.scalastyle.skip=true \
+      $MVN_FAST_SKIP_OPTS \
+      -pl sql-plugin-api -am
 
     printf "%s\n" "${SPARK_SHIM_VERSIONS[@]}" | \
       xargs -t -I% -P "$BUILD_PARALLEL" -n 1 \

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -36,8 +36,8 @@ RUN yum update -y && \
     yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel java-17-openjdk-devel wget expect rsync zip unzip procps
 
 # The plugin: net.alchim31.maven requires a higher mvn version.
-ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"
-RUN wget ${ART_URL}/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz -P /usr/local && \
+ENV MAVEN_HOME "/usr/local/apache-maven-3.8.1"
+RUN wget ${ART_URL}/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.tar.gz -P /usr/local && \
     tar xzvf $MAVEN_HOME-bin.tar.gz -C /usr/local && \
     rm -f $MAVEN_HOME-bin.tar.gz
 

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -48,18 +48,26 @@ RUN sed -i -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubu
 RUN find /etc/apt/sources.list.d/ -name '*.sources' -exec sed -i \
            -e "s|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g" \
            -e "s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g" {} +
-# Install jdk-8, jdk-11, jdk-17, maven, docker image
+# Install jdk-8, jdk-11, jdk-17, docker image
 RUN apt-get update -y && \
     apt-get install -y software-properties-common rsync
 
 # libnuma1 and libgomp1 are required by ucx packaging
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk \
     python3 python3-pip python3-venv python3-setuptools \
     tzdata git zip unzip bzip2 wget parallel \
     inetutils-ping expect wget libnuma1 libgomp1 locales
+
+ARG MAVEN_VERSION=3.8.1
+ARG MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3
+RUN wget "${MAVEN_BASE_URL}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+        -O /tmp/apache-maven.tar.gz && \
+    tar xf /tmp/apache-maven.tar.gz -C /usr/local/ && \
+    rm -f /tmp/apache-maven.tar.gz && \
+    ln -sf "/usr/local/apache-maven-${MAVEN_VERSION}/bin/mvn" /usr/bin/mvn
 
 # avoid global environment conflicts since python 3.12+
 RUN python3 -m venv /opt/venv

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -74,12 +74,12 @@ initialize()
     sudo apt-get update
     # install rsync to be used for copying onto the databricks nodes
     sudo apt install -y rsync openjdk-17-jdk
-    if [[ ! -d $HOME/apache-maven-3.6.3 ]]; then
+    if [[ ! -d $HOME/apache-maven-3.8.1 ]]; then
         # DBFS cache for Maven
         DBFS_CACHE_DIR=${DBFS_CACHE_DIR:-"/dbfs/cached_jars"}
-        JAR_FILE_NAME=${JAR_FILE_NAME:-"apache-maven-3.6.3-bin.tar.gz"}
+        JAR_FILE_NAME=${JAR_FILE_NAME:-"apache-maven-3.8.1-bin.tar.gz"}
         MAVEN_CACHE_FILE=${MAVEN_CACHE_FILE:-"$DBFS_CACHE_DIR/$JAR_FILE_NAME"}
-        MAVEN_URL=${MAVEN_URL:-"https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/$JAR_FILE_NAME"}
+        MAVEN_URL=${MAVEN_URL:-"https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/$JAR_FILE_NAME"}
         # Create cache directory if it doesn't exist
         mkdir -p "$DBFS_CACHE_DIR"        
         # Check if file exists in DBFS cache
@@ -99,7 +99,7 @@ initialize()
         
         tar xf "/tmp/$JAR_FILE_NAME" -C $HOME
         rm -f "/tmp/$JAR_FILE_NAME"
-        sudo ln -s $HOME/apache-maven-3.6.3/bin/mvn /usr/local/bin/mvn
+        sudo ln -s $HOME/apache-maven-3.8.1/bin/mvn /usr/local/bin/mvn
     fi
 
     # Set JDK 17 as the default for nightly builds across both:

--- a/pom.xml
+++ b/pom.xml
@@ -778,7 +778,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -817,7 +822,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -856,7 +866,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -894,7 +909,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -1134,9 +1154,7 @@
              shim profile once Spark 5.0.0 is officially released. -->
         <spark500.version>5.0.0-SNAPSHOT</spark500.version>
         <mockito.version>3.12.4</mockito.version>
-        <!-- 4.7.1 required: later versions auto-derive -release from -target,
-             preventing JDK 17 boot classpath access with JDK 8 classfile output -->
-        <scala.plugin.version>4.7.1</scala.plugin.version>
+        <scala.plugin.version>4.9.10</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -778,7 +778,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -822,7 +821,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -866,7 +864,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -909,7 +906,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -1050,7 +1046,6 @@
         <!-- end dyn.shim properties -->
 
         <rapids.module>.</rapids.module>
-        <rapids.secondaryCacheDir>${spark.rapids.project.basedir}/target/${spark.version.classifier}/.sbt/1.0/zinc/org.scala-sbt</rapids.secondaryCacheDir>
         <allowConventionalDistJar>false</allowConventionalDistJar>
         <rapids.shimplify.skip>false</rapids.shimplify.skip>
         <rapids.build.info.skip>false</rapids.build.info.skip>
@@ -1695,12 +1690,7 @@ This will force full Scala code rebuild in downstream modules.
                             <arg>-Wunused:imports,locals,patvars,privates</arg>
                             --><!-- #endif scala-2.13 -->
                         </args>
-                        <jvmArgs>
-                            <jvmArg>-Xms1024m</jvmArg>
-                            <jvmArg>-Xmx1024m</jvmArg>
-                        </jvmArgs>
                         <addJavacArgs>${scala.javac.args}</addJavacArgs>
-                        <secondaryCacheDir>${rapids.secondaryCacheDir}</secondaryCacheDir>
                         <!-- #if scala-2.13 --><!--
                         <compilerPlugins combine.self="override">
                         </compilerPlugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1848,8 +1848,8 @@ This will force full Scala code rebuild in downstream modules.
                     <configuration>
                       <rules>
                         <requireMavenVersion>
-                          <message>Minimum Maven version 3.6.x required</message>
-                          <version>[3.6,)</version>
+                          <message>Minimum Maven version 3.8.1 required</message>
+                          <version>[3.8.1,)</version>
                         </requireMavenVersion>
                         <requireJavaVersion>
                             <message>To compile, use Java 17 or above (at runtime you can use Java 8+, however, other optional dependencies in your setup such as Iceberg may impose higher lower bound on the JDK runtime version )</message>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -778,7 +778,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -817,7 +822,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -856,7 +866,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -894,7 +909,12 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <target>${java.major.version}</target>
+                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
+                                <target combine.self="override"/>
+                                <args combine.children="append">
+                                    <arg>-target:jvm-1.8</arg>
+                                </args>
+                                <addJavacArgs combine.self="override">${scala.javac.args}|-target|8</addJavacArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -1134,9 +1154,7 @@
              shim profile once Spark 5.0.0 is officially released. -->
         <spark500.version>5.0.0-SNAPSHOT</spark500.version>
         <mockito.version>3.12.4</mockito.version>
-        <!-- 4.7.1 required: later versions auto-derive -release from -target,
-             preventing JDK 17 boot classpath access with JDK 8 classfile output -->
-        <scala.plugin.version>4.7.1</scala.plugin.version>
+        <scala.plugin.version>4.9.10</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -778,7 +778,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -822,7 +821,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -866,7 +864,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -909,7 +906,6 @@
                             <artifactId>scala-maven-plugin</artifactId>
                             <configuration>
                                 <release combine.self="override"/>
-                                <!-- Keep JDK 17 APIs visible while emitting Java 8 bytecode. -->
                                 <target combine.self="override"/>
                                 <args combine.children="append">
                                     <arg>-target:jvm-1.8</arg>
@@ -1050,7 +1046,6 @@
         <!-- end dyn.shim properties -->
 
         <rapids.module>.</rapids.module>
-        <rapids.secondaryCacheDir>${spark.rapids.project.basedir}/target/${spark.version.classifier}/.sbt/1.0/zinc/org.scala-sbt</rapids.secondaryCacheDir>
         <allowConventionalDistJar>false</allowConventionalDistJar>
         <rapids.shimplify.skip>false</rapids.shimplify.skip>
         <rapids.build.info.skip>false</rapids.build.info.skip>
@@ -1695,12 +1690,7 @@ This will force full Scala code rebuild in downstream modules.
                             <arg>-Wunused:imports,locals,patvars,privates</arg>
                             <!-- #endif scala-2.13 -->
                         </args>
-                        <jvmArgs>
-                            <jvmArg>-Xms1024m</jvmArg>
-                            <jvmArg>-Xmx1024m</jvmArg>
-                        </jvmArgs>
                         <addJavacArgs>${scala.javac.args}</addJavacArgs>
-                        <secondaryCacheDir>${rapids.secondaryCacheDir}</secondaryCacheDir>
                         <!-- #if scala-2.13 -->
                         <compilerPlugins combine.self="override">
                         </compilerPlugins>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1848,8 +1848,8 @@ This will force full Scala code rebuild in downstream modules.
                     <configuration>
                       <rules>
                         <requireMavenVersion>
-                          <message>Minimum Maven version 3.6.x required</message>
-                          <version>[3.6,)</version>
+                          <message>Minimum Maven version 3.8.1 required</message>
+                          <version>[3.8.1,)</version>
                         </requireMavenVersion>
                         <requireJavaVersion>
                             <message>To compile, use Java 17 or above (at runtime you can use Java 8+, however, other optional dependencies in your setup such as Iceberg may impose higher lower bound on the JDK runtime version )</message>


### PR DESCRIPTION
No linked issue.

### Description

Upgrade `scala-maven-plugin` from 4.7.1 to 4.9.10 and keep the existing build semantics and performance.

Version 4.9.10 requires Maven 3.8.1 or newer. Raise the project enforcer requirement accordingly, test 3.8.1 as the minimum supported version, and update the Blossom and Databricks build toolchains so CI uses a compatible Maven runtime.

For Spark 4.1 and newer, the build must see the JDK 17 boot classpath while still emitting Java 8 bytecode. The affected profiles therefore clear the structured `release` and `target` plugin settings, pass `-target:jvm-1.8` directly to scalac, and pass `-target 8` to the embedded javac. Other Spark profiles continue to use `-release 8`.

Starting in scala-maven-plugin 4.8, configuring `jvmArgs` makes incremental Zinc compilation run in a separate JVM. The previous heap arguments therefore add a fresh JVM startup to every compile and testCompile execution under 4.9.10. Remove those arguments to keep Zinc in the Maven JVM, restoring 4.7.1 behavior.

Also stop placing the Zinc compiler bridge under the repository `target` directory. The plugin default cache under the user SBT cache survives Maven clean, and the bridge filename identifies the Zinc, Scala, and JVM class versions. Parallel `buildall` workers are separate Maven JVMs, while the plugin installation lock is JVM-local, so `buildall` now runs `process-resources` for `sql-plugin-api` serially before starting workers. This replaces the previous serial JNI initialize preflight, performs that setup as part of the same lifecycle invocation, and ensures a cold bridge cache is populated once before parallel compilation.

Performance, measured with clean Spark 4.1.1 `sql-plugin -am package` builds on the same machine:

| Configuration | Runs | Mean |
| --- | ---: | ---: |
| scala-maven-plugin 4.7.1 | 51.97 s, 52.02 s | 52.00 s |
| 4.9.10 with the previous `jvmArgs` | 59.00 s, 58.92 s | 58.96 s |
| This PR | 52.21 s, 51.83 s | 52.02 s |

This avoids a 6.94-second regression, an 11.8% build-time reduction relative to the direct 4.9.10 upgrade, and is effectively at parity with 4.7.1.

Validation:

- Regenerated Scala 2.13 POMs with `./build/make-scala-version-build-files.sh 2.13`.
- Validated both Maven reactor roots with `mvn -q -N validate` and `mvn -q -f scala2.13/pom.xml -N validate`.
- Downloaded the official Maven 3.8.1 distribution and verified both reactor validation and `scala-maven-plugin` `add-source`/compile lifecycle execution at the exact new minimum.
- Clean Spark 4.1.1 Scala 2.13 `sql-plugin -am package` succeeded against an isolated cold bridge cache in 51.83 seconds.
- Inspected Scala and Java output with `javap`; both use class-file major version 52.
- Clean Scala 2.13 `buildall` for Spark 3.5.0 and 3.5.1 with two parallel workers succeeded through the final dist and downstream reactor against a separate empty bridge cache. The serial prewarm created one bridge and both workers reused it without installation attempts.
- `bash -O extglob -n build/buildall` and `git diff --check` pass.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Clean Maven reactor builds for Spark 4.1.1 and parallel `buildall` for Spark 3.5.0/3.5.1 exercise the changed compiler and bridge setup.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required