### PR TITLE
[DOC] Document GPU expression registration [skip ci]

### DIFF
--- a/.claude/skills/gpu-operator-patterns.md
+++ b/.claude/skills/gpu-operator-patterns.md
@@ -4,20 +4,42 @@ Common patterns for implementing GPU operators in spark-rapids.
 
 ## GPU Operator Registration
 
-New GPU operators are registered in `GpuOverrides.scala`:
+Add a shared expression rule to the closest domain registry, such as
+`GpuMathAndDateExpressionOverrides` or `GpuCollectionExpressionOverrides`.
+Define its metadata as a named case class in the corresponding
+`Gpu*ExpressionRuleMetas.scala` file, or beside the GPU operator when they are
+tightly coupled:
+
 ```scala
-GpuOverrides.expr[MyExpression](
+case class MyExpressionRuleMeta(
+    expression: MyExpression,
+    override val conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends UnaryExprMeta[MyExpression](expression, conf, parent, rule) {
+
+  override def convertToGpu(child: Expression): GpuExpression =
+    GpuMyExpression(child)
+}
+```
+
+Pass the named case class constructor to the registry rule:
+
+```scala
+expr[MyExpression](
   "Description of what this does on GPU",
   ExprChecks.unaryProject(
-    TypeSig.commonCudf,  // output types
-    TypeSig.all,         // Spark output types
-    TypeSig.commonCudf,  // input types
-    TypeSig.all),        // Spark input types
-  (expr, conf, parent, rule) => new UnaryExprMeta[MyExpression](expr, conf, parent, rule) {
-    override def convertToGpu(child: Expression): GpuExpression =
-      GpuMyExpression(child)
-  })
+    TypeSig.commonCudfTypes,  // output types
+    TypeSig.all,              // Spark output types
+    TypeSig.commonCudfTypes,  // input types
+    TypeSig.all),             // Spark input types
+  MyExpressionRuleMeta)
 ```
+
+Do not add shared rules directly to `GpuOverrides` or use a constructor lambda.
+Register Spark-version-specific expressions through the appropriate shim. See
+[`docs/dev/README.md`](../../docs/dev/README.md#registering-a-gpu-expression)
+for the domain registry list and validation guidance.
 
 ## CPU Fallback
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ these upstream repositories to verify correctness:
 - [ ] C5: Resource lifecycle — SpillableColumnarBatch used after close or without retry handling
 - [ ] H1: Performance — unnecessary host-device copies, redundant materializations, avoidable data serialization
 - [ ] H2: Concurrency — missing GpuSemaphore.acquireIfNecessary(context), nested locks without ordering
-- [ ] H3: Fallback gaps — new operator in GpuOverrides without fallback declaration or test
+- [ ] H3: Fallback gaps — new replacement rule without a fallback declaration or test
 - [ ] H4: Test quality — no GPU execution verification, hardcoded sleeps, unseeded random data; GPU resource cleanup in afterAll/afterEach
 - [ ] H5: Configuration — new RapidsConf without docs/defaults; should use .internal() if not user-visible; new features default off
 - [ ] H6: Magic numbers — unexplained numeric literals without named constants or comments

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -131,6 +131,68 @@ walked, node by node, looking up rules based on the type of node (e.g.: scan,
 executor, expression, etc.), and applying the rule that matches.  See the
 `ColumnarOverrideRules` and `GpuOverrides` classes for more details.
 
+#### Registering a GPU Expression
+
+Shared expression replacement rules are grouped by domain. Add a new rule to
+the registry that contains the most closely related expressions:
+
+* `GpuCoreExpressionOverrides`
+* `GpuMathAndDateExpressionOverrides`
+* `GpuComparisonAndAggregateExpressionOverrides`
+* `GpuCollectionExpressionOverrides`
+* `GpuStringAndAggregateExpressionOverrides`
+* `GpuMiscExpressionOverrides`
+
+Do not add shared expression rules directly to `GpuOverrides`. It combines the
+domain registries in `commonExpressions` and then appends shim and external
+provider rules in the required override order.
+
+Define the replacement metadata as a named case class. Small metadata classes
+normally belong in the corresponding `Gpu*ExpressionRuleMetas.scala` file.
+Metadata that is substantial or tightly coupled to its GPU operator can remain
+beside that operator. In either case, pass the named case class constructor to
+the rule instead of creating metadata with a constructor lambda. Keeping the
+registry declaration separate from the metadata implementation reduces the
+Scala sources invalidated by a registry edit, and Scalastyle enforces this
+pattern in the shared registries.
+
+For example, define the metadata class:
+
+```scala
+case class MyExpressionRuleMeta(
+    expression: MyExpression,
+    override val conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends UnaryExprMeta[MyExpression](expression, conf, parent, rule) {
+
+  override def convertToGpu(child: Expression): GpuExpression =
+    GpuMyExpression(child)
+}
+```
+
+Then add the rule to the selected domain registry:
+
+```scala
+expr[MyExpression](
+  "Description of what this does on GPU",
+  ExprChecks.unaryProject(
+    TypeSig.commonCudfTypes,  // GPU output types
+    TypeSig.all,              // Spark output types
+    TypeSig.commonCudfTypes,  // GPU input types
+    TypeSig.all),             // Spark input types
+  MyExpressionRuleMeta)
+```
+
+If an expression or its CPU class is Spark-version-specific, register it
+through the appropriate shim instead. See the [shim layer guide](shims.md) for
+placement and cross-version requirements.
+
+Test new expression support against the CPU implementation, including its
+fallback conditions, and verify that the expected GPU expression appears in
+the executed plan. Run Scalastyle, compile both the Scala 2.12 and Scala 2.13
+builds, and run the relevant unit and integration tests.
+
 There is a separate guide for working with
 [Adaptive Query Execution](adaptive-query.md).
 


### PR DESCRIPTION
Follow-up to #15734.

### Description

#15734 split the shared expression replacement rules into domain-focused registries and replaced constructor lambdas with named metadata classes. The checked-in developer guidance still directed contributors to add rules to `GpuOverrides.scala` with a constructor lambda, which is now both inefficient and rejected by Scalastyle.

This change:

- documents how to select a domain registry, define a named metadata case class, and register an expression
- explains when metadata should remain beside its GPU operator and when registration belongs in a Spark-version shim
- updates the checked-in GPU operator pattern and Copilot review checklist so they no longer recommend the old layout
- records the expected validation for new expression support

There is no user-facing configuration or runtime behavior change.

Validation:

- `git diff --check`
- verified the new relative documentation links resolve in the repository

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
