### PR TITLE
Update Iceberg S3 input byte metrics

### DIFF
--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -25,6 +25,7 @@ import com.nvidia.spark.rapids.iceberg.ShimUtils;
 import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.metrics.Counter;
 import org.apache.spark.TaskContext;
 import org.apache.spark.sql.rapids.GpuTaskMetrics$;
 import org.slf4j.Logger;
@@ -46,16 +47,19 @@ public final class IcebergS3InputFile extends IcebergInputFile {
   private final String s3Bucket;
   private final String s3Key;
   private final IcebergS3Client icebergS3Client;
+  private final Counter readBytes;
 
   private IcebergS3InputFile(
       InputFile delegate,
       String s3Bucket,
       String s3Key,
-      IcebergS3Client icebergS3Client) {
+      IcebergS3Client icebergS3Client,
+      Counter readBytes) {
     super(delegate);
     this.s3Bucket = s3Bucket;
     this.s3Key = s3Key;
     this.icebergS3Client = icebergS3Client;
+    this.readBytes = readBytes;
   }
 
   public static IcebergInputFile maybeCreate(InputFile inputFile, FileIO fileIO) {
@@ -85,14 +89,17 @@ public final class IcebergS3InputFile extends IcebergInputFile {
       return delegate;
     }
     LOG.debug("IcebergS3RangeCopier path active for {}", inputFile.location());
-    return new IcebergS3InputFile(inputFile, s3Bucket, s3Key, icebergS3Client);
+    Counter readBytes = IcebergS3InputFileAccess.readBytesCounter(inputFile);
+    return new IcebergS3InputFile(
+        inputFile, s3Bucket, s3Key, icebergS3Client, readBytes);
   }
 
   @Override
   public void readVectored(HostMemoryBuffer output, List<CopyRange> copyRanges)
       throws IOException {
-    IcebergS3RangeCopier.copyToHMB(
+    long bytesRead = IcebergS3RangeCopier.copyToHMB(
         icebergS3Client, output, s3Bucket, s3Key, copyRanges);
+    readBytes.increment(bytesRead);
   }
 
   /**
@@ -108,8 +115,9 @@ public final class IcebergS3InputFile extends IcebergInputFile {
     if (length < 0) {
       throw new IllegalArgumentException("length must be non-negative");
     }
-    IcebergS3RangeCopier.copyTailToHMB(
+    long bytesRead = IcebergS3RangeCopier.copyTailToHMB(
         icebergS3Client, output, s3Bucket, s3Key, length, /*dstOffset*/ 0L);
+    readBytes.increment(bytesRead);
     LOG.debug(
         "PerfIO S3 Iceberg readTail suffix-range GET completed: uri=s3://{}/{}, "
             + "range=bytes=-{}",

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFileAccess.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFileAccess.java
@@ -19,6 +19,7 @@ package org.apache.iceberg.aws.s3;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.metrics.Counter;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
 
 /**
  * Root-loadable bridge for package-private Iceberg S3 APIs.
@@ -56,6 +57,6 @@ public final class IcebergS3InputFileAccess {
     if (!(inputFile instanceof BaseS3File)) {
       return null;
     }
-    return ((BaseS3File) inputFile).metrics().counter(FileIOMetricsContext.READ_BYTES);
+    return ((BaseS3File) inputFile).metrics().counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES);
   }
 }

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFileAccess.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFileAccess.java
@@ -16,7 +16,9 @@
 
 package org.apache.iceberg.aws.s3;
 
+import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.metrics.Counter;
 
 /**
  * Root-loadable bridge for package-private Iceberg S3 APIs.
@@ -47,5 +49,13 @@ public final class IcebergS3InputFileAccess {
     }
     S3URI uri = ((BaseS3File) inputFile).uri();
     return new String[] {uri.bucket(), uri.key()};
+  }
+
+  /** Returns the Iceberg read-bytes counter for an S3 input file. */
+  public static Counter readBytesCounter(InputFile inputFile) {
+    if (!(inputFile instanceof BaseS3File)) {
+      return null;
+    }
+    return ((BaseS3File) inputFile).metrics().counter(FileIOMetricsContext.READ_BYTES);
   }
 }

--- a/scala2.13/tests/pom.xml
+++ b/scala2.13/tests/pom.xml
@@ -106,6 +106,12 @@
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-spark-runtime-${iceberg.artifact.suffix}_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.23.14</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -106,6 +106,12 @@
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-spark-runtime-${iceberg.artifact.suffix}_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.23.14</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/src/test/scala/org/apache/iceberg/aws/s3/IcebergS3InputFileSuite.scala
+++ b/tests/src/test/scala/org/apache/iceberg/aws/s3/IcebergS3InputFileSuite.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.aws.s3
+
+import java.io.IOException
+import java.util.Collections
+
+import ai.rapids.cudf.HostMemoryBuffer
+import com.nvidia.spark.rapids.IcebergS3RangeCopier
+import com.nvidia.spark.rapids.IcebergS3RangeCopier.IcebergS3Client
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile.CopyRange
+import org.apache.iceberg.hadoop.HadoopMetricsContext
+import org.apache.iceberg.io.{FileIOMetricsContext, InputFile}
+import org.apache.iceberg.metrics.{Counter, DefaultMetricsContext}
+import org.mockito.Mockito.{mock, mockStatic, when}
+import org.mockito.invocation.InvocationOnMock
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+
+class IcebergS3InputFileSuite extends AnyFunSuite with Matchers {
+
+  private def newInputFile(readBytes: Counter): IcebergS3InputFile = {
+    val constructor = classOf[IcebergS3InputFile].getDeclaredConstructor(
+      classOf[InputFile],
+      classOf[String],
+      classOf[String],
+      classOf[IcebergS3Client],
+      classOf[Counter])
+    constructor.setAccessible(true)
+    constructor.newInstance(
+      mock(classOf[InputFile]),
+      "bucket",
+      "key",
+      mock(classOf[IcebergS3Client]),
+      readBytes)
+  }
+
+  test("read bytes counter updates Hadoop statistics used by Spark") {
+    val metrics = new HadoopMetricsContext("s3")
+    val delegate = mock(classOf[S3InputFile])
+    when(delegate.uri()).thenReturn(new S3URI("s3://bucket/key"))
+    when(delegate.metrics()).thenReturn(metrics)
+
+    IcebergS3InputFileAccess.s3BucketAndKey(delegate) should contain theSameElementsInOrderAs
+      Array("bucket", "key")
+    val readBytes = IcebergS3InputFileAccess.readBytesCounter(delegate)
+    val sparkBytesRead = TrampolineUtil.getFSBytesReadOnThreadCallback()
+
+    readBytes.increment(17L)
+
+    sparkBytesRead() shouldBe 17L
+  }
+
+  test("successful PerfIO reads count the bytes delivered by the copier") {
+    val metrics = new DefaultMetricsContext
+    val readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES)
+    val inputFile = newInputFile(readBytes)
+    val output = mock(classOf[HostMemoryBuffer])
+    val ranges = Collections.singletonList(new CopyRange(0L, 100L, 0L))
+    val copier = mockStatic(classOf[IcebergS3RangeCopier], (invocation: InvocationOnMock) => {
+      invocation.getMethod.getName match {
+        case "copyToHMB" => Long.box(23L)
+        case "copyTailToHMB" => Long.box(11L)
+        case _ => null
+      }
+    })
+    try {
+      inputFile.readVectored(output, ranges)
+      readBytes.value() shouldBe 23L
+
+      inputFile.readTail(100L, output)
+      readBytes.value() shouldBe 34L
+
+      inputFile.readTail(0L, output)
+      readBytes.value() shouldBe 34L
+    } finally {
+      copier.close()
+    }
+  }
+
+  test("failed PerfIO reads do not update read bytes") {
+    val metrics = new DefaultMetricsContext
+    val readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES)
+    val inputFile = newInputFile(readBytes)
+    val output = mock(classOf[HostMemoryBuffer])
+    val ranges = Collections.singletonList(new CopyRange(0L, 100L, 0L))
+    val copier = mockStatic(classOf[IcebergS3RangeCopier], (invocation: InvocationOnMock) => {
+      invocation.getMethod.getName match {
+        case "copyToHMB" | "copyTailToHMB" => throw new IOException("read failed")
+        case _ => null
+      }
+    })
+    try {
+      intercept[IOException](inputFile.readVectored(output, ranges))
+      intercept[IOException](inputFile.readTail(100L, output))
+      readBytes.value() shouldBe 0L
+    } finally {
+      copier.close()
+    }
+  }
+}

