### PR TITLE
Fail on conflicting duplicate aggregator classes [databricks]

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -115,6 +115,45 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ban-conflicting-aggregator-classes</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!--
+                                  Only direct dependencies are shaded aggregator inputs. Checking
+                                  transitives would report unrelated third-party class conflicts.
+                                  See https://github.com/NVIDIA/cudf-spark/issues/14829.
+                                -->
+                                <banDuplicateClasses>
+                                    <searchTransitive>false</searchTransitive>
+                                    <scopes>
+                                        <scope>compile</scope>
+                                    </scopes>
+                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                    <findAllDuplicates>true</findAllDuplicates>
+                                    <message>Conflicting classes found in RAPIDS aggregator inputs</message>
+                                </banDuplicateClasses>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.12.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/converter/FromIcebergShaded.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/converter/FromIcebergShaded.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/converter/FromIcebergShaded.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/converter/FromIcebergShaded.scala
@@ -16,8 +16,6 @@
 
 package com.nvidia.spark.rapids.iceberg.parquet.converter
 
-import java.util.Optional
-
 import scala.collection.JavaConverters._
 
 import org.apache.iceberg.shaded.org.apache.parquet.column.{Encoding => ShadedEncoding, EncodingStats => ShadedEncodingStats}
@@ -25,7 +23,7 @@ import org.apache.iceberg.shaded.org.apache.parquet.column.statistics.{Statistic
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.metadata.{BlockMetaData => ShadedBlockMetaData, ColumnChunkMetaData => ShadedColumnChunkMetaData, ColumnChunkProperties => ShadedColumnChunkProperties, ColumnPath => ShadedColumnPath, CompressionCodecName => ShadedCompressionCodecName}
 import org.apache.iceberg.shaded.org.apache.parquet.internal.hadoop.metadata.{IndexReference => ShadedIndexReference}
 import org.apache.iceberg.shaded.org.apache.parquet.schema.{ColumnOrder => ShadedColumnOrder, GroupType => ShadedGroupType, LogicalTypeAnnotation => ShadedLogicalTypeAnnotation, MessageType => ShadedMessageType, PrimitiveType => ShadedPrimitiveType, Type => ShadedType}
-import org.apache.iceberg.shaded.org.apache.parquet.schema.LogicalTypeAnnotation.{LogicalTypeAnnotationVisitor => ShadedLogicalTypeAnnotationVisitor, TimeUnit => ShadedTimeUnit}
+import org.apache.iceberg.shaded.org.apache.parquet.schema.LogicalTypeAnnotation.{TimeUnit => ShadedTimeUnit}
 import org.apache.iceberg.shaded.org.apache.parquet.schema.PrimitiveType.{PrimitiveTypeName => ShadedPrimitiveTypeName}
 import org.apache.parquet.column.{Encoding, EncodingStats}
 import org.apache.parquet.column.statistics.Statistics
@@ -73,87 +71,39 @@ object FromIcebergShaded {
     if (inner == null) {
       return null
     }
-    inner.accept(new ShadedLogicalTypeAnnotationVisitor[LogicalTypeAnnotation] {
-      override def visit(stringLogicalType: ShadedLogicalTypeAnnotation
-      .StringLogicalTypeAnnotation): Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.stringType())
-      }
-
-      override def visit(mapLogicalType: ShadedLogicalTypeAnnotation.MapLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.mapType())
-      }
-
-      override def visit(listLogicalType: ShadedLogicalTypeAnnotation.ListLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.listType())
-      }
-
-      override def visit(enumLogicalType: ShadedLogicalTypeAnnotation.EnumLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.enumType())
-      }
-
-      override def visit(shaded: ShadedLogicalTypeAnnotation
-      .DecimalLogicalTypeAnnotation): Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.decimalType(
-          shaded.getScale,
-          shaded.getPrecision))
-      }
-
-      override def visit(dateLogicalType: ShadedLogicalTypeAnnotation.DateLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.dateType())
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.TimeLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.timeType(
-          inner.isAdjustedToUTC,
-          unshade(inner.getUnit)))
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.TimestampLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.timestampType(
-          inner.isAdjustedToUTC,
-          unshade(inner.getUnit)))
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.IntLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.intType(
-          inner.getBitWidth,
-          inner.isSigned))
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.JsonLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.jsonType())
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.BsonLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.bsonType())
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.UUIDLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.uuidType())
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.IntervalLogicalTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.IntervalLogicalTypeAnnotation.getInstance())
-      }
-
-      override def visit(inner: ShadedLogicalTypeAnnotation.MapKeyValueTypeAnnotation)
-      : Optional[LogicalTypeAnnotation] = {
-        Optional.of(LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance())
-      }
-    }).orElseGet(() => {
-      throw new IllegalArgumentException(s"Unknown logical type annotation: $inner")
-    })
+    // Iceberg releases can expose different visitor interfaces. Direct dispatch keeps the
+    // generated helper bytecode identical when multiple Iceberg artifacts are aggregated.
+    inner match {
+      case _: ShadedLogicalTypeAnnotation.StringLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.stringType()
+      case _: ShadedLogicalTypeAnnotation.MapLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.mapType()
+      case _: ShadedLogicalTypeAnnotation.ListLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.listType()
+      case _: ShadedLogicalTypeAnnotation.EnumLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.enumType()
+      case shaded: ShadedLogicalTypeAnnotation.DecimalLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.decimalType(shaded.getScale, shaded.getPrecision)
+      case _: ShadedLogicalTypeAnnotation.DateLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.dateType()
+      case shaded: ShadedLogicalTypeAnnotation.TimeLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.timeType(shaded.isAdjustedToUTC, unshade(shaded.getUnit))
+      case shaded: ShadedLogicalTypeAnnotation.TimestampLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.timestampType(shaded.isAdjustedToUTC, unshade(shaded.getUnit))
+      case shaded: ShadedLogicalTypeAnnotation.IntLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.intType(shaded.getBitWidth, shaded.isSigned)
+      case _: ShadedLogicalTypeAnnotation.JsonLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.jsonType()
+      case _: ShadedLogicalTypeAnnotation.BsonLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.bsonType()
+      case _: ShadedLogicalTypeAnnotation.UUIDLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.uuidType()
+      case _: ShadedLogicalTypeAnnotation.IntervalLogicalTypeAnnotation =>
+        LogicalTypeAnnotation.IntervalLogicalTypeAnnotation.getInstance()
+      case _: ShadedLogicalTypeAnnotation.MapKeyValueTypeAnnotation =>
+        LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance()
+      case _ => throw new IllegalArgumentException(s"Unknown logical type annotation: $inner")
+    }
   }
 
 

