### PR TITLE
Fix pre-1000 DateGen lead lag defaults [databricks] 

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -910,6 +910,12 @@ def gen_df(spark, data_gen, length=2048, seed=None, num_slices=None):
         SparkContext.getOrCreate().parallelize(data, numSlices=num_slices),
         src.data_type)
 
+def _date_to_iso_string(data):
+    # Due to https://bugs.python.org/issue13305 we need to zero pad for years prior to 1000,
+    # but this works for all of them.
+    return data.strftime("%Y-%m-%d").zfill(10)
+
+
 def _mark_as_lit(data, data_type):
     # To support nested types, 'data_type' is required.
     assert data_type is not None
@@ -927,9 +933,7 @@ def _mark_as_lit(data, data_type):
         children = zip(data, data_type.fields)
         return f.struct([_mark_as_lit(x, fd.dataType).alias(fd.name) for x, fd in children])
     elif isinstance(data_type, DateType):
-        # Due to https://bugs.python.org/issue13305 we need to zero pad for years prior to 1000,
-        # but this works for all of them
-        dateString = data.strftime("%Y-%m-%d").zfill(10)
+        dateString = _date_to_iso_string(data)
         return f.lit(dateString).cast(data_type)
     elif isinstance(data_type, MapType):
         assert isinstance(data, dict)
@@ -972,12 +976,20 @@ def gen_scalar(data_gen, seed=None, force_no_nulls=False):
     return v[0]
 
 def gen_scalar_values(data_gen, count, seed=None, force_no_nulls=False):
-    """Generate scalar values."""
+    """Generate scalar values suitable for PySpark function arguments."""
     src = _gen_scalars_common(data_gen, count, seed=seed)
-    return (src.gen(force_no_nulls=force_no_nulls) for i in range(0, count))
+    data_type = src.data_type
+
+    def gen_value():
+        value = src.gen(force_no_nulls=force_no_nulls)
+        if value is not None and isinstance(data_type, DateType):
+            return _date_to_iso_string(value)
+        return value
+
+    return (gen_value() for i in range(0, count))
 
 def gen_scalar_value(data_gen, seed=None, force_no_nulls=False):
-    """Generate a single scalar value."""
+    """Generate a single scalar value suitable for a PySpark function argument."""
     v = list(gen_scalar_values(data_gen, 1, seed=seed, force_no_nulls=force_no_nulls))
     return v[0]
 

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -1826,7 +1826,15 @@ def test_multi_types_window_aggs_for_rows_lead_lag(a_b_gen, c_gen, batch_size, a
 @ignore_order(local=True)
 @approximate_float
 @pytest.mark.parametrize(
-    'data_gen', [ByteGen(), ShortGen(), FloatGen(), DateGen()], ids=idfn)
+    'data_gen', [
+        ByteGen(),
+        ShortGen(),
+        FloatGen(),
+        DateGen(),
+        pytest.param(
+            DateGen(start=date(4, 3, 1), end=date(4, 3, 1)),
+            id='pre-1000-date')],
+    ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 @validate_execs_in_gpu_plan('GpuBatchedBoundedWindowExec')
 def test_lead_lag_byte_short_float_date(data_gen):


### PR DESCRIPTION
Fixes #15787.

### Description

DateGen can generate dates before year 1000. PySpark formats raw Python date arguments for lead and lag with strftime, which may omit leading zeroes and cause java.sql.Date.valueOf to reject the default before query execution.

This change centralizes the existing zero-padded ISO date formatting used by _mark_as_lit and applies it to generated scalar values intended for PySpark function arguments. Null and non-date scalar values are unchanged.

The lead and lag integration test retains unrestricted DateGen coverage and adds a bounded year-4 case so the regression is exercised on every run without pinning DATAGEN_SEED.

Validation:
- python3 -m py_compile for the modified Python files
- git diff --check
- Direct DateGen validation for the bounded year-4 case and DATAGEN_SEED=1787731280
- Spark 4.0.1 CPU validation confirmed a DateType result containing 0004-03-01
- Full GPU integration test not run locally because the NVIDIA driver is unavailable

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required