### PR TITLE
[BUG] Copy root-safe module artifacts into nightly Maven repo [skip ci]

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -134,9 +134,21 @@ function build_shim() {
   ( # use flock to prevent maven local repository contention across all parallel builds
     flock -x -w 300 200 || { echo "Lock acquisition failed"; exit 1; }
 
-    echo "Copying sql-plugin-api,aggregator to .m2 repo..."
-    for mod in \
-      "rapids-4-spark-sql-plugin-api_${SCALA_BINARY_VER}" "rapids-4-spark-aggregator_${SCALA_BINARY_VER}"; do
+    local -a copy_modules=("sql-plugin-api" "aggregator")
+    local module mod
+    # The dist packager resolves these module jars for the highest Spark shim, so copy them out
+    # of the isolated shim repository along with the API and aggregator artifacts.
+    while IFS= read -r module || [[ -n "$module" ]]; do
+      module="${module#"${module%%[![:space:]]*}"}"
+      module="${module%"${module##*[![:space:]]}"}"
+      if [[ -n "$module" && "$module" != \#* ]]; then
+        copy_modules+=("$module")
+      fi
+    done < dist/root-safe-module-classes.txt
+
+    echo "Copying ${copy_modules[*]} to .m2 repo..."
+    for module in "${copy_modules[@]}"; do
+      mod="rapids-4-spark-${module}_${SCALA_BINARY_VER}"
       SRC_DIR="${SHIM_M2DIR}/com/nvidia/${mod}/${ART_VER}"
       DEST_DIR="${M2DIR}/com/nvidia/${mod}/${ART_VER}"
 


### PR DESCRIPTION
Fixes #15768. The separate `ClassInitializationSuite` failure is tracked by #15770.

### Description

Nightly builds each non-base Spark shim in an isolated workspace and Maven repository. After each build, it copies the classified `sql-plugin-api` and `aggregator` artifacts into the shared Maven repository used for final dist assembly.

The root-safe module packaging added in #15739 also requires the highest-shim `sql-plugin-format` artifact. That artifact was present in the isolated shim repository but was not copied to the shared repository, so `create-parallel-world` attempted remote snapshot resolution and failed.

Read `dist/root-safe-module-classes.txt` when assembling the copy list and propagate every declared root-safe module alongside `sql-plugin-api` and `aggregator`. This uses the same module list as the dist packager and automatically covers future root-safe modules.

### Validation

- `bash -n jenkins/spark-nightly-build.sh`
- `git diff --check`
- Ran an isolated-Maven-repository simulation of `build_shim` for Spark 3.5.9 and verified that the classified `sql-plugin-api`, `aggregator`, and `sql-plugin-format` artifacts were copied into the shared repository.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