--- a/tests/src/test/scala/org/apache/iceberg/aws/s3/IcebergS3InputFileSuite.scala
+++ b/tests/src/test/scala/org/apache/iceberg/aws/s3/IcebergS3InputFileSuite.scala
@@ -26,6 +26,7 @@ import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile.CopyRange
 import org.apache.iceberg.hadoop.HadoopMetricsContext
 import org.apache.iceberg.io.{FileIOMetricsContext, InputFile}
 import org.apache.iceberg.metrics.{Counter, DefaultMetricsContext}
+import org.apache.iceberg.metrics.MetricsContext.Unit
 import org.mockito.Mockito.{mock, mockStatic, when}
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.funsuite.AnyFunSuite
@@ -69,7 +70,7 @@ class IcebergS3InputFileSuite extends AnyFunSuite with Matchers {
 
   test("successful PerfIO reads count the bytes delivered by the copier") {
     val metrics = new DefaultMetricsContext
-    val readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES)
+    val readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES)
     val inputFile = newInputFile(readBytes)
     val output = mock(classOf[HostMemoryBuffer])
     val ranges = Collections.singletonList(new CopyRange(0L, 100L, 0L))
@@ -96,7 +97,7 @@ class IcebergS3InputFileSuite extends AnyFunSuite with Matchers {
 
   test("failed PerfIO reads do not update read bytes") {
     val metrics = new DefaultMetricsContext
-    val readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES)
+    val readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES)
     val inputFile = newInputFile(readBytes)
     val output = mock(classOf[HostMemoryBuffer])
     val ranges = Collections.singletonList(new CopyRange(0L, 100L, 0L))

