### PR TITLE
[fast-ut] [reduced-it] Add ANSI interval expression type coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -22,7 +22,7 @@ from conftest import is_not_utc
 from data_gen import *
 from spark_session import with_cpu_session, is_before_spark_313
 from pyspark.sql.types import *
-from marks import datagen_overrides, allow_non_gpu
+from marks import datagen_overrides, allow_non_gpu, validate_execs_in_gpu_plan
 import pyspark.sql.functions as f
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + struct_gens_sample_with_decimal128_no_list, ids=idfn)
@@ -252,11 +252,13 @@ def test_isnull(data_gen):
             lambda spark : unary_op_df(spark, data_gen).select(
                 f.isnull(f.col('a'))))
 
-def test_isnull_for_interval():
+@validate_execs_in_gpu_plan('GpuProjectExec')
+def test_isnull_and_isnotnull_for_interval():
     data_gen = DayTimeIntervalGen()
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).select(
-            f.isnull(f.col('a'))))
+            f.isnull(f.col('a')),
+            f.col('a').isNotNull()))
 
 @pytest.mark.parametrize('data_gen', [FloatGen(), DoubleGen()], ids=idfn)
 def test_isnan(data_gen):

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -161,25 +161,22 @@ def test_coalesce(data_gen):
 def test_coalesce_year_month_interval():
     # PySpark 3.3 cannot deserialize a YearMonthIntervalType result, so cast the
     # coalesce result to its month count after the expression has been evaluated.
-    # Keep the interval producer and Coalesce in separate projects. Otherwise,
-    # Databricks can collapse them and rewrite the integer CaseWhen + multiply
-    # into an unsupported interval-valued CaseWhen, obscuring the Coalesce path.
+    # Use nullable input columns for the interval multipliers. Building the
+    # nullability with CaseWhen lets Databricks rewrite it as an unsupported
+    # interval-valued CPU expression before Coalesce reaches the GPU.
     def do_it(spark):
-        return spark.range(4).selectExpr(
-            "INTERVAL '0-1' YEAR TO MONTH * "
-            "CASE id WHEN 0 THEN 1 WHEN 3 THEN -13 END AS a",
-            "INTERVAL '0-1' YEAR TO MONTH * "
-            "CASE id WHEN 1 THEN 2 WHEN 3 THEN 0 END AS b") \
+        return spark.createDataFrame(
+            [(1, None), (None, 2), (None, None), (-13, 0)],
+            'a_multiplier INT, b_multiplier INT') \
+            .selectExpr(
+                "INTERVAL '0-1' YEAR TO MONTH * a_multiplier AS a",
+                "INTERVAL '0-1' YEAR TO MONTH * b_multiplier AS b") \
             .selectExpr("CAST(coalesce(a, b) AS BIGINT)")
 
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         do_it,
         exist_classes='GpuCoalesce',
-        conf={
-            'spark.sql.optimizer.excludedRules':
-                'org.apache.spark.sql.catalyst.optimizer.CollapseProject',
-            'spark.sql.adaptive.enabled': 'false'
-        })
+        conf={'spark.sql.adaptive.enabled': 'false'})
 
 def test_coalesce_constant_output():
     # Coalesce can allow a constant value as output. Technically Spark should mark this

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -158,18 +158,28 @@ def test_coalesce(data_gen):
             lambda spark : gen_df(spark, gen).select(
                 f.coalesce(*command_args)))
 
-@validate_execs_in_gpu_plan('GpuProjectExec')
 def test_coalesce_year_month_interval():
     # PySpark 3.3 cannot deserialize a YearMonthIntervalType result, so cast the
     # coalesce result to its month count after the expression has been evaluated.
