### PR TITLE
[AutoSparkUT] Recover filtered and pruned scan coverage [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFilteredScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFilteredScanSuite.scala
@@ -19,7 +19,180 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
-import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
-import org.apache.spark.sql.sources.FilteredScanSuite
+import com.nvidia.spark.rapids.{GpuProjectExec, GpuRowToColumnarExec}
 
-class RapidsFilteredScanSuite extends FilteredScanSuite with RapidsSQLTestsTrait
+import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+import org.apache.spark.sql.sources.{ColumnsRequired, EqualTo, Filter, FilteredScanSuite,
+  FiltersPushed, LessThan}
+
+class RapidsFilteredScanSuite extends FilteredScanSuite with RapidsSQLTestsTrait {
+  private case class PushDownObservation(
+      count: Long,
+      requiredColumns: Set[String],
+      pushedFilters: Seq[Filter],
+      unhandledFilters: Set[Filter])
+
+  // Adapted from Spark 3.3 FilteredScanSuite lines 237-344. The inherited helper executes the
+  // CPU RowDataSourceScanExec directly, bypassing every GPU operator in the query-level plan.
+  // https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/
+  // sources/FilteredScanSuite.scala#L237-L344
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE A = 1", 1,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT a FROM oneToTenFiltered WHERE A = 1", 1, Set("a"))
+  testRapidsPushDown("SELECT b FROM oneToTenFiltered WHERE A = 1", 1, Set("b"))
+  testRapidsPushDown("SELECT a, b FROM oneToTenFiltered WHERE A = 1", 1, Set("a", "b"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a = 1", 1,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE 1 = a", 1,
+    Set("a", "b", "c"))
+
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a > 1", 9,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a >= 2", 9,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE 1 < a", 9,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE 2 <= a", 9,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE 1 > a", 0,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE 2 >= a", 2,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a < 1", 0,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a <= 2", 2,
+    Set("a", "b", "c"))
+
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a > 1 AND a < 10", 8,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a IN (1,3,5)", 3,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a = 20", 0,
+    Set("a", "b", "c"))
+  testRapidsPushDown(
+    "SELECT * FROM oneToTenFiltered WHERE b = 1",
+    10,
+    Set("a", "b", "c"),
+    Set(EqualTo("b", 1)))
+
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a < 5 AND a > 1", 3,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE a < 3 OR a > 8", 4,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT * FROM oneToTenFiltered WHERE NOT (a < 6)", 5,
+    Set("a", "b", "c"))
+
+  testRapidsPushDown("SELECT a, b, c FROM oneToTenFiltered WHERE c like 'c%'", 1,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT a, b, c FROM oneToTenFiltered WHERE c like 'C%'", 0,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT a, b, c FROM oneToTenFiltered WHERE c like '%D'", 1,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT a, b, c FROM oneToTenFiltered WHERE c like '%d'", 0,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT a, b, c FROM oneToTenFiltered WHERE c like '%eE%'", 1,
+    Set("a", "b", "c"))
+  testRapidsPushDown("SELECT a, b, c FROM oneToTenFiltered WHERE c like '%Ee%'", 0,
+    Set("a", "b", "c"))
+
+  testRapidsPushDown("SELECT c FROM oneToTenFiltered WHERE c = 'aaaaaAAAAA'", 1,
+    Set("c"))
+  testRapidsPushDown(
+    "SELECT c FROM oneToTenFiltered WHERE c IN ('aaaaaAAAAA', 'foo')",
+    1,
+    Set("c"))
+
+  // Filters referencing multiple columns are not convertible, so all referenced columns must be
+  // required by the source scan.
+  testRapidsPushDown("SELECT c FROM oneToTenFiltered WHERE A + b > 9", 10,
+    Set("a", "b", "c"))
+
+  // A query with an inconvertible filter, an unhandled filter, and a handled filter.
+  testRapidsPushDown(
+    """SELECT a
+      |  FROM oneToTenFiltered
+      | WHERE a + b > 9
+      |   AND b < 16
+      |   AND c IN ('bbbbbBBBBB', 'cccccCCCCC', 'dddddDDDDD', 'foo')
+    """.stripMargin.split("\n").map(_.trim).mkString(" "),
+    3,
+    Set("a", "b"),
+    Set(LessThan("b", 16)))
+
+  private def testRapidsPushDown(
+      sqlString: String,
+      expectedCount: Int,
+      requiredColumnNames: Set[String]): Unit = {
+    testRapidsPushDown(sqlString, expectedCount, requiredColumnNames, Set.empty[Filter])
+  }
+
+  private def testRapidsPushDown(
+      sqlString: String,
+      expectedCount: Int,
+      requiredColumnNames: Set[String],
+      expectedUnhandledFilters: Set[Filter]): Unit = {
+    testRapids(s"PushDown Returns $expectedCount: $sqlString") {
+      spark.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, false)
+      try {
+        val (cpuObservation, _) = executeQueryAndObservePushDown(sqlString, rapidsEnabled = false)
+        val (gpuObservation, gpuPlan) =
+          executeQueryAndObservePushDown(sqlString, rapidsEnabled = true)
+
+        assert(cpuObservation.count === expectedCount.toLong)
+        assert(cpuObservation.requiredColumns === requiredColumnNames)
+        assert(cpuObservation.unhandledFilters === expectedUnhandledFilters)
+        assert(gpuObservation === cpuObservation,
+          s"GPU and CPU pushdown observations differ for $sqlString")
+        assertGpuQueryPlan(gpuPlan)
+      } finally {
+        spark.conf.set(
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key,
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.defaultValue.get)
+      }
+    }
+  }
+
+  private def executeQueryAndObservePushDown(
+      sqlString: String,
+      rapidsEnabled: Boolean): (PushDownObservation, SparkPlan) = {
+    val rapidsSqlEnabledKey = "spark.rapids.sql.enabled"
+    val originalRapidsEnabled = spark.conf.get(rapidsSqlEnabledKey)
+    spark.conf.set(rapidsSqlEnabledKey, rapidsEnabled)
+    try {
+      val query = sql(sqlString).selectExpr("*", "1 AS __rapids_probe")
+      val queryExecution = query.queryExecution
+      val plan = queryExecution.executedPlan
+      val sourceScan = plan.collect {
+        case scan: DataSourceScanExec => scan
+      } match {
+        case Seq(scan) => scan
+        case _ => fail(s"Expected exactly one DataSourceScanExec\n$queryExecution")
+      }
+
+      // Use the scan metric after the complete query runs to retain Spark's original assertion
+      // about source rows without directly executing the CPU data-source leaf.
+      query.collect()
+      val relation = spark.table("oneToTenFiltered").queryExecution.analyzed.collectFirst {
+        case logicalRelation: LogicalRelation => logicalRelation.relation
+      }.get
+      val observation = PushDownObservation(
+        sourceScan.metrics("numOutputRows").value,
+        ColumnsRequired.set,
+        FiltersPushed.list,
+        relation.unhandledFilters(FiltersPushed.list.toArray).toSet)
+      (observation, plan)
+    } finally {
+      spark.conf.set(rapidsSqlEnabledKey, originalRapidsEnabled)
+    }
+  }
+
+  private def assertGpuQueryPlan(plan: SparkPlan): Unit = {
+    assert(plan.find(_.isInstanceOf[GpuRowToColumnarExec]).nonEmpty,
+      s"Expected GpuRowToColumnarExec above the CPU data source scan:\n$plan")
+    assert(plan.find(_.isInstanceOf[GpuProjectExec]).nonEmpty,
+      s"Expected GpuProjectExec in the query-level plan:\n$plan")
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFilteredScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFilteredScanSuite.scala
@@ -21,10 +21,11 @@ package org.apache.spark.sql.rapids.suites
 
 import com.nvidia.spark.rapids.{GpuProjectExec, GpuRowToColumnarExec}
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+import org.apache.spark.sql.rapids.utils.{RapidsQueryTestUtil, RapidsSQLTestsTrait}
 import org.apache.spark.sql.sources.{ColumnsRequired, EqualTo, Filter, FilteredScanSuite,
   FiltersPushed, LessThan}
 
@@ -33,7 +34,8 @@ class RapidsFilteredScanSuite extends FilteredScanSuite with RapidsSQLTestsTrait
       count: Long,
       requiredColumns: Set[String],
       pushedFilters: Seq[Filter],
-      unhandledFilters: Set[Filter])
+      unhandledFilters: Set[Filter],
+      resultRows: Seq[Row])
 
   // Adapted from Spark 3.3 FilteredScanSuite lines 237-344. The inherited helper executes the
   // CPU RowDataSourceScanExec directly, bypassing every GPU operator in the query-level plan.
