### PR TITLE
Fix Spark master VariantType shim build[databricks][fast-ut][reduced-it]

### DIFF
--- a/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/VariantTypeShims.scala
+++ b/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/VariantTypeShims.scala
@@ -25,6 +25,7 @@
 {"spark": "412"}
 {"spark": "413"}
 {"spark": "420"}
+{"spark": "500"}
 spark-rapids-shim-json-lines ***/
 
 package com.nvidia.spark.rapids.shims


### PR DESCRIPTION
Fixes #15782.

### Description

The Spark master build uses build version `500`, but the Spark 4.x `VariantTypeShims` implementation was only annotated through `420`. As a result, Shimplify did not include `VariantTypeShims` for Spark 500 even though common `GpuColumnVector.java` imports it unconditionally, causing the SQL plugin compile to fail.

This PR adds `500` to the existing Spark 4.x `VariantTypeShims` shim annotation so the Spark master profile generates the required shim source.

Testing performed:

- `mvn -s <settings.xml> -f scala2.13/pom.xml -PsparkMaster -Dcuda.version=cuda13 -DskipTests -DskipITs -pl sql-plugin -am install`
- `mvn -s <settings.xml> -f scala2.13/pom.xml -PsparkMaster -Dcuda.version=cuda13 -DskipTests -DskipITs -pl sql-plugin -am clean verify`
- `mvn -s <settings.xml> -f scala2.13/pom.xml -PsparkMaster -Dcuda.version=cuda13 -DskipTests -DskipITs clean verify`

Performance testing is not required because this is a shim-selection annotation change only. It does not change runtime code or generated execution behavior.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required