--- a/tests/src/test/spark350/scala/org/apache/iceberg/aws/s3/IcebergS3InputFileSuite.scala
+++ b/tests/src/test/spark350/scala/org/apache/iceberg/aws/s3/IcebergS3InputFileSuite.scala
@@ -14,6 +14,26 @@
  * limitations under the License.
  */
 
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+{"spark": "359"}
+{"spark": "400"}
+{"spark": "401"}
+{"spark": "402"}
+{"spark": "403"}
+{"spark": "404"}
+{"spark": "411"}
+{"spark": "412"}
+{"spark": "413"}
+spark-rapids-shim-json-lines ***/
 package org.apache.iceberg.aws.s3
 
 import java.io.IOException


### PR DESCRIPTION
Fixes #15705.

### Description

PerfIO S3 reads used by Iceberg bypassed Iceberg's normal input stream and therefore did not update Iceberg `READ_BYTES`, Hadoop `FileSystem.Statistics`, or Spark task input metrics.

This change obtains the delegate S3 input file's read-bytes counter and increments it with the bytes actually delivered after each successful vectored or tail read. Failed reads do not update the counter. The tests cover propagation into Hadoop/Spark statistics, successful vectored and tail reads, zero-length tail reads, and failed reads.

### Performance

Measured the exact added operation, `HadoopMetricsContext`'s `READ_BYTES` counter increment, using five fresh JVM runs. Each run used 5 million warm-up increments followed by seven trials of 20 million increments; the median was recorded per run.

- Environment: AMD Ryzen Threadripper PRO 5975WX, OpenJDK 17.0.19
- Median increment overhead across runs: 3.28-3.43 ns per completed read call
- At 100,000 read calls/second, the measured cost is approximately 0.034% of one CPU core

The counter is updated once after a completed S3 vectored or tail read, not once per byte or individual range, so this CPU cost is negligible relative to the S3 I/O operation.

### Checklists

Documentation
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths

Validated with Spark 3.5/Scala 2.12 and the reported Spark 4.0.2/Scala 2.13 profile. The Spark 4.0.2 reactor compiled both Iceberg 1.10 and Iceberg 1.11 modules.

```text
mvn test -Dbuildver=350 \
  -pl iceberg/iceberg-1-6-x,tests -am \
  -DwildcardSuites=org.apache.iceberg.aws.s3.IcebergS3InputFileSuite

cd scala2.13
mvn install -Dbuildver=402 \
  -pl iceberg/iceberg-1-10-x,iceberg/iceberg-1-11-x,tests -am \
  -DskipTests
mvn test -Dbuildver=402 -pl tests \
  -DwildcardSuites=org.apache.iceberg.aws.s3.IcebergS3InputFileSuite
```

All three focused tests passed in both profiles.

Performance
- [x] Tests ran and results are added in the PR description
