### PR TITLE
[fast-ut] [reduced-it] Add collection expression corner-case coverage [databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_and_cpu_same_data_or_error, assert_gpu_fallback_collect
 from data_gen import *
 from conftest import is_databricks_runtime
-from marks import incompat, allow_non_gpu, disable_ansi_mode
+from marks import incompat, allow_non_gpu, disable_ansi_mode, validate_execs_in_gpu_plan
 from spark_session import *
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
@@ -314,7 +314,10 @@ def test_array_contains_for_nans(data_gen):
 orderable_gens_sample = orderable_gens + array_gens_sample + struct_gens_sample_with_decimal128
 orderable_gens_sample_no_null = [g for g in orderable_gens_sample if g != null_gen]
 @pytest.mark.parametrize('data_gen',
-    orderable_gens_sample_no_null if is_spark_340_or_later() or is_databricks_runtime() else orderable_gens_sample, ids=idfn)
+    (orderable_gens_sample_no_null if is_spark_340_or_later() or is_databricks_runtime()
+     else orderable_gens_sample) + [
+        pytest.param(BinaryGen(), marks=validate_execs_in_gpu_plan('GpuProjectExec'))
+    ], ids=idfn)
 def test_array_position(data_gen):
     # min_length=6 to make sure 'a[5]' always works.
     arr_gen = ArrayGen(data_gen, min_length=6)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -860,27 +860,8 @@ def test_sql_map_scalars(query):
 
 @pytest.mark.parametrize('data_gen', map_gens_sample + maps_with_binary_value \
                          + [MapGen(f(nullable=False, min_val=-10, max_val=10), f(), min_length=10) for f in [ByteGen, ShortGen, IntegerGen, LongGen]] \
-                         + [MapGen(StringGen(pattern='key_[0-9]', nullable=False), StringGen(), min_length=10)]
-                         + [
-                             pytest.param(
-                                 MapGen(DecimalGen(12, 2, nullable=False),
-                                        DecimalGen(12, 2, nullable=False), nullable=False),
-                                 marks=[
-                                     pytest.mark.xfail(
-                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783',
-                                         raises=_MapZipWithDecimalKnownIssue,
-                                         strict=True),
-                                     validate_execs_in_gpu_plan('GpuProjectExec')]),
-                             pytest.param(
-                                 MapGen(DecimalGen(20, 2, nullable=False),
-                                        DecimalGen(20, 2, nullable=False), nullable=False),
-                                 marks=[
-                                     pytest.mark.xfail(
-                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783',
-                                         raises=_MapZipWithDecimalKnownIssue,
-                                         strict=True),
-                                     validate_execs_in_gpu_plan('GpuProjectExec')])
-                         ], ids=idfn)
+                         + [MapGen(StringGen(pattern='key_[0-9]', nullable=False), StringGen(), min_length=10)],
+                         ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_map_zip_with(data_gen):
     def do_it(spark):
