### PR TITLE
Preserve per-write Parquet option precedence [databricks][reduced-it][fast-ut]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -74,7 +74,7 @@ object GpuParquetFileFormat {
       spark: SparkSession,
       options: Map[String, String],
       schema: StructType): Option[GpuParquetFileFormat] = {
-    tagGpuSupport(meta, spark, options, spark.sparkContext.hadoopConfiguration, schema)
+    tagGpuSupport(meta, spark, options, spark.sessionState.newHadoopConf(), schema)
   }
 
   def tagGpuSupport(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import java.time.ZoneId
+import java.util.Locale
 
 import scala.util.Try
 
@@ -86,6 +87,19 @@ object GpuParquetFileFormat {
     val sqlConf = spark.sessionState.conf
 
     val parquetOptions = new ParquetOptions(options, sqlConf)
+    // Spark 4.2+ lets per-write options override SQLConf defaults. The version shim preserves
+    // the legacy SQLConf-only behavior on older Spark releases so tagging matches runtime.
+    val writeLegacyParquetFormat = FileWriteOptionsShims.getEffectiveOption(
+      options,
+      hadoopConf,
+      SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key,
+      sqlConf.writeLegacyParquetFormat.toString).toBoolean
+    val outputTimestampType = ParquetOutputTimestampType.withName(
+      FileWriteOptionsShims.getEffectiveOption(
+        options,
+        hadoopConf,
+        SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+        sqlConf.parquetOutputTimestampType.toString).toUpperCase(Locale.ROOT))
 
     // lookup encryption keys in the options, then Hadoop conf, then Spark runtime conf
     def lookupEncryptionConfig(key: String): String = {
@@ -136,11 +150,11 @@ object GpuParquetFileFormat {
       .getOrElse(meta.willNotWorkOnGpu(
         s"compression codec ${parquetOptions.compressionCodecClassName} is not supported"))
 
-    if (sqlConf.writeLegacyParquetFormat) {
+    if (writeLegacyParquetFormat) {
       meta.willNotWorkOnGpu("Spark legacy format is not supported")
     }
 
-    if (!meta.conf.isParquetInt96WriteEnabled && sqlConf.parquetOutputTimestampType ==
+    if (!meta.conf.isParquetInt96WriteEnabled && outputTimestampType ==
       ParquetOutputTimestampType.INT96) {
       meta.willNotWorkOnGpu(s"Writing INT96 is disabled, if you want to enable it turn it on by " +
         s"setting the ${RapidsConf.ENABLE_PARQUET_INT96_WRITE} to true. NOTE: check " +
@@ -151,9 +165,9 @@ object GpuParquetFileFormat {
       TrampolineUtil.dataTypeExistsRecursively(field.dataType, _.isInstanceOf[TimestampType])
     }
     if (schemaHasTimestamps &&
-      !isOutputTimestampTypeSupported(sqlConf.parquetOutputTimestampType)) {
+      !isOutputTimestampTypeSupported(outputTimestampType)) {
       meta.willNotWorkOnGpu(s"Output timestamp type " +
-        s"${sqlConf.parquetOutputTimestampType} is not supported")
+        s"$outputTimestampType is not supported")
     }
 
     val schemaHasDates = schema.exists { field =>
@@ -220,11 +234,30 @@ class GpuParquetFileFormat extends ColumnarFileFormat with Logging {
     val parquetOptions = new ParquetOptions(options, sqlConf)
 
     val conf = ContextUtil.getConfiguration(job)
+    // GpuFileFormatWriter merges per-write options into the job configuration on Spark 4.2+.
+    // Treat SQLConf values as defaults there; older shims keep the previous unconditional sets.
+    FileWriteOptionsShims.setConfWithWriteOptionPrecedence(
+      conf,
+      SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key,
+      sqlConf.writeLegacyParquetFormat.toString)
+    FileWriteOptionsShims.setConfWithWriteOptionPrecedence(
+      conf,
+      SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+      sqlConf.parquetOutputTimestampType.toString)
+    FileWriteOptionsShims.setupLegacyParquetNanosAsLong(conf, sqlConf)
+
     GpuParquetFileFormat.parquetBlockSizeWarning(conf, options).foreach { warning =>
       logWarning(warning)
     }
 
-    val outputTimestampType = sqlConf.parquetOutputTimestampType
+    val writeLegacyParquetFormat =
+      conf.getBoolean(
+        SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key,
+        sqlConf.writeLegacyParquetFormat)
+    val outputTimestampType = ParquetOutputTimestampType.withName(
+      conf.get(
+        SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+        sqlConf.parquetOutputTimestampType.toString).toUpperCase(Locale.ROOT))
     val dateTimeRebaseMode = DateTimeRebaseMode.fromName(
       sparkSession.sqlContext.getConf(SparkShimImpl.parquetRebaseWriteKey))
     val timestampRebaseMode = if (outputTimestampType.equals(ParquetOutputTimestampType.INT96)) {
@@ -263,14 +296,9 @@ class GpuParquetFileFormat extends ColumnarFileFormat with Logging {
     // This metadata is useful for keeping UDTs like Vector/Matrix.
     ParquetWriteSupport.setSchema(dataSchema, conf)
 
-    if (sqlConf.writeLegacyParquetFormat) {
+    if (writeLegacyParquetFormat) {
       throw new UnsupportedOperationException("Spark legacy output format not supported")
     }
-    // Sets flags for `ParquetWriteSupport`, which converts Catalyst schema to Parquet
-    // schema and writes actual rows to Parquet files.
-    conf.set(
-      SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key,
-      sqlConf.writeLegacyParquetFormat.toString)
 
     if(!GpuParquetFileFormat.isOutputTimestampTypeSupported(outputTimestampType)) {
       val hasTimestamps = dataSchema.exists { field =>
@@ -281,7 +309,6 @@ class GpuParquetFileFormat extends ColumnarFileFormat with Logging {
           s"Unsupported output timestamp type: $outputTimestampType")
       }
     }
-    conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, outputTimestampType.toString)
 
     ParquetFieldIdShims.setupParquetFieldIdWriteConfig(conf, sqlConf)
     val parquetFieldIdWriteEnabled = ParquetFieldIdShims.getParquetIdWriteEnabled(conf, sqlConf)
@@ -453,10 +480,12 @@ class GpuParquetWriter(
 
   override val tableWriter: TableWriter = {
     val writeContext = new ParquetWriteSupport().init(conf)
+    // Use the value resolved in prepareWrite. Reading SQLConf here would discard
+    // a per-write option.
     val builder = SchemaUtils
       .writerOptionsFromSchema(ParquetWriterOptions.builder(), dataSchema,
         nullable = false,
-        ParquetOutputTimestampType.INT96 == SQLConf.get.parquetOutputTimestampType,
+        ParquetOutputTimestampType.INT96.toString == outputTimestampType,
         parquetFieldIdEnabled)
       .withMetadata(writeContext.getExtraMetaData)
       .withCompressionType(compressionType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/parquet/ParquetFieldIdShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/parquet/ParquetFieldIdShims.scala
@@ -16,20 +16,27 @@
 
 package com.nvidia.spark.rapids.shims.parquet
 
+import com.nvidia.spark.rapids.shims.FileWriteOptionsShims
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.internal.SQLConf
 
 object ParquetFieldIdShims {
-  /** Updates the Hadoop configuration with the Parquet field ID write setting from SQLConf */
+  /**
+   * Applies the SQLConf field ID setting without replacing a Spark 4.2+ per-write option.
+   * Older shims retain the original unconditional SQLConf behavior.
+   */
   def setupParquetFieldIdWriteConfig(conf: Configuration, sqlConf: SQLConf): Unit = {
-    conf.set(
+    FileWriteOptionsShims.setConfWithWriteOptionPrecedence(
+      conf,
       SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key,
       sqlConf.parquetFieldIdWriteEnabled.toString)
   }
 
-  /** Get Parquet field ID write enabled configuration value */
+  /** Gets the field ID setting resolved in the Hadoop configuration. */
   def getParquetIdWriteEnabled(conf: Configuration, sqlConf: SQLConf): Boolean = {
-    sqlConf.parquetFieldIdWriteEnabled
+    conf.getBoolean(
+      SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key,
+      sqlConf.parquetFieldIdWriteEnabled)
   }
 }

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/FileWriteOptionsShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/FileWriteOptionsShims.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "400db173"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Compatibility implementation for Spark versions before 4.2.
+ *
+ * Shared writer code calls these helpers, but these versions must keep the original behavior:
+ * write options are not merged here and prepareWrite applies SQLConf values unconditionally.
+ */
+object FileWriteOptionsShims {
+  def mergeWriteOptionsIntoHadoopConf(
+      options: Map[String, String],
+      conf: Configuration): Unit = {}
+
+  def setConfWithWriteOptionPrecedence(
+      conf: Configuration,
+      key: String,
+      value: => String): Unit = {
+    conf.set(key, value)
+  }
+
+  def getEffectiveOption(
+      options: Map[String, String],
+      conf: Configuration,
+      key: String,
+      defaultValue: String): String = {
+    defaultValue
+  }
+
+  def setupLegacyParquetNanosAsLong(conf: Configuration, sqlConf: SQLConf): Unit = {}
+}

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -52,7 +52,7 @@ import java.util.{Date, UUID}
 import com.nvidia.spark.TimingUtils
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.AssertUtils.assertInTests
-import com.nvidia.spark.rapids.shims.{BucketingUtilsShim, RapidsFileSourceMetaUtils}
+import com.nvidia.spark.rapids.shims.{BucketingUtilsShim, FileWriteOptionsShims, RapidsFileSourceMetaUtils}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce._
@@ -123,6 +123,10 @@ trait GpuFileFormatWriterBase extends Serializable with Logging {
     // needs to fallback to the row-based write path.
     job.setOutputValueClass(classOf[InternalRow])
     FileOutputFormat.setOutputPath(job, new Path(outputSpec.outputPath))
+
+    // Spark 4.2+ requires write options in the Job conf before file-format setup.
+    // This shim call is a no-op on older Spark releases to preserve their behavior.
+    FileWriteOptionsShims.mergeWriteOptionsIntoHadoopConf(options, job.getConfiguration)
 
     val partitionSet = AttributeSet(partitionColumns)
     // cleanup the internal metadata information of

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
@@ -29,12 +29,13 @@ import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Shim for Parquet variant-related configurations in Spark 4.1.0+.
- * Sets PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE which is required by ParquetWriteSupport.
+ * Applies PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE without replacing a Spark 4.2+ per-write option.
  */
 object ParquetVariantShims {
   def setupParquetVariantConfig(conf: Configuration, sqlConf: SQLConf): Unit = {
-    // Set the variant annotation config that SparkToParquetSchemaConverter requires
-    conf.set(
+    // SparkToParquetSchemaConverter requires this value in the Hadoop configuration.
+    FileWriteOptionsShims.setConfWithWriteOptionPrecedence(
+      conf,
       SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key,
       sqlConf.parquetAnnotateVariantLogicalType.toString)
   }

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/FileWriteOptionsShims.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/FileWriteOptionsShims.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+{"spark": "500"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.sql.execution.datasources.DataSourceUtils
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Spark 4.2+ adapters for the per-write option precedence introduced by SPARK-56414.
+ */
+object FileWriteOptionsShims {
+  def mergeWriteOptionsIntoHadoopConf(
+      options: Map[String, String],
+      conf: Configuration): Unit = {
+    DataSourceUtils.mergeWriteOptionsIntoHadoopConf(options, conf)
+  }
+
+  def setConfWithWriteOptionPrecedence(
+      conf: Configuration,
+      key: String,
+      value: => String): Unit = {
+    DataSourceUtils.setConfIfAbsent(conf, key, value)
+  }
+
+  def getEffectiveOption(
+      options: Map[String, String],
+      conf: Configuration,
+      key: String,
+      defaultValue: String): String = {
+    // Resolve tagging decisions against a copy so the shared Hadoop configuration is not mutated.
+    val effectiveConf = new Configuration(conf)
+    DataSourceUtils.mergeWriteOptionsIntoHadoopConf(options, effectiveConf)
+    Option(effectiveConf.get(key)).getOrElse(defaultValue)
+  }
+
+  def setupLegacyParquetNanosAsLong(conf: Configuration, sqlConf: SQLConf): Unit = {
+    DataSourceUtils.setConfIfAbsent(
+      conf,
+      SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
+      sqlConf.legacyParquetNanosAsLong.toString)
+  }
+}

--- a/tests/src/test/spark420/scala/com/nvidia/spark/rapids/ParquetWriteOptionPrecedenceSuite.scala
+++ b/tests/src/test/spark420/scala/com/nvidia/spark/rapids/ParquetWriteOptionPrecedenceSuite.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids
+
+import java.sql.Timestamp
+
+import com.nvidia.spark.rapids.shims.FileWriteOptionsShims
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+import org.apache.spark.sql.types.StructType
+
+@scala.annotation.nowarn("msg=method readFooter in class ParquetFileReader is deprecated")
+class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
+  test("prepareWrite preserves merged Parquet options over SQLConf defaults") {
+    val sparkConf = new SparkConf()
+      .set(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "true")
+      .set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
+      .set(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, "true")
+      .set(SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key, "true")
+      .set(SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key, "true")
+
+    withGpuSparkSession(spark => {
+      val job = Job.getInstance(new Configuration(false))
+      val conf = job.getConfiguration
+      val writeOptions = Map(
+        SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key -> "false",
+        SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> "TIMESTAMP_MICROS",
+        SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key -> "false",
+        SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key -> "false",
+        SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key -> "false")
+
+      FileWriteOptionsShims.mergeWriteOptionsIntoHadoopConf(writeOptions, conf)
+      new GpuParquetFileFormat().prepareWrite(spark, job, Map.empty, new StructType())
+
+      assert(!conf.getBoolean(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, true))
+      assert(conf.get(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key) === "TIMESTAMP_MICROS")
+      assert(!conf.getBoolean(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, true))
+      assert(!conf.getBoolean(SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key, true))
+      assert(!conf.getBoolean(SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key, true))
+    }, sparkConf)
+  }
+
+  test("per-write timestamp option takes precedence over session config") {
+    val sparkConf = new SparkConf()
+      .set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
+
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+
+      withTempPath { outputPath =>
+        ExecutionPlanCaptureCallback.startCapture()
+        Seq(Timestamp.valueOf("2024-01-01 12:00:00"))
+          .toDF("ts")
+          .coalesce(1)
+          .write
+          .option(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "TIMESTAMP_MICROS")
+          .parquet(outputPath.getAbsolutePath)
+
+        val plans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
+        assert(plans.nonEmpty, "Did not capture GPU write plan")
+        ExecutionPlanCaptureCallback.assertContains(plans.head, "GpuDataWritingCommandExec")
+
+        val parquetFile = outputPath.listFiles()
+          .find(file => file.getName.startsWith("part-") && file.getName.endsWith(".parquet"))
+          .getOrElse(fail("Expected a Parquet data file"))
+        val footer = ParquetFileReader.readFooter(
+          spark.sparkContext.hadoopConfiguration,
+          new Path(parquetFile.getAbsolutePath))
+        val timestampField = footer.getFileMetaData.getSchema.getFields.get(0).asPrimitiveType()
+        assert(timestampField.getPrimitiveTypeName === PrimitiveTypeName.INT64)
+      }
+    }, sparkConf)
+  }
+
+  test("per-write legacy format option prevents session-config fallback") {
+    val sparkConf = new SparkConf()
+      .set(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "true")
+
+    withGpuSparkSession(spark => {
+      withTempPath { outputPath =>
+        ExecutionPlanCaptureCallback.startCapture()
+        spark.range(1)
+          .write
+          .option(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "false")
+          .parquet(outputPath.getAbsolutePath)
+
+        val plans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
+        assert(plans.nonEmpty, "Did not capture GPU write plan")
+        ExecutionPlanCaptureCallback.assertContains(plans.head, "GpuDataWritingCommandExec")
+      }
+    }, sparkConf)
+  }
+}

--- a/tests/src/test/spark420/scala/com/nvidia/spark/rapids/ParquetWriteOptionPrecedenceSuite.scala
+++ b/tests/src/test/spark420/scala/com/nvidia/spark/rapids/ParquetWriteOptionPrecedenceSuite.scala
@@ -28,11 +28,11 @@ import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.execution.datasources.{FileFormatWriter, SQLHadoopMapReduceCommitProtocol}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{ExecutionPlanCaptureCallback, GpuFileFormatWriter}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StructField, StructType}
 
 @scala.annotation.nowarn("msg=method readFooter in class ParquetFileReader is deprecated")
 class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
@@ -98,6 +98,37 @@ class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
     }, sparkConf)
   }
 
+  test("tagging uses the session Hadoop configuration snapshot") {
+    val key = SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key
+    val sparkConf = new SparkConf()
+      .set(key, "true")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "DataWritingCommandExec,WriteFilesExec")
+
+    withGpuSparkSession(spark => {
+      val hadoopConf = spark.sparkContext.hadoopConfiguration
+      val originalValue = Option(hadoopConf.get(key))
+      try {
+        hadoopConf.set(key, "false")
+        spark.conf.set(key, "true")
+
+        withTempPath { outputPath =>
+          ExecutionPlanCaptureCallback.startCapture()
+          spark.range(1).write.parquet(outputPath.getAbsolutePath)
+
+          val plans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
+          assert(plans.nonEmpty, "Did not capture write plan")
+          ExecutionPlanCaptureCallback.assertNotContain(
+            plans.head, "GpuDataWritingCommandExec")
+        }
+      } finally {
+        originalValue match {
+          case Some(value) => hadoopConf.set(key, value)
+          case None => hadoopConf.unset(key)
+        }
+      }
+    }, sparkConf)
+  }
+
   test("per-write timestamp option takes precedence over session config") {
     val sparkConf = new SparkConf()
       .set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
@@ -126,6 +157,40 @@ class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
           new Path(parquetFile.getAbsolutePath))
         val timestampField = footer.getFileMetaData.getSchema.getFields.get(0).asPrimitiveType()
         assert(timestampField.getPrimitiveTypeName === PrimitiveTypeName.INT64)
+      }
+    }, sparkConf)
+  }
+
+  test("per-write field ID option controls the Parquet footer") {
+    val sparkConf = new SparkConf()
+      .set(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, "true")
+
+    withGpuSparkSession(spark => {
+      val metadata = new MetadataBuilder()
+        .putLong("parquet.field.id", 1)
+        .build()
+      val schema = StructType(Seq(
+        StructField("id", IntegerType, nullable = true, metadata = metadata)))
+
+      withTempPath { outputPath =>
+        ExecutionPlanCaptureCallback.startCapture()
+        spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(1))), schema)
+          .coalesce(1)
+          .write
+          .option(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, "false")
+          .parquet(outputPath.getAbsolutePath)
+
+        val plans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
+        assert(plans.nonEmpty, "Did not capture GPU write plan")
+        ExecutionPlanCaptureCallback.assertContains(plans.head, "GpuDataWritingCommandExec")
+
+        val parquetFile = outputPath.listFiles()
+          .find(file => file.getName.startsWith("part-") && file.getName.endsWith(".parquet"))
+          .getOrElse(fail("Expected a Parquet data file"))
+        val footer = ParquetFileReader.readFooter(
+          spark.sparkContext.hadoopConfiguration,
+          new Path(parquetFile.getAbsolutePath))
+        assert(footer.getFileMetaData.getSchema.getFields.get(0).getId == null)
       }
     }, sparkConf)
   }

--- a/tests/src/test/spark420/scala/com/nvidia/spark/rapids/ParquetWriteOptionPrecedenceSuite.scala
+++ b/tests/src/test/spark420/scala/com/nvidia/spark/rapids/ParquetWriteOptionPrecedenceSuite.scala
@@ -21,7 +21,6 @@ package com.nvidia.spark.rapids
 
 import java.sql.Timestamp
 
-import com.nvidia.spark.rapids.shims.FileWriteOptionsShims
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
@@ -29,13 +28,17 @@ import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.{FileFormatWriter, SQLHadoopMapReduceCommitProtocol}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+import org.apache.spark.sql.rapids.{ExecutionPlanCaptureCallback, GpuFileFormatWriter}
 import org.apache.spark.sql.types.StructType
 
 @scala.annotation.nowarn("msg=method readFooter in class ParquetFileReader is deprecated")
 class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
-  test("prepareWrite preserves merged Parquet options over SQLConf defaults") {
+  private class PrepareWriteReached extends RuntimeException
+
+  test("GpuFileFormatWriter merges Parquet options before prepareWrite") {
     val sparkConf = new SparkConf()
       .set(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "true")
       .set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
@@ -44,8 +47,6 @@ class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
       .set(SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key, "true")
 
     withGpuSparkSession(spark => {
-      val job = Job.getInstance(new Configuration(false))
-      val conf = job.getConfiguration
       val writeOptions = Map(
         SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key -> "false",
         SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> "TIMESTAMP_MICROS",
@@ -53,9 +54,42 @@ class ParquetWriteOptionPrecedenceSuite extends SparkQueryCompareTestSuite {
         SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key -> "false",
         SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key -> "false")
 
-      FileWriteOptionsShims.mergeWriteOptionsIntoHadoopConf(writeOptions, conf)
-      new GpuParquetFileFormat().prepareWrite(spark, job, Map.empty, new StructType())
+      var preparedConf: Option[Configuration] = None
+      val fileFormat = new GpuParquetFileFormat() {
+        override def prepareWrite(
+            sparkSession: SparkSession,
+            job: Job,
+            options: Map[String, String],
+            dataSchema: StructType): ColumnarOutputWriterFactory = {
+          super.prepareWrite(sparkSession, job, options, dataSchema)
+          preparedConf = Some(new Configuration(job.getConfiguration))
+          throw new PrepareWriteReached
+        }
+      }
 
+      withTempPath { outputPath =>
+        val plan = spark.range(1).queryExecution.executedPlan
+        intercept[PrepareWriteReached] {
+          GpuFileFormatWriter.write(
+            sparkSession = spark,
+            plan = plan,
+            fileFormat = fileFormat,
+            committer = new SQLHadoopMapReduceCommitProtocol(
+              "write-option-precedence", outputPath.getAbsolutePath, false),
+            outputSpec = FileFormatWriter.OutputSpec(
+              outputPath.getAbsolutePath, Map.empty, plan.output),
+            hadoopConf = new Configuration(false),
+            partitionColumns = Seq.empty,
+            bucketSpec = None,
+            statsTrackers = Seq.empty,
+            options = writeOptions,
+            useStableSort = false,
+            concurrentWriterPartitionFlushSize = 0L,
+            baseDebugOutputPath = None)
+        }
+      }
+
+      val conf = preparedConf.getOrElse(fail("GpuParquetFileFormat.prepareWrite was not reached"))
       assert(!conf.getBoolean(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, true))
       assert(conf.get(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key) === "TIMESTAMP_MICROS")
       assert(!conf.getBoolean(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, true))


### PR DESCRIPTION
Fixes #15669.

### Description

- Align the GPU Parquet writer with the per-write option precedence introduced in [apache/spark#55280](https://github.com/apache/spark/pull/55280). Previously, GPU file-format setup could overwrite a writer option with the corresponding session-level SQLConf value.
- Merge the original write options into the Hadoop Job configuration before GPU file-format setup on Spark 4.2+, preserving the original option-key casing.
- Treat SQLConf values as defaults for `spark.sql.parquet.writeLegacyFormat`, `spark.sql.parquet.outputTimestampType`, `spark.sql.parquet.fieldId.write.enabled`, `spark.sql.legacy.parquet.nanosAsLong`, and `spark.sql.parquet.annotateVariantLogicalType` instead of overwriting an existing per-write value.
- Resolve legacy-format and output-timestamp options consistently during GPU tagging and writer setup, and make the GPU Parquet writer consume the resolved timestamp type rather than re-reading SQLConf.
- Isolate the new behavior behind version shims so Spark 3.x through 4.1 retain their existing write semantics.
- Add Spark 4.2 tests that verify all five Hadoop configuration values, the physical Parquet timestamp type, and that conflicting session settings do not force the write off GPU.
- Validated Spark 4.2 `ParquetWriterSuite`, `ParquetFieldIdSuite`, and `ParquetWriteOptionPrecedenceSuite` (22 tests passed), and re-ran `ParquetWriteOptionPrecedenceSuite` after rebasing to the latest `NVDA/main` (3 tests passed).
- Validated Spark 3.4.1 `ParquetWriterSuite` and `ParquetFieldIdSuite` (19 tests passed), packaged the Spark 4.0.3 Scala 2.13 SQL plugin, and ran Spark 3.4.1 plus Spark 4.2 `validate`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required