### PR TITLE
[AutoSparkUT] Preserve CHAR/VARCHAR metadata for GPU CTAS [databricks]

### DIFF
--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
@@ -27,7 +27,7 @@ package org.apache.spark.sql.rapids.shims
 import java.net.URI
 
 import com.nvidia.spark.rapids.{ColumnarFileFormat, GpuDataWritingCommand}
-import com.nvidia.spark.rapids.shims.SparkShimImpl
+import com.nvidia.spark.rapids.shims.{CharVarcharUtilsShims, SparkShimImpl}
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog._
@@ -87,12 +87,13 @@ case class GpuCreateDataSourceTableAsSelectCommand(
       }
       val result = saveDataIntoTable(
         sparkSession, table, tableLocation, child, SaveMode.Overwrite, tableExists = false)
+      val tableSchema = CharVarcharUtilsShims.getRawSchema(result.schema, sessionState.conf)
       val newTable = table.copy(
         storage = table.storage.copy(locationUri = tableLocation),
         // We will use the schema of resolved.relation as the schema of the table (instead of
         // the schema of df). It is important since the nullability may be changed by the relation
         // provider (for example, see org.apache.spark.sql.parquet.DefaultSource).
-        schema = result.schema)
+        schema = tableSchema)
       // Table location is already validated. No need to check it again during table creation.
       sessionState.catalog.createTable(newTable, ignoreIfExists = false, validateLocation = false)
 

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
@@ -51,7 +51,7 @@ import java.net.URI
 
 import com.nvidia.spark.rapids.AssertUtils.assertInTests
 import com.nvidia.spark.rapids.GpuDataWritingCommand
-import com.nvidia.spark.rapids.shims.SparkShimImpl
+import com.nvidia.spark.rapids.shims.{CharVarcharUtilsShims, SparkShimImpl}
 
 import org.apache.spark.sql.{AnalysisException, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.catalog._
@@ -110,12 +110,14 @@ case class GpuCreateDataSourceTableAsSelectCommand(
       val result = saveDataIntoTable(
         TrampolineConnectShims.getActiveSession, table, tableLocation, SaveMode.Overwrite,
         tableExists = false)
+      val tableSchema = CharVarcharUtilsShims.getRawSchema(
+        SchemaMetadataShims.getCleanedSchema(result.schema), sessionState.conf)
       val newTable = table.copy(
         storage = table.storage.copy(locationUri = tableLocation),
         // We will use the schema of resolved.relation as the schema of the table (instead of
         // the schema of df). It is important since the nullability may be changed by the relation
         // provider (for example, see org.apache.spark.sql.parquet.DefaultSource).
-        schema = SchemaMetadataShims.getCleanedSchema(result.schema))
+        schema = tableSchema)
       // Table location is already validated. No need to check it again during table creation.
       sessionState.catalog.createTable(newTable, ignoreIfExists = false, validateLocation = false)
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsCharVarcharDDLTestSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsCharVarcharDDLTestSuite.scala
@@ -19,14 +19,42 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
 import org.apache.spark.sql.execution.command.{
   DSV2CharVarcharDDLTestSuite,
   FileSourceCharVarcharDDLTestSuite
 }
+import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
 
 class RapidsFileSourceCharVarcharDDLTestSuite
-    extends FileSourceCharVarcharDDLTestSuite with RapidsSQLTestsTrait
+    extends FileSourceCharVarcharDDLTestSuite with RapidsSQLTestsTrait {
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    val isGpuCtasMetadataTest =
+      testName == "SPARK-33901: ctas should should not change table's schema" ||
+        testName == "SPARK-37160: CREATE TABLE AS SELECT with CHAR_AS_VARCHAR"
+    if (isGpuCtasMetadataTest) {
+      super.test(testName, testTags: _*) {
+        ExecutionPlanCaptureCallback.startCapture()
+        try {
+          testFun
+          val plans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
+          assert(plans.exists(ExecutionPlanCaptureCallback.contains(
+            _, "GpuDataWritingCommandExec")),
+            s"Did not capture a GPU CTAS write plan:\n${plans.mkString("\n")}")
+        } finally {
+          ExecutionPlanCaptureCallback.endCapture()
+        }
+      }
+    } else {
+      super.test(testName, testTags: _*)(testFun)
+    }
+  }
+}
 
 class RapidsDSV2CharVarcharDDLTestSuite
     extends DSV2CharVarcharDDLTestSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -310,12 +310,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsV1ReadFallbackWithDataFrameReaderSuite]
   enableSuite[RapidsV1ReadFallbackWithCatalogSuite]
   enableSuite[RapidsFileSourceCharVarcharDDLTestSuite]