@@ -911,17 +892,63 @@ def test_map_zip_with(data_gen):
     # ANSI mode is disabled since this test verifies the behaviour of map_zip_with and the evaluation of the associated lambda. 
     # Exceptions during overflow conditions are tested in the arithmetic-ops tests.
     # Not using @disable_ansi_mode because of https://github.com/NVIDIA/spark-rapids/issues/13214.  Using explicit setting instead.
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
+
+
+@pytest.mark.parametrize('data_gen', [
+    MapGen(DecimalGen(12, 2, nullable=False),
+           DecimalGen(12, 2, nullable=False), nullable=False),
+    MapGen(DecimalGen(20, 2, nullable=False),
+           DecimalGen(20, 2, nullable=False), nullable=False),
+], ids=idfn)
+@validate_execs_in_gpu_plan('GpuProjectExec')
+@allow_non_gpu(*non_utc_allow)
+def test_map_zip_with_decimal_non_identity(data_gen):
+    def do_it(spark):
+        df = two_col_df(spark, data_gen, data_gen)
+        return df.selectExpr(
+            'a',
+            'b',
+            'map_zip_with(a, b, (key, value1, value2) -> null) as n',
+            'map_zip_with(a, b, (key, value1, value2) -> 1) as one',
+            'map_zip_with(a, b, (key, value1, value2) -> key) as indexed')
+
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
+
+
+@pytest.mark.parametrize('data_gen', [
+    MapGen(DecimalGen(12, 2, nullable=False),
+           DecimalGen(12, 2, nullable=False), nullable=False),
+    MapGen(DecimalGen(20, 2, nullable=False),
+           DecimalGen(20, 2, nullable=False), nullable=False),
+], ids=idfn)
+@pytest.mark.xfail(
+    reason='https://github.com/NVIDIA/cudf-spark/issues/15783',
+    raises=_MapZipWithDecimalKnownIssue,
+    strict=True)
+@validate_execs_in_gpu_plan('GpuProjectExec')
+@allow_non_gpu(*non_utc_allow)
+def test_map_zip_with_decimal_identity(data_gen):
+    def do_it(spark):
+        df = two_col_df(spark, data_gen, data_gen)
+        return df.selectExpr(
+            'map_zip_with(a, b, (key, value1, value2) -> value1) as ident1',
+            'map_zip_with(a, b, (key, value1, value2) -> value2) as ident2')
+
     try:
         assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
     except AssertionError as error:
-        if isinstance(data_gen.data_type.valueType, DecimalType):
+        message = str(error)
+        is_known_decimal_failure = (
+            'CPU (null) values are different at ' in message
+            and ("'ident1'" in message or "'ident2'" in message))
+        if is_known_decimal_failure:
             raise _MapZipWithDecimalKnownIssue() from error
         raise
     except Py4JJavaError as error:
         message = str(error)
         is_known_decimal_failure = (
-            isinstance(data_gen.data_type.valueType, DecimalType)
-            and 'java.lang.AssertionError:' in message
+            'java.lang.AssertionError:' in message
             and 'value at ' in message
             and ' is null' in message)
         if is_known_decimal_failure:

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -18,7 +18,8 @@ from asserts import *
 from conftest import is_not_utc
 from data_gen import *
 from conftest import is_databricks_runtime
-from marks import allow_non_gpu, datagen_overrides, disable_ansi_mode, ignore_order
+from marks import allow_non_gpu, datagen_overrides, disable_ansi_mode, ignore_order, \
+    validate_execs_in_gpu_plan
 from spark_session import *
 from pyspark.sql.functions import create_map, col, lit, row_number
 from pyspark.sql.types import *
@@ -852,7 +853,23 @@ def test_sql_map_scalars(query):
 
 @pytest.mark.parametrize('data_gen', map_gens_sample + maps_with_binary_value \
                          + [MapGen(f(nullable=False, min_val=-10, max_val=10), f(), min_length=10) for f in [ByteGen, ShortGen, IntegerGen, LongGen]] \
-                         + [MapGen(StringGen(pattern='key_[0-9]', nullable=False), StringGen(), min_length=10)], ids=idfn)
+                         + [MapGen(StringGen(pattern='key_[0-9]', nullable=False), StringGen(), min_length=10)]
+                         + [
+                             pytest.param(
+                                 MapGen(DecimalGen(12, 2, nullable=False),
+                                        DecimalGen(12, 2, nullable=False), nullable=False),
+                                 marks=[
+                                     pytest.mark.xfail(
+                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783'),
+                                     validate_execs_in_gpu_plan('GpuProjectExec')]),
+                             pytest.param(
+                                 MapGen(DecimalGen(20, 2, nullable=False),
+                                        DecimalGen(20, 2, nullable=False), nullable=False),
+                                 marks=[
+                                     pytest.mark.xfail(
+                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783'),
+                                     validate_execs_in_gpu_plan('GpuProjectExec')])
+                         ], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_map_zip_with(data_gen):
     def do_it(spark):

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from py4j.protocol import Py4JJavaError
 
 from asserts import *
 from conftest import is_not_utc
@@ -44,6 +45,12 @@ maps_with_struct_key = [
     MapGen(StructGen([['child0', IntegerGen()],
                       ['child1', IntegerGen()]], nullable=False),
            IntegerGen())]
+
+
+# Keep the xfail limited to issue #15783 so plan-validation failures still propagate.
+class _MapZipWithDecimalKnownIssue(Exception):
+    pass
+
 
 supported_key_map_gens = \
     map_gens_sample + \
@@ -860,14 +867,18 @@ def test_sql_map_scalars(query):
                                         DecimalGen(12, 2, nullable=False), nullable=False),
                                  marks=[
                                      pytest.mark.xfail(
-                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783'),
+                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783',
+                                         raises=_MapZipWithDecimalKnownIssue,
+                                         strict=True),
                                      validate_execs_in_gpu_plan('GpuProjectExec')]),
                              pytest.param(
                                  MapGen(DecimalGen(20, 2, nullable=False),
                                         DecimalGen(20, 2, nullable=False), nullable=False),
                                  marks=[
                                      pytest.mark.xfail(
-                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783'),
+                                         reason='https://github.com/NVIDIA/cudf-spark/issues/15783',
+                                         raises=_MapZipWithDecimalKnownIssue,
+                                         strict=True),
                                      validate_execs_in_gpu_plan('GpuProjectExec')])
                          ], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