-    # Build nullable inputs through the existing GPU-supported interval multiply path.
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.range(4).selectExpr(
+    # Keep the interval producer and Coalesce in separate projects. Otherwise,
+    # Databricks can collapse them and rewrite the integer CaseWhen + multiply
+    # into an unsupported interval-valued CaseWhen, obscuring the Coalesce path.
+    def do_it(spark):
+        return spark.range(4).selectExpr(
             "INTERVAL '0-1' YEAR TO MONTH * "
             "CASE id WHEN 0 THEN 1 WHEN 3 THEN -13 END AS a",
             "INTERVAL '0-1' YEAR TO MONTH * "
-            "CASE id WHEN 1 THEN 2 WHEN 3 THEN 0 END AS b")
-        .selectExpr("CAST(coalesce(a, b) AS BIGINT)"))
+            "CASE id WHEN 1 THEN 2 WHEN 3 THEN 0 END AS b") \
+            .selectExpr("CAST(coalesce(a, b) AS BIGINT)")
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes='GpuCoalesce',
+        conf={
+            'spark.sql.optimizer.excludedRules':
+                'org.apache.spark.sql.catalyst.optimizer.CollapseProject',
+            'spark.sql.adaptive.enabled': 'false'
+        })
 
 def test_coalesce_constant_output():
     # Coalesce can allow a constant value as output. Technically Spark should mark this

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -18,7 +18,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are
 from data_gen import *
 from spark_session import is_before_spark_320, is_jvm_charset_utf8, is_before_spark_400
 from pyspark.sql.types import *
-from marks import datagen_overrides, allow_non_gpu, disable_ansi_mode
+from marks import datagen_overrides, allow_non_gpu, disable_ansi_mode, validate_execs_in_gpu_plan
 import pyspark.sql.functions as f
 
 # mark this test as ci_1 for mvn verify sanity check in pre-merge CI
@@ -138,7 +138,13 @@ def test_nvl(data_gen):
 # in both cpu and gpu runs.
 #      E: java.lang.AssertionError: assertion failed: each serializer expression should contain\
 #         at least one `BoundReference`
-@pytest.mark.parametrize('data_gen', all_gens + all_nested_gens_nonempty_struct + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize(
+    'data_gen', all_gens + [
+        pytest.param(
+            DayTimeIntervalGen(),
+            marks=validate_execs_in_gpu_plan('GpuProjectExec'))
+    ] +
+    all_nested_gens_nonempty_struct + map_gens_sample, ids=idfn)
 def test_coalesce(data_gen):
     num_cols = 20
     s1 = with_cpu_session(
@@ -151,6 +157,19 @@ def test_coalesce(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gen).select(
                 f.coalesce(*command_args)))
+
+@validate_execs_in_gpu_plan('GpuProjectExec')
+def test_coalesce_year_month_interval():
+    # PySpark 3.3 cannot deserialize a YearMonthIntervalType result, so cast the
+    # coalesce result to its month count after the expression has been evaluated.
+    # Build nullable inputs through the existing GPU-supported interval multiply path.
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.range(4).selectExpr(
+            "INTERVAL '0-1' YEAR TO MONTH * "
+            "CASE id WHEN 0 THEN 1 WHEN 3 THEN -13 END AS a",
+            "INTERVAL '0-1' YEAR TO MONTH * "
+            "CASE id WHEN 1 THEN 2 WHEN 3 THEN 0 END AS b")
+        .selectExpr("CAST(coalesce(a, b) AS BIGINT)"))
 
 def test_coalesce_constant_output():
     # Coalesce can allow a constant value as output. Technically Spark should mark this

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2000,7 +2000,8 @@ def test_reduction_with_max_by_same(data_gen):
             DayTimeIntervalGen(),
             marks=[
                 pytest.mark.xfail(
-                    reason='https://github.com/NVIDIA/cudf-spark/issues/15776'),
+                    reason='https://github.com/NVIDIA/cudf-spark/issues/15776',
+                    strict=True),
                 validate_execs_in_gpu_plan('GpuHashAggregateExec')
             ])
     ] + _nested_gens, ids=idfn)