-    .exclude("SPARK-33901: ctas should should not change table's schema",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15549. " +
-        "Recovery trigger: GPU V1 CTAS preserves raw CHAR/VARCHAR schema metadata; P0."))
-    .exclude("SPARK-37160: CREATE TABLE AS SELECT with CHAR_AS_VARCHAR",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15549. " +
-        "Recovery trigger: GPU V1 CTAS applies CHAR_AS_VARCHAR to raw schema metadata; P0."))
   enableSuite[RapidsDSV2CharVarcharDDLTestSuite]
   enableSuite[RapidsParquetCodecSuite]
     .exclude("write and read - file source parquet - codec: lz4",

--- a/tests/src/test/spark340/scala/org/apache/spark/sql/rapids/GpuCreateDataSourceTableAsSelectCommandCharVarcharSuite.scala
+++ b/tests/src/test/spark340/scala/org/apache/spark/sql/rapids/GpuCreateDataSourceTableAsSelectCommandCharVarcharSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350db143"}
+{"spark": "400db173"}
+spark-rapids-shim-json-lines ***/
+
+package org.apache.spark.sql.rapids
+
+import com.nvidia.spark.rapids.{FunSuiteWithTempDir, RapidsConf, SparkQueryCompareTestSuite}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
+
+class GpuCreateDataSourceTableAsSelectCommandCharVarcharSuite
+  extends SparkQueryCompareTestSuite
+  with FunSuiteWithTempDir {
+
+  test("CTAS preserves CHAR/VARCHAR metadata and honors CHAR_AS_VARCHAR") {
+    val sourceTable = "charVarcharSource"
+    val preserveTarget = "charVarcharPreserveTarget"
+    val convertTarget = "charVarcharConvertTarget"
+    // Spark's CHAR read-side padding remains a CPU Project on these shims.
+    val conf = new SparkConf(false)
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "ProjectExec")
+    withGpuSparkSession({ spark =>
+      withTable(spark, sourceTable, preserveTarget, convertTarget) {
+        spark.conf.set(SQLConf.CHAR_AS_VARCHAR.key, "false")
+        spark.sql(s"CREATE TABLE $sourceTable(c CHAR(5), v VARCHAR(4)) USING PARQUET")
+
+        Seq(
+          (false, preserveTarget, Seq("char(5)", "varchar(4)")),
+          (true, convertTarget, Seq("varchar(5)", "varchar(4)"))).foreach {
+          case (charAsVarchar, targetTable, expectedTypes) =>
+            spark.conf.set(SQLConf.CHAR_AS_VARCHAR.key, charAsVarchar.toString)
+            spark.sql(s"CREATE TABLE $targetTable USING PARQUET AS SELECT * FROM $sourceTable")
+            val actualTypes = spark.sql(s"DESC $targetTable")
+              .selectExpr("data_type")
+              .where("data_type like '%char%'")
+              .collect()
+              .map(_.getString(0))
+              .toSeq
+            assert(actualTypes == expectedTypes)
+        }
+      }
+    }, conf)
+  }
+
+  private def withTable(spark: SparkSession, tableNames: String*)(f: => Unit): Unit = {
+    Utils.tryWithSafeFinally(f) {
+      tableNames.foreach { name =>
+        spark.sql(s"DROP TABLE IF EXISTS $name")
+      }
+    }
+  }
+}

--- a/tests/src/test/spark350/scala/org/apache/spark/sql/rapids/GpuCreateDataSourceTableAsSelectCommandSuite.scala
+++ b/tests/src/test/spark350/scala/org/apache/spark/sql/rapids/GpuCreateDataSourceTableAsSelectCommandSuite.scala
@@ -39,13 +39,14 @@ spark-rapids-shim-json-lines ***/
 
 package org.apache.spark.sql.rapids
 
-import com.nvidia.spark.rapids.FunSuiteWithTempDir
-import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
+import com.nvidia.spark.rapids.{FunSuiteWithTempDir, RapidsConf, SparkQueryCompareTestSuite}
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.FileSourceMetadataAttribute.FILE_SOURCE_METADATA_COL_ATTR_KEY
 import org.apache.spark.sql.connector.catalog.{Column, Identifier}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -84,6 +85,36 @@ class GpuCreateDataSourceTableAsSelectCommandSuite
         assert(firstColumn.metadataInJSON() == null, "Column metadata should be empty.")
       }
     }