@@ -900,7 +911,22 @@ def test_map_zip_with(data_gen):
     # ANSI mode is disabled since this test verifies the behaviour of map_zip_with and the evaluation of the associated lambda. 
     # Exceptions during overflow conditions are tested in the arithmetic-ops tests.
     # Not using @disable_ansi_mode because of https://github.com/NVIDIA/spark-rapids/issues/13214.  Using explicit setting instead.
-    assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
+    try:
+        assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
+    except AssertionError as error:
+        if isinstance(data_gen.data_type.valueType, DecimalType):
+            raise _MapZipWithDecimalKnownIssue() from error
+        raise
+    except Py4JJavaError as error:
+        message = str(error)
+        is_known_decimal_failure = (
+            isinstance(data_gen.data_type.valueType, DecimalType)
+            and 'java.lang.AssertionError:' in message
+            and 'value at ' in message
+            and ' is null' in message)
+        if is_known_decimal_failure:
+            raise _MapZipWithDecimalKnownIssue() from error
+        raise
 
 @pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(False, min_val=-5, max_val=5), ArrayGen(int_gen, max_length=5), min_length=7)], ids=idfn)
 @allow_non_gpu(*non_utc_allow)


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — `sql-plugin` is N/A because the shim-350/b23 baseline has 3 class-ID mismatches; measured compatible scope: `sql-plugin subset +0`, `delta-stub +0`, `iceberg +0`, `shuffle-plugin +0`, `udf-compiler +0`** (anchor `01ad3b33ff93c3a069aec12caad5dedac39eca7c`, Scala 2.12, shim 350, b23)

Fixes #15784.
Refs #15783.

### Description

This adds missing integration-test definition coverage for collection expression/type combinations:

- extend the existing `test_array_position` matrix with a literal `BinaryGen()` case;
- extend the existing `test_map_zip_with` matrix with non-null DECIMAL(12,2) and DECIMAL(20,2) map key/value cases;
- require `GpuProjectExec` for the added parameters.

The two DECIMAL cases reproduce the correctness defect tracked by #15783 and are marked `xfail` so the coverage definition lands without hiding the unresolved Milestone 2 work. There is no user-facing behavior change.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

Validation:

- Spark 3.3 dist build: `BUILD SUCCESS`
- Spark 3.3 integration-test harness build: `BUILD SUCCESS`
- Spark 3.3 / Python 3.10 focused integration test: `1 passed, 2 xfailed, 1437 deselected`
- Spark 3.5.0 / shim-350 b23 focused integration test: `1 passed, 2 xfailed, 1436 deselected`

The full shim-350 `sql-plugin` delta is not reported because its nightly baseline is bytecode-incompatible for three classes, and the PR exec reaches one of those classes. The compatible 1850-class subset and the other published report groups each measured `+0` production lines. The shim-350 report contains only the Delta stub group, so it is not evidence of real Delta implementation coverage.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