--- a/iceberg/iceberg-1-9-x/src/main/java/com/nvidia/spark/rapids/iceberg/GpuInternalRow.java
+++ b/iceberg/iceberg-1-9-x/src/main/java/com/nvidia/spark/rapids/iceberg/GpuInternalRow.java
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*** spark-rapids-shim-json-lines
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+spark-rapids-shim-json-lines ***/
 
 package com.nvidia.spark.rapids.iceberg;
 

--- a/scala2.13/aggregator/pom.xml
+++ b/scala2.13/aggregator/pom.xml
@@ -115,6 +115,45 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ban-conflicting-aggregator-classes</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!--
+                                  Only direct dependencies are shaded aggregator inputs. Checking
+                                  transitives would report unrelated third-party class conflicts.
+                                  See https://github.com/NVIDIA/cudf-spark/issues/14829.
+                                -->
+                                <banDuplicateClasses>
+                                    <searchTransitive>false</searchTransitive>
+                                    <scopes>
+                                        <scope>compile</scope>
+                                    </scopes>
+                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                    <findAllDuplicates>true</findAllDuplicates>
+                                    <message>Conflicting classes found in RAPIDS aggregator inputs</message>
+                                </banDuplicateClasses>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.12.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>


### PR DESCRIPTION
Fixes #14829.

### Description

The aggregator can currently shade multiple RAPIDS artifacts containing the same class name.
Maven Shade reports duplicates as warnings and keeps one input, which can silently package the
wrong shim implementation.

Add a deterministic Maven Enforcer check to the aggregator before packaging. The check scans
direct aggregator inputs, fails when the same class name has different bytecode, and permits
byte-identical duplicates such as the existing Spark 3.3 Delta `ShimUsesMetadataFields` classes.
Transitive dependencies are excluded so unrelated third-party class conflicts do not create noise.

The guard exposed two existing Iceberg 1.9/1.10 collisions in Spark 3.5.4+ builds. Resolve them
without an allowlist:

- Give both Spark 3.5 `GpuInternalRow` sources the same shim metadata so their generated class
  files are identical.
- Replace the Iceberg-version-sensitive anonymous Parquet logical-type visitor with direct type
  dispatch. This removes the conflicting `FromIcebergShaded` anonymous class while preserving
  conversion behavior.

The generated Scala 2.13 aggregator POM contains the same guard.

Validation:

- `./build/make-scala-version-build-files.sh 2.13`
- `mvn -Dbuildver=330 -DskipTests clean package`
- `mvn -Dbuildver=354 -DskipTests clean package`
- `mvn -f scala2.13/pom.xml -Dbuildver=354 -DskipTests clean package`
- `mvn -Dbuildver=354 -pl tests -am -DwildcardSuites=com.nvidia.spark.rapids.iceberg.GpuPostProcessorSuite package`
  (18 tests passed)

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      Spark 330 exercises the known identical Delta duplicates. Spark 354 exercises the
      two-version Iceberg aggregation, and `GpuPostProcessorSuite` covers shaded Parquet
      conversion.
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

This changes Maven build-time validation only and does not modify packaged runtime behavior.
