### PR TITLE
Support Delta CDF read [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationStrategy.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationStrategy.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.common
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Literal}
+import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
+import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
+import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+
+/**
+ * Plans the internal DataFrame of an OSS Delta batch CDF relation directly.
+ *
+ * DeltaCDFRelation.buildScan returns the internal DataFrame as RDD[Row]. Spark wraps that RDD in a
+ * RowDataSourceScanExec, introducing a row boundary around file scans that can otherwise remain
+ * columnar. Replanning the internal logical plan exposes those scans to the regular Spark and
+ * RAPIDS planning rules.
+ */
+object DeltaCDFRelationStrategy extends SparkStrategy {
+
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case PhysicalOperation(projects, filters, relation: LogicalRelation)
+        if relation.relation.isInstanceOf[DeltaCDFRelation] =>
+      val cdf = relation.relation.asInstanceOf[DeltaCDFRelation]
+      if (cdf.startingVersion.isEmpty) {
+        Nil
+      } else {
+        val spark = cdf.sqlContext.sparkSession
+        val snapshot = cdf.snapshotWithSchemaMode.snapshot
+        val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
+          case BatchCDFSchemaEndVersion =>
+            val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
+            snapshot.deltaLog.getSnapshotAt(version)
+          case _ => snapshot
+        }
+        val changes = CDCReader.changesToBatchDF(
+          snapshot.deltaLog,
+          cdf.startingVersion.get,
+          cdf.endingVersion.getOrElse(snapshot.deltaLog.update().version),
+          spark,
+          readSchemaSnapshot = Some(readSchemaSnapshot))
+
+        val changesByName = changes.queryExecution.analyzed.output.map(a => a.name -> a).toMap
+        val relationOutput = relation.output.map { attr =>
+          Alias(changesByName(attr.name), attr.name)(
+            exprId = attr.exprId,
+            qualifier = attr.qualifier,
+            explicitMetadata = Some(attr.metadata))
+        }
+        val filter = filters.reduceOption(And).getOrElse(Literal.TrueLiteral)
+        val rewritten = Project(projects,
+          Filter(filter, Project(relationOutput, changes.queryExecution.analyzed)))
+
+        Seq(planLater(spark.sessionState.optimizer.execute(rewritten)))
+      }
+    case _ => Nil
+  }
+}

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationStrategy.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationStrategy.scala
@@ -19,8 +19,6 @@ package com.nvidia.spark.rapids.delta.common
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, Literal}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
-import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
-import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -43,19 +41,7 @@ object DeltaCDFRelationStrategy extends SparkStrategy {
         Nil
       } else {
         val spark = cdf.sqlContext.sparkSession
-        val snapshot = cdf.snapshotWithSchemaMode.snapshot
-        val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
-          case BatchCDFSchemaEndVersion =>
-            val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
-            snapshot.deltaLog.getSnapshotAt(version)
-          case _ => snapshot
-        }
-        val changes = CDCReader.changesToBatchDF(
-          snapshot.deltaLog,
-          cdf.startingVersion.get,
-          cdf.endingVersion.getOrElse(snapshot.deltaLog.update().version),
-          spark,
-          readSchemaSnapshot = Some(readSchemaSnapshot))
+        val changes = DeltaCDFRelationShim.changesToBatchDF(cdf)
 
         val changesByName = changes.queryExecution.analyzed.output.map(a => a.name -> a).toMap
         val relationOutput = relation.output.map { attr =>

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -71,6 +71,9 @@ case class GpuIncrementMetric(cpuInc: IncrementMetric, override val child: Expre
 
 abstract class DeltaProviderBase extends DeltaIOProvider {
 
+  override def getStrategyRules: Seq[SparkStrategy] =
+    DeltaCDFRelationStrategy +: super.getStrategyRules
+
   override def getCreatableRelationRules: Map[Class[_ <: CreatableRelationProvider],
       CreatableRelationProviderRule[_ <: CreatableRelationProvider]] = {
     Seq(

--- a/delta-lake/common/src/main/delta-33x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/common/src/main/delta-33x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.common
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
+
+private[common] object DeltaCDFRelationShim {
+
+  def changesToBatchDF(cdf: DeltaCDFRelation): DataFrame = {
+    val spark = cdf.sqlContext.sparkSession
+    val snapshot = cdf.snapshotWithSchemaMode.snapshot
+    val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
+      case BatchCDFSchemaEndVersion =>
+        val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
+        snapshot.deltaLog.getSnapshotAt(version)
+      case _ => snapshot
+    }
+    CDCReader.changesToBatchDF(
+      snapshot.deltaLog,
+      cdf.startingVersion.get,
+      cdf.endingVersion.getOrElse(snapshot.deltaLog.update().version),
+      spark,
+      readSchemaSnapshot = Some(readSchemaSnapshot))
+  }
+}

--- a/delta-lake/common/src/main/delta-33x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/common/src/main/delta-33x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -17,21 +17,25 @@
 package com.nvidia.spark.rapids.delta.common
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
 
 private[common] object DeltaCDFRelationShim {
 
+  // Delta 3.3 keeps the analysis-time schema snapshot private. This version-pinned shim accesses
+  // the exact snapshot used to build relation.output rather than reconstructing it from the log.
+  private val snapshotForBatchSchemaMethod = {
+    val method = classOf[DeltaCDFRelation].getDeclaredMethod("snapshotForBatchSchema")
+    method.setAccessible(true)
+    method
+  }
+
   def changesToBatchDF(cdf: DeltaCDFRelation): DataFrame = {
     val spark = cdf.sqlContext.sparkSession
     val snapshot = cdf.snapshotWithSchemaMode.snapshot
-    val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
-      case BatchCDFSchemaEndVersion =>
-        val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
-        snapshot.deltaLog.getSnapshotAt(version)
-      case _ => snapshot
-    }
+    val readSchemaSnapshot =
+      snapshotForBatchSchemaMethod.invoke(cdf).asInstanceOf[Snapshot]
     CDCReader.changesToBatchDF(
       snapshot.deltaLog,
       cdf.startingVersion.get,

--- a/delta-lake/common/src/main/delta-40x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/common/src/main/delta-40x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.common
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
+
+private[common] object DeltaCDFRelationShim {
+
+  def changesToBatchDF(cdf: DeltaCDFRelation): DataFrame = {
+    val spark = cdf.sqlContext.sparkSession
+    val snapshot = cdf.snapshotWithSchemaMode.snapshot
+    val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
+      case BatchCDFSchemaEndVersion =>
+        val latestVersion = snapshot.deltaLog.update(
+          catalogTableOpt = cdf.catalogTableOpt).version
+        val version = cdf.endingVersion.map(latestVersion min _).getOrElse(latestVersion)
+        snapshot.deltaLog.getSnapshotAt(version, catalogTableOpt = cdf.catalogTableOpt)
+      case _ => snapshot
+    }
+    CDCReader.changesToBatchDF(
+      snapshot.deltaLog,
+      cdf.startingVersion.get,
+      cdf.endingVersion.getOrElse {
+        snapshot.deltaLog.update(catalogTableOpt = cdf.catalogTableOpt).version
+      },
+      spark,
+      readSchemaSnapshot = Some(readSchemaSnapshot))
+  }
+}

--- a/delta-lake/common/src/main/delta-40x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/common/src/main/delta-40x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -28,9 +28,8 @@ private[common] object DeltaCDFRelationShim {
     val snapshot = cdf.snapshotWithSchemaMode.snapshot
     val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
       case BatchCDFSchemaEndVersion =>
-        val latestVersion = snapshot.deltaLog.update(
-          catalogTableOpt = cdf.catalogTableOpt).version
-        val version = cdf.endingVersion.map(latestVersion min _).getOrElse(latestVersion)
+        // Keep the schema consistent with the relation output that Delta resolved during analysis.
+        val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
         snapshot.deltaLog.getSnapshotAt(version, catalogTableOpt = cdf.catalogTableOpt)
       case _ => snapshot
     }

--- a/delta-lake/common/src/main/delta-40x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/common/src/main/delta-40x/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -17,22 +17,25 @@
 package com.nvidia.spark.rapids.delta.common
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
 
 private[common] object DeltaCDFRelationShim {
 
+  // Delta 4.0 keeps the analysis-time schema snapshot private. This version-pinned shim accesses
+  // the exact snapshot used to build relation.output rather than reconstructing it from the log.
+  private val snapshotForBatchSchemaMethod = {
+    val method = classOf[DeltaCDFRelation].getDeclaredMethod("snapshotForBatchSchema")
+    method.setAccessible(true)
+    method
+  }
+
   def changesToBatchDF(cdf: DeltaCDFRelation): DataFrame = {
     val spark = cdf.sqlContext.sparkSession
     val snapshot = cdf.snapshotWithSchemaMode.snapshot
-    val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
-      case BatchCDFSchemaEndVersion =>
-        // Keep the schema consistent with the relation output that Delta resolved during analysis.
-        val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
-        snapshot.deltaLog.getSnapshotAt(version, catalogTableOpt = cdf.catalogTableOpt)
-      case _ => snapshot
-    }
+    val readSchemaSnapshot =
+      snapshotForBatchSchemaMethod.invoke(cdf).asInstanceOf[Snapshot]
     CDCReader.changesToBatchDF(
       snapshot.deltaLog,
       cdf.startingVersion.get,

--- a/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -28,9 +28,8 @@ private[common] object DeltaCDFRelationShim {
     val snapshot = cdf.snapshotWithSchemaMode.snapshot
     val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
       case BatchCDFSchemaEndVersion =>
-        val latestVersion = snapshot.deltaLog.update(
-          catalogTableOpt = cdf.catalogTableOpt).version
-        val version = cdf.endingVersion.map(latestVersion min _).getOrElse(latestVersion)
+        // Keep the schema consistent with the relation output that Delta resolved during analysis.
+        val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
         snapshot.deltaLog.getSnapshotAt(version, catalogTableOpt = cdf.catalogTableOpt)
       case _ => snapshot
     }

--- a/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -17,22 +17,23 @@
 package com.nvidia.spark.rapids.delta.common
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
 
 private[common] object DeltaCDFRelationShim {
 
+  // Delta 4.1 exposes the analysis-time schema snapshot as protected. This version-pinned shim
+  // accesses the exact snapshot used to build relation.output rather than reconstructing it.
+  private val snapshotForBatchSchemaMethod = {
+    val method = classOf[DeltaCDFRelation].getMethod("snapshotForBatchSchema")
+    method.setAccessible(true)
+    method
+  }
+
   def changesToBatchDF(cdf: DeltaCDFRelation): DataFrame = {
     val spark = cdf.sqlContext.sparkSession
     val snapshot = cdf.snapshotWithSchemaMode.snapshot
-    val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
-      case BatchCDFSchemaEndVersion =>
-        // Keep the schema consistent with the relation output that Delta resolved during analysis.
-        val version = cdf.endingVersion.map(snapshot.version min _).getOrElse(snapshot.version)
-        snapshot.deltaLog.getSnapshotAt(version, catalogTableOpt = cdf.catalogTableOpt)
-      case _ => snapshot
-    }
     CDCReader.changesToBatchDF(
       snapshot.deltaLog,
       cdf.startingVersion.get,
@@ -41,6 +42,7 @@ private[common] object DeltaCDFRelationShim {
       },
       spark,
       catalogTableOpt = cdf.catalogTableOpt,
-      readSchemaSnapshot = Some(readSchemaSnapshot))
+      readSchemaSnapshot = Some(
+        snapshotForBatchSchemaMethod.invoke(cdf).asInstanceOf[Snapshot]))
   }
 }

--- a/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
+++ b/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/common/DeltaCDFRelationShim.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.common
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.delta.BatchCDFSchemaEndVersion
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader.DeltaCDFRelation
+
+private[common] object DeltaCDFRelationShim {
+
+  def changesToBatchDF(cdf: DeltaCDFRelation): DataFrame = {
+    val spark = cdf.sqlContext.sparkSession
+    val snapshot = cdf.snapshotWithSchemaMode.snapshot
+    val readSchemaSnapshot = cdf.snapshotWithSchemaMode.schemaMode match {
+      case BatchCDFSchemaEndVersion =>
+        val latestVersion = snapshot.deltaLog.update(
+          catalogTableOpt = cdf.catalogTableOpt).version
+        val version = cdf.endingVersion.map(latestVersion min _).getOrElse(latestVersion)
+        snapshot.deltaLog.getSnapshotAt(version, catalogTableOpt = cdf.catalogTableOpt)
+      case _ => snapshot
+    }
+    CDCReader.changesToBatchDF(
+      snapshot.deltaLog,
+      cdf.startingVersion.get,
+      cdf.endingVersion.getOrElse {
+        snapshot.deltaLog.update(catalogTableOpt = cdf.catalogTableOpt).version
+      },
+      spark,
+      catalogTableOpt = cdf.catalogTableOpt,
+      readSchemaSnapshot = Some(readSchemaSnapshot))
+  }
+}

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -194,9 +194,33 @@ def test_delta_deletion_vector_read(spark_tmp_path, chunk_size, use_cdf, dv_pred
         ])
 
 
-# Spark generates a RowDataSourceScanExec for the CDF scan, which falls back to CPU.
-# See https://github.com/NVIDIA/cudf-spark/issues/15367 for details.
-cdf_fallback = ["RowDataSourceScanExec"]
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(is_databricks_runtime(), reason="OSS Delta CDF test")
+def test_delta_cdf_read_stays_columnar(spark_tmp_path):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+
+    with_cpu_session(
+        lambda spark: setup_delta_dest_table(
+            spark,
+            data_path,
+            dest_table_func=lambda spark: spark.createDataFrame(
+                [(1, "a"), (2, "b"), (3, "a")], ["id", "data"]),
+            use_cdf=True))
+
+    def read_cdf(spark):
+        return spark.read.format("delta") \
+            .option("readChangeFeed", "true") \
+            .option("startingVersion", 0) \
+            .load(data_path) \
+            .groupBy("_change_type") \
+            .count()
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        read_cdf,
+        exist_classes="GpuFileSourceScanExec,GpuHashAggregateExec",
+        non_exist_classes="RowDataSourceScanExec")
 
 
 def _test_delta_deletion_vector_read_with_cdf(
@@ -218,16 +242,16 @@ def _test_delta_deletion_vector_read_with_cdf(
         return read_delta_path_with_cdf(spark, data_path)
 
     if expect_fallback:
-        # DeltaCDFRelation hides its internal file scan behind this V1 CPU scan.
+        # The internal CDF scan is exposed, but deletion vectors are not supported on the GPU.
         assert_gpu_fallback_collect(
             read_cdf,
-            "RowDataSourceScanExec",
+            "FileSourceScanExec",
             conf=conf)
     else:
         assert_gpu_and_cpu_are_equal_collect(read_cdf, conf=conf)
 
 
-@allow_non_gpu(*cdf_fallback, *delta_meta_allow)
+@allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.parametrize("chunk_size", ["2000", "4000", None], ids=idfn)
@@ -240,7 +264,7 @@ def test_delta_deletion_vector_read_with_cdf(spark_tmp_path, chunk_size, parquet
         spark_tmp_path, chunk_size, parquet_reader_type, expect_fallback=False)
 
 
-@allow_non_gpu("ColumnarToRowExec", *cdf_fallback, *delta_meta_allow)
+@allow_non_gpu("ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.parametrize("chunk_size", ["2000", "4000", None], ids=idfn)
@@ -447,7 +471,7 @@ def _run_delta_cdf_commit_read_test(
         conf=conf)
 
 
-@allow_non_gpu(*cdf_fallback, *delta_meta_allow)
+@allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.parametrize(
@@ -483,7 +507,7 @@ def test_delta_cdf_mixed_row_index_filter_types_different_partitions(
         expected=_delta_cdf_mixed_filter_expected_rows(second_file_partition=1))
 
 
-@allow_non_gpu(*cdf_fallback, *delta_meta_allow)
+@allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.parametrize(
@@ -512,7 +536,7 @@ def test_delta_cdf_mixed_row_index_filter_types_same_delta_partition(
         expected=_delta_cdf_mixed_filter_expected_rows(second_file_partition=0))
 
 
-@allow_non_gpu(*cdf_fallback, *delta_meta_allow)
+@allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.parametrize(

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -198,8 +198,15 @@ def test_delta_deletion_vector_read(spark_tmp_path, chunk_size, use_cdf, dv_pred
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.skipif(is_databricks_runtime(), reason="OSS Delta CDF test")
-def test_delta_cdf_read_stays_columnar(spark_tmp_path):
+@pytest.mark.parametrize("column_mapping", [False, True], ids=["legacy_schema", "end_version_schema"])
+def test_delta_cdf_read_stays_columnar(spark_tmp_path, column_mapping):
     data_path = spark_tmp_path + "/DELTA_DATA"
+    conf = {} if not column_mapping else {
+        "spark.databricks.delta.properties.defaults.columnMapping.mode": "name",
+        "spark.databricks.delta.properties.defaults.minReaderVersion": "2",
+        "spark.databricks.delta.properties.defaults.minWriterVersion": "5",
+        "spark.sql.parquet.fieldId.read.enabled": "true"
+    }
 
     with_cpu_session(
         lambda spark: setup_delta_dest_table(
@@ -207,7 +214,8 @@ def test_delta_cdf_read_stays_columnar(spark_tmp_path):
             data_path,
             dest_table_func=lambda spark: spark.createDataFrame(
                 [(1, "a"), (2, "b"), (3, "a")], ["id", "data"]),
-            use_cdf=True))
+            use_cdf=True),
+        conf=conf)
 
     def read_cdf(spark):
         return spark.read.format("delta") \
@@ -220,7 +228,8 @@ def test_delta_cdf_read_stays_columnar(spark_tmp_path):
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         read_cdf,
         exist_classes="GpuFileSourceScanExec,GpuHashAggregateExec",
-        non_exist_classes="RowDataSourceScanExec")
+        non_exist_classes="RowDataSourceScanExec",
+        conf=conf)
 
 
 def _test_delta_deletion_vector_read_with_cdf(


### PR DESCRIPTION
Fixes #15367

### Description

Avoid the row boundary introduced by `RowDataSourceScanExec` for OSS Delta batch CDF reads.

This adds a Delta planning strategy that exposes the internal CDF logical plan to normal Spark and RAPIDS planning. Eligible CDF Parquet scans and downstream operators can consequently remain columnar and execute on the GPU.

The change applies to OSS Delta 3.3 through 4.1.

### Performance Testing

- Added integration coverage verifying that CDF aggregation uses `GpuFileSourceScanExec` and `GpuHashAggregateExec` without `RowDataSourceScanExec`.
- Verified CPU and GPU results match.
- Built against Delta 3.3, 4.0, and 4.1.

#### Environment

- Apache Spark 3.5.7
- OSS Delta Lake 3.3.0
- RAPIDS Accelerator running in local mode with four Spark threads
- Same GPU and Delta table used for the baseline and feature runs

#### Workload

The benchmark used a Delta table containing 20 million CDF rows across 32 Parquet files.

```python
spark.read.format("delta") \
    .option("readChangeFeed", "true") \
    .option("startingVersion", 0) \
    .load(table_path) \
    .groupBy("_change_type") \
    .count() \
    .collect()
```

| Revision | Median Time | Mean Time | Measured Range |
|---:|---:|---:|---:|
| Baseline | 1.186 seconds | 1.194 seconds | 1.082–1.345 seconds |
| `support-cdf-read` | 0.227 seconds | 0.231 seconds | 0.207–0.273 seconds |

The feature reduced measured query time with a speedup of around 5.2x


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
