### PR TITLE
[fast-ut] [reduced-it] Add missing numeric expression type coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2371,12 +2371,14 @@ def test_hash_groupby_approx_percentile_reduction_no_rows(aqe_enabled):
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/14634")
+@pytest.mark.parametrize(
+    'data_gen', [ByteGen(), ShortGen(), FloatGen()], ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-def test_hash_groupby_approx_percentile_byte(aqe_enabled):
+def test_hash_groupby_approx_percentile_small_numeric(data_gen, aqe_enabled):
     conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
-                                     ('v', ByteGen())], length=100),
+                                     ('v', data_gen)], length=100),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
 @incompat

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -1823,6 +1823,31 @@ def test_multi_types_window_aggs_for_rows_lead_lag(a_b_gen, c_gen, batch_size, a
     assert_gpu_and_cpu_are_equal_collect(do_it, conf=conf)
 
 
+@ignore_order(local=True)
+@approximate_float
+@pytest.mark.parametrize(
+    'data_gen', [ByteGen(), ShortGen(), FloatGen(), DateGen()], ids=idfn)
+@allow_non_gpu(*non_utc_allow)
+@validate_execs_in_gpu_plan('GpuBatchedBoundedWindowExec')
+def test_lead_lag_byte_short_float_date(data_gen):
+    default_value = with_cpu_session(
+        lambda spark: gen_scalar_value(data_gen, force_no_nulls=True))
+
+    def do_it(spark):
+        window_spec = Window.partitionBy('part').orderBy('order')
+        return gen_df(spark, [
+            ('part', RepeatSeqGen(int_gen, length=20)),
+            ('order', UniqueLongGen(nullable=False)),
+            ('value', data_gen)], length=2048).select(
+                'part',
+                'order',
+                f.lead('value', 2, default_value).over(window_spec).alias('lead_value'),
+                f.lag('value', 2, default_value).over(window_spec).alias('lag_value'))
+
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it, conf={'spark.sql.adaptive.enabled': 'false'})
+
+
 struct_with_arrays = StructGen(children=[
                        ['child_int', int_gen],
                        ['child_time', date_gen],
@@ -1946,6 +1971,23 @@ def test_percent_rank_ntile_no_part_multiple_batches():
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
     assert_gpu_and_cpu_are_equal_collect(do_it, conf = {'spark.rapids.sql.batchSizeBytes': '100',
                                                         'spark.sql.adaptive.enabled': 'false'})
+
+
+@ignore_order(local=True)
+@validate_execs_in_gpu_plan("GpuRunningWindowExec", "GpuCachedDoublePassWindowExec")
+@pytest.mark.parametrize(
+    'data_gen', [ByteGen(), ShortGen(), FloatGen()], ids=idfn)
+def test_percent_rank_byte_short_float_ordering(data_gen):
+    window_spec = Window.orderBy('a')
+
+    def do_it(spark):
+        return gen_df(spark, [('a', data_gen)], length=2048) \
+                .withColumn('percent_rank_val', f.percent_rank().over(window_spec))
+
+    assert_gpu_and_cpu_are_equal_collect(
+        do_it,
+        conf={'spark.rapids.sql.batchSizeBytes': '100',
+              'spark.sql.adaptive.enabled': 'false'})
 
 @validate_execs_in_gpu_plan("GpuRunningWindowExec", "GpuCachedDoublePassWindowExec")
 def test_percent_rank_ntile_single_part_multiple_batches():


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — sql-plugin published b23 private classfiles are unavailable/class-ID mismatched; delta-lake +0, iceberg +0, shuffle-plugin +0, udf-compiler +0**

Fixes #15764.

### Description

This test-only change adds missing Python integration-test type coverage for four expressions:

- Exercise `Lead` and `Lag` with literal `ByteGen`, `ShortGen`, `FloatGen`, and `DateGen` inputs and generated non-null defaults, while checking for `GpuBatchedBoundedWindowExec`.
- Exercise `PercentRank` with literal `ByteGen`, `ShortGen`, and `FloatGen` ordering inputs, while checking for the intended GPU running/double-pass window plans.
- Extend the existing `ApproximatePercentile` known-issue test from `ByteGen` to literal `ByteGen`, `ShortGen`, and `FloatGen`. Its six data-type/AQE combinations remain skipped under #14634.

This closes the planned Milestone 1 static definition gaps for these expressions. Runtime correctness and #14634 resolution remain separate Milestone 2 work.

Local focused validation with Spark 3.3.0 and Python 3.10.18:

`7 passed, 6 skipped, 3267 deselected`

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