@@ -174,7 +176,7 @@ class RapidsFilteredScanSuite extends FilteredScanSuite with RapidsSQLTestsTrait
 
       // Use the scan metric after the complete query runs to retain Spark's original assertion
       // about source rows without directly executing the CPU data-source leaf.
-      query.collect()
+      val resultRows = RapidsQueryTestUtil.prepareAnswer(query.collect().toSeq, isSorted = false)
       val relation = spark.table("oneToTenFiltered").queryExecution.analyzed.collectFirst {
         case logicalRelation: LogicalRelation => logicalRelation.relation
       }.get
@@ -182,7 +184,8 @@ class RapidsFilteredScanSuite extends FilteredScanSuite with RapidsSQLTestsTrait
         sourceScan.metrics("numOutputRows").value,
         ColumnsRequired.set,
         FiltersPushed.list,
-        relation.unhandledFilters(FiltersPushed.list.toArray).toSet)
+        relation.unhandledFilters(FiltersPushed.list.toArray).toSet,
+        resultRows)
       (observation, plan)
     } finally {
       spark.conf.set(rapidsSqlEnabledKey, originalRapidsEnabled)

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPrunedScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPrunedScanSuite.scala
@@ -19,7 +19,84 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
+import com.nvidia.spark.rapids.{GpuProjectExec, GpuRowToColumnarExec}
+
+import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
 import org.apache.spark.sql.sources.PrunedScanSuite
 
-class RapidsPrunedScanSuite extends PrunedScanSuite with RapidsSQLTestsTrait
+class RapidsPrunedScanSuite extends PrunedScanSuite with RapidsSQLTestsTrait {
+  private case class PruningObservation(columns: Seq[String], numOutputRows: Long)
+
+  // Adapted from Spark 3.3 PrunedScanSuite lines 112-154. The inherited helper executes the CPU
+  // RowDataSourceScanExec directly instead of executing the complete query-level GPU plan.
+  // https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/
+  // sources/PrunedScanSuite.scala#L112-L154
+  testRapidsPruning("SELECT * FROM oneToTenPruned", "a", "b")
+  testRapidsPruning("SELECT a, b FROM oneToTenPruned", "a", "b")
+  testRapidsPruning("SELECT b, a FROM oneToTenPruned", "b", "a")
+  testRapidsPruning("SELECT b, b FROM oneToTenPruned", "b")
+  testRapidsPruning("SELECT a FROM oneToTenPruned", "a")
+  testRapidsPruning("SELECT b FROM oneToTenPruned", "b")
+  testRapidsPruning("SELECT a, rand() FROM oneToTenPruned WHERE a > 5", "a")
+  testRapidsPruning("SELECT a FROM oneToTenPruned WHERE rand() > 0.5", "a")
+  testRapidsPruning("SELECT a, rand() FROM oneToTenPruned WHERE rand() > 0.5", "a")
+  testRapidsPruning("SELECT a, rand() FROM oneToTenPruned WHERE b > 5", "a", "b")
+
+  private def testRapidsPruning(sqlString: String, expectedColumns: String*): Unit = {
+    testRapids(s"Columns output ${expectedColumns.mkString(",")}: $sqlString") {
+      spark.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, false)
+      try {
+        val (cpuObservation, _) = executeQueryAndObservePruning(sqlString, rapidsEnabled = false)
+        val (gpuObservation, gpuPlan) =
+          executeQueryAndObservePruning(sqlString, rapidsEnabled = true)
+
+        assert(cpuObservation.columns === expectedColumns)
+        assert(cpuObservation.numOutputRows > 0,
+          s"Expected the complete CPU plan to consume source rows for $sqlString")
+        assert(gpuObservation === cpuObservation,
+          s"GPU and CPU pruning observations differ for $sqlString")
+        assertGpuQueryPlan(gpuPlan)
+      } finally {
+        spark.conf.set(
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key,
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.defaultValue.get)
+      }
+    }
+  }
+
+  private def executeQueryAndObservePruning(
+      sqlString: String,
+      rapidsEnabled: Boolean): (PruningObservation, SparkPlan) = {
+    val rapidsSqlEnabledKey = "spark.rapids.sql.enabled"
+    val originalRapidsEnabled = spark.conf.get(rapidsSqlEnabledKey)
+    spark.conf.set(rapidsSqlEnabledKey, rapidsEnabled)
+    try {
+      val query = sql(sqlString).selectExpr("*", "1 AS __rapids_probe")
+      val queryExecution = query.queryExecution
+      val plan = queryExecution.executedPlan
+      val sourceScan = plan.collect {
+        case scan: DataSourceScanExec => scan
+      } match {
+        case Seq(scan) => scan
+        case _ => fail(s"Expected exactly one DataSourceScanExec\n$queryExecution")
+      }
+
+      // A row-width mismatch fails while the complete plan converts source rows into a batch.
+      query.collect()
+      (PruningObservation(
+        sourceScan.output.map(_.name),
+        sourceScan.metrics("numOutputRows").value), plan)
+    } finally {
+      spark.conf.set(rapidsSqlEnabledKey, originalRapidsEnabled)
+    }
+  }
+
+  private def assertGpuQueryPlan(plan: SparkPlan): Unit = {
+    assert(plan.find(_.isInstanceOf[GpuRowToColumnarExec]).nonEmpty,
+      s"Expected GpuRowToColumnarExec above the CPU data source scan:\n$plan")
+    assert(plan.find(_.isInstanceOf[GpuProjectExec]).nonEmpty,
+      s"Expected GpuProjectExec in the query-level plan:\n$plan")
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPrunedScanSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPrunedScanSuite.scala
@@ -39,10 +39,10 @@ class RapidsPrunedScanSuite extends PrunedScanSuite with RapidsSQLTestsTrait {
   testRapidsPruning("SELECT b, b FROM oneToTenPruned", "b")
   testRapidsPruning("SELECT a FROM oneToTenPruned", "a")
   testRapidsPruning("SELECT b FROM oneToTenPruned", "b")
-  testRapidsPruning("SELECT a, rand() FROM oneToTenPruned WHERE a > 5", "a")
-  testRapidsPruning("SELECT a FROM oneToTenPruned WHERE rand() > 0.5", "a")
-  testRapidsPruning("SELECT a, rand() FROM oneToTenPruned WHERE rand() > 0.5", "a")
-  testRapidsPruning("SELECT a, rand() FROM oneToTenPruned WHERE b > 5", "a", "b")
+  testRapidsPruning("SELECT a, rand(7) FROM oneToTenPruned WHERE a > 5", "a")
+  testRapidsPruning("SELECT a FROM oneToTenPruned WHERE rand(11) > 0.5", "a")
+  testRapidsPruning("SELECT a, rand(7) FROM oneToTenPruned WHERE rand(11) > 0.5", "a")
+  testRapidsPruning("SELECT a, rand(7) FROM oneToTenPruned WHERE b > 5", "a", "b")
 
   private def testRapidsPruning(sqlString: String, expectedColumns: String*): Unit = {
     testRapids(s"Columns output ${expectedColumns.mkString(",")}: $sqlString") {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -604,19 +604,19 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsFilteredScanSuite]
     .excludeByPrefix(
       "PushDown Returns ",
-      KNOWN_ISSUE(
-        "The Spark helper directly executes the CPU RowDataSourceScanExec instead of the " +
-          "query-level plan. See https://github.com/NVIDIA/cudf-spark/issues/15566. " +
-          "Recovery trigger: add query-level RAPIDS coverage for equivalent pushdown and " +
-          "column-pruning assertions; P2."))
+      ADJUST_UT(
+        "Replaced by testRapids coverage that executes the full query plan, requires " +
+          "GpuRowToColumnarExec and GpuProjectExec, and preserves the pushdown, required-column, " +
+          "unhandled-filter, and result-count assertions. See " +
+          "https://github.com/NVIDIA/cudf-spark/issues/15566."))
   enableSuite[RapidsPrunedScanSuite]
     .excludeByPrefix(
       "Columns output ",
-      KNOWN_ISSUE(
-        "The Spark helper directly executes the CPU RowDataSourceScanExec instead of the " +
-          "query-level plan. See https://github.com/NVIDIA/cudf-spark/issues/15567. " +
-          "Recovery trigger: add query-level RAPIDS coverage for equivalent column-pruning " +
-          "assertions; P2."))
+      ADJUST_UT(
+        "Replaced by testRapids coverage that executes the full query plan, requires " +
+          "GpuRowToColumnarExec and GpuProjectExec, and preserves the source-column and " +
+          "runtime row-width assertions. See " +
+          "https://github.com/NVIDIA/cudf-spark/issues/15567."))
   enableSuite[RapidsSupportsCatalogOptionsSuite]
   enableSuite[RapidsLocalTempViewTestSuite]
   enableSuite[RapidsGlobalTempViewTestSuite]


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — the only published baseline is Scala 2.12, shim 350, anchor `3421ec13231cc246ca2b4da5d0a2a391f0b87763`, nightly b22, but these suites and their RAPIDS test utilities are Spark 3.3-only; `sql-plugin`, `delta-lake`, `iceberg`, `shuffle-plugin`, and `udf-compiler` are N/A because no matching shim 330 baseline is published.**

Fixes #15566.
Fixes #15567.

### Description

The inherited `FilteredScanSuite` and `PrunedScanSuite` helpers execute the CPU `RowDataSourceScanExec` leaf directly. As a result, their existing assertions do not exercise a query-level RAPIDS plan.

This change adds 41 replacement `testRapids` cases while retaining the inherited CPU-leaf cases as `ADJUST_UT` exclusions:

- `RapidsFilteredScanSuite` runs each query with RAPIDS disabled and enabled, then compares source row counts, required columns, pushed and unhandled filters, and normalized result rows. It also requires `GpuRowToColumnarExec` and `GpuProjectExec` in the GPU plan.
- `RapidsPrunedScanSuite` runs complete CPU and GPU query plans, compares source columns and consumed row counts, and requires the same GPU plan evidence.

Spark test traceability:

- [`FilteredScanSuite` pushdown cases, Spark 3.3.0 lines 237-344](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/sources/FilteredScanSuite.scala#L237-L344)
- [`PrunedScanSuite` pruning cases, Spark 3.3.0 lines 112-154](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/sources/PrunedScanSuite.scala#L112-L154)

Local validation:

```text
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsFilteredScanSuite,org.apache.spark.sql.rapids.suites.RapidsPrunedScanSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm

Run starting. Expected test count is: 72
Tests: succeeded 72, failed 0, canceled 0, ignored 41, pending 0
All tests passed.
BUILD SUCCESS
```

JaCoCo measurement detail: the refreshed published report contains the `sql-plugin`, `delta-lake` (shim-350 `delta-stub` only), `iceberg`, `shuffle-plugin`, and `udf-compiler` groups. A measurement-only shim-350 rig at the exact b22 anchor built the production reactor, but the Spark 3.3-only suites could not be compiled against that report tuple because `RapidsSQLTestsTrait` and `RapidsQueryTestUtil` are not routed to shim 350. Reporting `+0` would therefore be misleading, so every applicable group is marked N/A.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
