### PR TITLE
Fix GPU aggregate produced attributes [databricks][reduced-it][fast-ut]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -2087,7 +2087,10 @@ case class GpuHashAggregateExec(
     }
   }
 
-  // Used in de-duping and optimizer rules
+  // Used in de-duping and optimizer rules.
+  // Final/PartialMerge aggregates read input buffer attributes from their child. If those
+  // attrs share exprIds with child output but have different names, keep them out of this
+  // node's produced attributes so QueryPlan.references retains the required inputs.
   override def producedAttributes: AttributeSet =
     (AttributeSet(aggregateAttributes) ++
       AttributeSet(resultExpressions.diff(groupingExpressions).map(_.toAttribute)) ++

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -2089,9 +2089,10 @@ case class GpuHashAggregateExec(
 
   // Used in de-duping and optimizer rules
   override def producedAttributes: AttributeSet =
-    AttributeSet(aggregateAttributes) ++
+    (AttributeSet(aggregateAttributes) ++
       AttributeSet(resultExpressions.diff(groupingExpressions).map(_.toAttribute)) ++
-      AttributeSet(aggregateBufferAttributes)
+      AttributeSet(aggregateBufferAttributes) ++
+      AttributeSet(inputAggBufferAttributes)) -- child.outputSet
 
   // AllTuples = distribution with a single partition and all tuples of the dataset are co-located.
   // Clustered = dataset with tuples co-located in the same partition if they share a specific value

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -43,8 +43,10 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
 
   test("SPARK-55979: GPU aggregate references retain renamed input buffer attributes") {
     val scanAggBufferAttr = AttributeReference("buf", IntegerType, nullable = true)()
+    // withName preserves exprId while changing the display name, matching the Spark regression.
     val inputAggBufferAttr = scanAggBufferAttr.withName("renamed_buf")
 
+    // LocalTableScanExec has version-specific constructors; this keeps the test common-shim safe.
     case class TestLeafExec(override val output: Seq[Attribute]) extends LeafExecNode {
       override protected def doExecute(): RDD[InternalRow] =
         throw new UnsupportedOperationException("TestLeafExec does not execute")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -21,18 +21,69 @@ import java.sql.Timestamp
 import org.apache.spark
 
 import org.apache.spark.SparkConf
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.execution.{SparkPlan, WholeStageCodegenExec}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression,
+  ExprId, Literal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Final
+import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+import org.apache.spark.sql.rapids.aggregate.{CudfAggregate, GpuAggregateExpression,
+  GpuAggregateFunction}
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
-import org.apache.spark.sql.types.{DataType, DataTypes}
+import org.apache.spark.sql.types.{DataType, DataTypes, IntegerType}
 
 class HashAggregatesSuite extends SparkQueryCompareTestSuite {
   private def floatAggConf: SparkConf = enableCsvConf()
       .set(RapidsConf.ENABLE_FLOAT_AGG.key, "true")
+
+  test("SPARK-55979: GPU aggregate references retain renamed input buffer attributes") {
+    val scanAggBufferAttr = AttributeReference("buf", IntegerType, nullable = true)()
+    val inputAggBufferAttr = scanAggBufferAttr.withName("renamed_buf")
+
+    case class TestLeafExec(override val output: Seq[Attribute]) extends LeafExecNode {
+      override protected def doExecute(): RDD[InternalRow] =
+        throw new UnsupportedOperationException("TestLeafExec does not execute")
+    }
+
+    case class MyGpuAggregate() extends GpuAggregateFunction {
+      override def children: Seq[Expression] = Nil
+      override def nullable: Boolean = true
+      override def dataType: DataType = IntegerType
+      override def prettyName: String = "test_gpu_agg"
+      override val initialValues: Seq[Expression] = Seq(Literal(0))
+      override val inputProjection: Seq[Expression] = Nil
+      override val updateAggregates: Seq[CudfAggregate] = Nil
+      override val mergeAggregates: Seq[CudfAggregate] = Nil
+      override val evaluateExpression: Expression = inputAggBufferAttr
+      override def aggBufferAttributes: Seq[AttributeReference] = Seq(inputAggBufferAttr)
+      override def withNewChildrenInternal(
+          newChildren: IndexedSeq[Expression]): Expression = copy()
+    }
+
+    val aggregateExpression = GpuAggregateExpression(
+      MyGpuAggregate(), Final, isDistinct = false, filter = None, resultId = ExprId(1))
+    val aggregateResult = AttributeReference("result", IntegerType, nullable = true)()
+    val aggregate = GpuHashAggregateExec(
+      requiredChildDistributionExpressions = None,
+      groupingExpressions = Nil,
+      aggregateExpressions = Seq(aggregateExpression),
+      aggregateAttributes = Seq(aggregateResult),
+      resultExpressions = Seq(Alias(aggregateExpression, "result")()),
+      child = TestLeafExec(Seq(scanAggBufferAttr)),
+      configuredTargetBatchSize = 1L,
+      estimatedPreProcessGrowth = 1.0,
+      forceSinglePassAgg = false,
+      allowSinglePassAgg = true,
+      allowNonFullyAggregatedOutput = false,
+      skipAggPassReductionRatio = Double.MaxValue)
+
+    assert(aggregate.references.contains(inputAggBufferAttr))
+  }
 
   def replaceHashAggMode(mode: String, conf: SparkConf = new SparkConf()): SparkConf = {
     // configures whether Plugin will replace certain aggregate exec nodes


### PR DESCRIPTION
Fixes #15670.

### Description

`GpuHashAggregateExec.producedAttributes` did not match Spark's aggregate handling for renamed input aggregate buffer attributes. When a final/partial-merge aggregate consumes buffer attributes that share an exprId with the child output but have a different name, the planner can treat required inputs as produced by the aggregate and prune them from `references`.

This PR updates GPU hash aggregate produced-attribute handling to include input aggregate buffer attributes and then remove child output attributes, matching Spark's behavior. It also adds a focused regression test that constructs the renamed-buffer shape and verifies the required input buffer attribute remains in `GpuHashAggregateExec.references`.

Testing performed:

- `mvn -s <settings.xml> -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests -DskipITs -pl sql-plugin,tests -am install`
- `mvn -s <settings.xml> -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -pl tests -DwildcardSuites=com.nvidia.spark.rapids.HashAggregatesSuite -Dtest=none -DfailIfNoTests=false test`
- `mvn -s <settings.xml> -Dbuildver=350 -Dcuda.version=cuda13 -DskipTests -DskipITs -pl sql-plugin,tests -am install`
- `mvn -s <settings.xml> -Dbuildver=350 -Dcuda.version=cuda13 -pl tests -DwildcardSuites=com.nvidia.spark.rapids.HashAggregatesSuite -Dtest=none -DfailIfNoTests=false test`
- Quick local review: no findings from compliance, correctness, and test coverage reviewers.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required