@@ -2015,7 +2016,8 @@ def test_count(data_gen):
             'count(1)'),
         conf = {'spark.sql.legacy.allowParameterlessCount': 'true'})
 
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/cudf-spark/issues/15776')
+@pytest.mark.xfail(
+    reason='https://github.com/NVIDIA/cudf-spark/issues/15776', strict=True)
 @validate_execs_in_gpu_plan('GpuHashAggregateExec')
 def test_count_year_month_interval():
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1994,7 +1994,16 @@ def test_reduction_with_max_by_same(data_gen):
         lambda spark: unary_op_df(spark, data_gen).selectExpr(
             "min_by(a, a)", "max_by(a, a)"))
 
-@pytest.mark.parametrize('data_gen', all_gen + _nested_gens, ids=idfn)
+@pytest.mark.parametrize(
+    'data_gen', all_gen + [
+        pytest.param(
+            DayTimeIntervalGen(),
+            marks=[
+                pytest.mark.xfail(
+                    reason='https://github.com/NVIDIA/cudf-spark/issues/15776'),
+                validate_execs_in_gpu_plan('GpuHashAggregateExec')
+            ])
+    ] + _nested_gens, ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_count(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -2005,6 +2014,15 @@ def test_count(data_gen):
             'count()',
             'count(1)'),
         conf = {'spark.sql.legacy.allowParameterlessCount': 'true'})
+
+@pytest.mark.xfail(reason='https://github.com/NVIDIA/cudf-spark/issues/15776')
+@validate_execs_in_gpu_plan('GpuHashAggregateExec')
+def test_count_year_month_interval():
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.range(4).selectExpr(
+            "INTERVAL '0-1' YEAR TO MONTH * "
+            "CASE WHEN id % 2 = 0 THEN 1 END AS a")
+        .selectExpr("count(a)"))
 
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
 @allow_non_gpu(*non_utc_allow)


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — the shim-350 b23 `sql-plugin` baseline contains 3 class-ID mismatches; the validated compatible subset contributes +1 line** (`sql-plugin` compatible subset `+1`; `delta-lake` N/A because shim 350 exposes only `delta-stub` (`+0`), `iceberg +0`, `shuffle-plugin +0`, `udf-compiler +0`; anchor `01ad3b33`, Scala 2.12, shim 350)

Fixes #15778.
Refs #15776.

### Description

Add focused Python integration coverage for five previously uncovered ANSI interval expression/type combinations:

- `IsNotNull` with `DayTimeIntervalType`
- `Coalesce` with `DayTimeIntervalType` and `YearMonthIntervalType`
- `Count` with `DayTimeIntervalType` and `YearMonthIntervalType`

The null predicate and `Coalesce` cases assert CPU/GPU equality and an intended GPU project plan. The YearMonth `Coalesce` result is cast to its month count only after expression evaluation because PySpark 3.3 cannot deserialize `YearMonthIntervalType` results.

Both `Count` cases are present as explicit `xfail` coverage linked to #15776. The focused reproduction preserves CPU/GPU result parity but shows partial hash aggregation falling back for ANSI interval inputs, while the final aggregation runs on GPU.

Local validation:

- Spark 3.3 focused Python IT: `3 passed, 2917 deselected, 2 xfailed, 3 warnings in 17.52s`
- Spark 3.3 distribution build: `BUILD SUCCESS` (`08:42`)
- Spark 3.3 integration-test harness build: `BUILD SUCCESS` (`03:08`)
- Full 32-config `Count` reproduction: `RAPIDS Enabled = YES`, `Plugins Loaded = YES`, GPU operators present, and CPU/GPU results equal for both interval types
- Spark 3.5 shim-350 JaCoCo run: `3 passed, 2856 deselected, 2 xfailed, 3 warnings in 7.69s`

JaCoCo detail: the compatible `sql-plugin` subset moves from `33869/41095` to `33870/41095`, covering `GpuOverrides.scala:784` at anchor `01ad3b33ff93c3a069aec12caad5dedac39eca7c`. The full-module total is intentionally not reported because the b23 baseline class IDs mismatch for `IcebergS3RangeCopier`, `RangeCopier`, and `OptimizeCorrelatedAggregateSubqueryRule`; the raw `+4` result is therefore not used.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