+  }
+
+  test("CTAS preserves CHAR/VARCHAR metadata and honors CHAR_AS_VARCHAR") {
+    val sourceTable = "charVarcharSource"
+    val preserveTarget = "charVarcharPreserveTarget"
+    val convertTarget = "charVarcharConvertTarget"
+    // Spark's CHAR read-side padding remains a CPU Project on these shims.
+    val conf = new SparkConf(false)
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "ProjectExec")
+    withGpuSparkSession({ spark =>
+      withTable(spark, sourceTable, preserveTarget, convertTarget) {
+        spark.conf.set(SQLConf.CHAR_AS_VARCHAR.key, "false")
+        spark.sql(s"CREATE TABLE $sourceTable(c CHAR(5), v VARCHAR(4)) USING PARQUET")
+
+        Seq(
+          (false, preserveTarget, Seq("char(5)", "varchar(4)")),
+          (true, convertTarget, Seq("varchar(5)", "varchar(4)"))).foreach {
+          case (charAsVarchar, targetTable, expectedTypes) =>
+            spark.conf.set(SQLConf.CHAR_AS_VARCHAR.key, charAsVarchar.toString)
+            spark.sql(s"CREATE TABLE $targetTable USING PARQUET AS SELECT * FROM $sourceTable")
+            val actualTypes = spark.sql(s"DESC $targetTable")
+              .selectExpr("data_type")
+              .where("data_type like '%char%'")
+              .collect()
+              .map(_.getString(0))
+              .toSeq
+            assert(actualTypes == expectedTypes)
+        }
+      }
+    }, conf)
   }
 
   private def withTable(spark: SparkSession, tableNames: String*)(f: => Unit): Unit = {


### PR DESCRIPTION
**JaCoCo production line coverage: +5 lines** (`sql-plugin +5`; fix-line coverage on shims 330 and 340 at `6695b1712b65aef4812c22d842b6d1cebb25eab9`)

Fixes #15549.

### Description

GPU V1 `CREATE TABLE AS SELECT` registered the provider-resolved schema directly. Unlike Spark's CPU path, this dropped raw `CHAR`/`VARCHAR` metadata and did not apply `spark.sql.charAsVarchar`, so the target table schema could diverge between CPU and GPU execution.

This change restores the raw schema with `CharVarcharUtilsShims.getRawSchema` before catalog registration. On the newer/Databricks shim family, existing internal-metadata cleanup remains first so file metadata is still removed before `CHAR`/`VARCHAR` metadata is restored. It also re-enables the two original Spark 3.3 tests and adds targeted coverage for Spark 3.4 and later shims.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

#### Test traceability

- RAPIDS suite: `RapidsFileSourceCharVarcharDDLTestSuite`
  - Original Spark test: `SPARK-33901: ctas should should not change table's schema`
  - Original Spark test: `SPARK-37160: CREATE TABLE AS SELECT with CHAR_AS_VARCHAR`
- RAPIDS suites for newer shims: `GpuCreateDataSourceTableAsSelectCommandCharVarcharSuite` and `GpuCreateDataSourceTableAsSelectCommandSuite`
- Spark source: [`CharVarcharDDLTestBase.scala` lines 108-140](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala#L108-L140)

#### Validation

- Spark 3.3 `RapidsFileSourceCharVarcharDDLTestSuite`: `Tests: succeeded 16, failed 0, canceled 0, ignored 0, pending 0`
- Spark 3.4 `GpuCreateDataSourceTableAsSelectCommandCharVarcharSuite`: `Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0`
- Spark 3.5 `GpuCreateDataSourceTableAsSelectCommandSuite`: `Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0`
- Spark 4.0 / Scala 2.13 `sql-plugin` compile-only package: `BUILD SUCCESS`
- Strict shim coverage check and `git diff --check`: passed
- JaCoCo fix-line intersection: shim 330 covered 2 of 3 added production lines; shim 340 covered 3 of 4 added production lines. The two uncovered additions are imports.
- The Databricks 14.3 test run could not start locally because `org.apache.spark:spark-parent_2.12:3.5.0-databricks-143` was unavailable from the configured internal Maven repository. The `[databricks]` marker requests the repository's Databricks CI coverage.

#### Performance

This only adds schema metadata normalization during CTAS table registration. It is a cold control-path operation, runs once per table creation, and does not add work to row processing or a data-path loop; no benchmark is required.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
