### PR TITLE
[AutoSparkUT] Fix legacy Hadoop LZ4 Parquet reads [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_testing_test.py
+++ b/integration_tests/src/main/python/parquet_testing_test.py
@@ -58,8 +58,6 @@ _xfail_files = {
     "delta_encoding_optional_column.parquet": "https://github.com/rapidsai/cudf/issues/13501",
     "delta_encoding_required_column.parquet": "https://github.com/rapidsai/cudf/issues/13501",
     "delta_length_byte_array.parquet": "https://github.com/rapidsai/cudf/issues/13501",
-    "hadoop_lz4_compressed.parquet": "cudf does not support Hadoop LZ4 format",
-    "hadoop_lz4_compressed_larger.parquet": "cudf does not support Hadoop LZ4 format",
     "nested_structs.rust.parquet": "PySpark cannot handle year 52951",
 }
 # Spark 3.5.0 adds support for lz4_raw compression codec, but we do not support that on GPU yet

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -55,7 +55,7 @@ import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.format.Util
 import org.apache.parquet.format.converter.ParquetMetadataConverter
-import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
+import org.apache.parquet.hadoop.{CodecFactory, ParquetFileReader, ParquetInputFormat}
 import org.apache.parquet.hadoop.ParquetFileWriter.MAGIC
 import org.apache.parquet.hadoop.metadata._
 import org.apache.parquet.io.{InputFile, SeekableInputStream => ParquetSeekableInputStream}
@@ -1573,8 +1573,18 @@ case class GpuParquetPartitionReaderFactory(
 
 case class CpuCompressionConfig(
     decompressSnappyCpu: Boolean,
-    decompressZstdCpu: Boolean) {
-  val decompressAnyCpu: Boolean = decompressSnappyCpu || decompressZstdCpu
+    decompressZstdCpu: Boolean,
+    decompressLz4Cpu: Boolean) {
+  def shouldDecompress(codec: CompressionCodecName): Boolean = codec match {
+    case CompressionCodecName.SNAPPY => decompressSnappyCpu
+    case CompressionCodecName.ZSTD => decompressZstdCpu
+    case CompressionCodecName.LZ4 => decompressLz4Cpu
+    case _ => false
+  }
+
+  def shouldDecompress(blocks: Seq[BlockMetaData]): Boolean = {
+    blocks.exists(_.getColumns.asScala.exists(c => shouldDecompress(c.getCodec)))
+  }
 }
 
 object CpuCompressionConfig {
@@ -1582,10 +1592,12 @@ object CpuCompressionConfig {
     val cpuEnable = conf.parquetDecompressCpu
     CpuCompressionConfig(
       decompressSnappyCpu = cpuEnable && conf.parquetDecompressCpuSnappy,
-      decompressZstdCpu = cpuEnable && conf.parquetDecompressCpuZstd)
+      decompressZstdCpu = cpuEnable && conf.parquetDecompressCpuZstd,
+      // cuDF does not support the legacy Hadoop LZ4 framing used by Parquet's LZ4 codec.
+      decompressLz4Cpu = true)
   }
 
-  def disabled(): CpuCompressionConfig = CpuCompressionConfig(false, false)
+  def disabled(): CpuCompressionConfig = CpuCompressionConfig(false, false, false)
 }
 
 trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
@@ -1951,6 +1963,11 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
                 decompressZstd(in, out, column)
                 columnCodec = CompressionCodecName.UNCOMPRESSED
                 columnTotalSize = out.getPos - columnStartPos
+              case CompressionCodecName.LZ4 if compressCfg.decompressLz4Cpu =>
+                val columnStartPos = out.getPos
+                decompressLz4(in, out, column)
+                columnCodec = CompressionCodecName.UNCOMPRESSED
+                columnTotalSize = out.getPos - columnStartPos
               case _ =>
                 in.seek(column.getStartingPos)
                 in.read(out, columnTotalSize)
@@ -2036,6 +2053,96 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
       }
     } finally {
       inData.foreach(_.close())
+    }
+  }
+
+  private def decompressLz4(
+      in: BufferedFileInput,
+      out: HostMemoryOutputStream,
+      column: ColumnChunkMetaData): Unit = {
+    val endPos = column.getStartingPos + column.getTotalSize
+    in.seek(column.getStartingPos)
+    var inData: Option[HostMemoryBuffer] = None
+    val codecFactory = new CodecFactory(conf, copyBufferSize)
+    try {
+      val decompressor = codecFactory.getDecompressor(CompressionCodecName.LZ4)
+      while (in.getPos < endPos) {
+        val pageHeader = Util.readPageHeader(in)
+        val compressedSize = pageHeader.getCompressed_page_size
+        val uncompressedSize = pageHeader.getUncompressed_page_size
+        val dataPageV2 = Option(pageHeader.getData_page_header_v2)
+        val definitionLevelSize = dataPageV2
+          .map(_.getDefinition_levels_byte_length)
+          .getOrElse(0)
+        val repetitionLevelSize = dataPageV2
+          .map(_.getRepetition_levels_byte_length)
+          .getOrElse(0)
+        val levelSizeLong = definitionLevelSize.toLong + repetitionLevelSize
+        if (compressedSize < 0 || uncompressedSize < 0 ||
+            definitionLevelSize < 0 || repetitionLevelSize < 0 ||
+            levelSizeLong > compressedSize || levelSizeLong > uncompressedSize) {
+          throw new IOException(
+            s"Invalid LZ4 Parquet page sizes for ${column.getPath}: " +
+              s"compressed=$compressedSize, uncompressed=$uncompressedSize, " +
+              s"definitionLevels=$definitionLevelSize, " +
+              s"repetitionLevels=$repetitionLevelSize")
+        }
+        val levelSize = levelSizeLong.toInt
+        val isCompressed = dataPageV2.forall { h =>
+          !h.isSetIs_compressed || h.isIs_compressed
+        }
+        if (!isCompressed && compressedSize != uncompressedSize) {
+          throw new IOException(
+            s"Invalid uncompressed Parquet data page V2 sizes for ${column.getPath}: " +
+              s"compressed=$compressedSize, uncompressed=$uncompressedSize")
+        }
+
+        pageHeader.unsetCrc()
+        pageHeader.setCompressed_page_size(uncompressedSize)
+        dataPageV2.foreach(_.setIs_compressed(false))
+        Util.writePageHeader(pageHeader, out)
+
+        if (!isCompressed) {
+          in.read(out, compressedSize)
+        } else {
+          if (levelSize > 0) {
+            in.read(out, levelSize)
+          }
+          val compressedDataSize = compressedSize - levelSize
+          val uncompressedDataSize = uncompressedSize - levelSize
+          if (compressedDataSize > 0 || uncompressedDataSize > 0) {
+            if (compressedDataSize <= 0 || uncompressedDataSize <= 0) {
+              throw new IOException(
+                s"Invalid LZ4 Parquet page data sizes for ${column.getPath}: " +
+                  s"compressed=$compressedDataSize, uncompressed=$uncompressedDataSize")
+            }
+            if (inData.map(_.getLength).getOrElse(0L) < compressedDataSize) {
+              inData.foreach(_.close())
+              inData = Some(HostMemoryBuffer.allocate(compressedDataSize, false))
+            }
+            inData.foreach { compressedBuffer =>
+              in.read(compressedBuffer, compressedDataSize)
+              val bbIn = compressedBuffer.asByteBuffer(0, compressedDataSize)
+              val bbOut = out.writeAsByteBuffer(uncompressedDataSize)
+              decompressor.decompress(
+                bbIn, compressedDataSize, bbOut, uncompressedDataSize)
+              if (bbOut.position() != uncompressedDataSize) {
+                throw new IOException(
+                  s"Unexpected LZ4 Parquet page size for ${column.getPath}: " +
+                    s"expected=$uncompressedDataSize, actual=${bbOut.position()}")
+              }
+            }
+          }
+        }
+      }
+      if (in.getPos != endPos) {
+        throw new IOException(
+          s"LZ4 Parquet column data exceeded its metadata boundary for ${column.getPath}: " +
+            s"expectedEnd=$endPos, actual=${in.getPos}")
+      }
+    } finally {
+      inData.foreach(_.close())
+      codecFactory.release()
     }
   }
 
@@ -2138,7 +2245,7 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
       closeOnExcept(outHostBuf) { hmb =>
         val out = new HostMemoryOutputStream(hmb)
         out.write(ParquetPartitionReader.PARQUET_MAGIC)
-        val outputBlocks = if (compressCfg.decompressAnyCpu) {
+        val outputBlocks = if (compressCfg.shouldDecompress(blocks)) {
           copyAndUncompressBlocksData(filePath, out, blocks, out.getPos, metrics, compressCfg)
         } else {
           copyBlocksData(filePath, out, blocks, out.getPos, metrics)
@@ -2387,7 +2494,7 @@ abstract class MultiFileCoalescingParquetPartitionReaderBase(
         val startBytesRead = fileSystemBytesRead()
         val outputBlocks = withResource(outhmb) { _ =>
           withResource(new HostMemoryOutputStream(outhmb)) { out =>
-            if (compressCfg.decompressAnyCpu) {
+            if (compressCfg.shouldDecompress(blocks.toSeq)) {
               copyAndUncompressBlocksData(file, out, blocks.toSeq, offset, metrics, compressCfg)
             } else {
               copyBlocksData(file, out, blocks.toSeq, offset, metrics)
@@ -3735,23 +3842,18 @@ object ParquetPartitionReader {
   private[parquet] def computeOutputSize(
       block: BlockMetaData,
       compressCfg: CpuCompressionConfig): Long = {
-    if (compressCfg.decompressAnyCpu) {
-      block.getColumns.asScala.map { c =>
-        if ((c.getCodec == CompressionCodecName.SNAPPY && compressCfg.decompressSnappyCpu)
-            || (c.getCodec == CompressionCodecName.ZSTD && compressCfg.decompressZstdCpu)) {
-          // Page headers need to be rewritten when CPU decompresses, and that may
-          // increase the size of the page header. Guess how many pages there may be
-          // and add a fudge factor per page to try to avoid a late realloc+copy.
-          // NOTE: Avoid using block.getTotalByteSize as that is the
-          //       uncompressed size rather than the size in the file.
-          val estimatedPageCount = (c.getTotalUncompressedSize / (1024 * 1024)) + 1
-          c.getTotalUncompressedSize + estimatedPageCount * 8
-        } else {
-          c.getTotalSize
-        }
-      }.sum
-    } else {
-      block.getColumns.asScala.map(_.getTotalSize).sum
-    }
+    block.getColumns.asScala.map { c =>
+      if (compressCfg.shouldDecompress(c.getCodec)) {
+        // Page headers need to be rewritten when CPU decompresses, and that may
+        // increase the size of the page header. Guess how many pages there may be
+        // and add a fudge factor per page to try to avoid a late realloc+copy.
+        // NOTE: Avoid using block.getTotalByteSize as that is the
+        //       uncompressed size rather than the size in the file.
+        val estimatedPageCount = (c.getTotalUncompressedSize / (1024 * 1024)) + 1
+        c.getTotalUncompressedSize + estimatedPageCount * 8
+      } else {
+        c.getTotalSize
+      }
+    }.sum
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -2120,7 +2120,9 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
                   s"compressed=$compressedDataSize, uncompressed=$uncompressedDataSize")
             }
             if (inData.map(_.getLength).getOrElse(0L) < compressedDataSize) {
-              inData.foreach(_.close())
+              val oldInData = inData
+              inData = None
+              oldInData.foreach(_.close())
               inData = Some(HostMemoryBuffer.allocate(compressedDataSize, false))
             }
             inData.foreach { compressedBuffer =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -55,7 +55,8 @@ import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.format.Util
 import org.apache.parquet.format.converter.ParquetMetadataConverter
-import org.apache.parquet.hadoop.{CodecFactory, ParquetFileReader, ParquetInputFormat}
+import org.apache.parquet.hadoop.{CodecFactory, ParquetFileReader, ParquetInputFormat,
+  ParquetOutputFormat, ParquetWriter}
 import org.apache.parquet.hadoop.ParquetFileWriter.MAGIC
 import org.apache.parquet.hadoop.metadata._
 import org.apache.parquet.io.{InputFile, SeekableInputStream => ParquetSeekableInputStream}
@@ -2063,7 +2064,9 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
     val endPos = column.getStartingPos + column.getTotalSize
     in.seek(column.getStartingPos)
     var inData: Option[HostMemoryBuffer] = None
-    val codecFactory = new CodecFactory(conf, copyBufferSize)
+    val codecBufferSize = conf.getInt(
+      ParquetOutputFormat.PAGE_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE)
+    val codecFactory = new CodecFactory(conf, codecBufferSize)
     try {
       val decompressor = codecFactory.getDecompressor(CompressionCodecName.LZ4)
       while (in.getPos < endPos) {
@@ -3843,7 +3846,15 @@ object ParquetPartitionReader {
       block: BlockMetaData,
       compressCfg: CpuCompressionConfig): Long = {
     block.getColumns.asScala.map { c =>
-      if (compressCfg.shouldDecompress(c.getCodec)) {
+      if (c.getCodec == CompressionCodecName.LZ4 && compressCfg.decompressLz4Cpu) {
+        // Legacy LZ4 pages can be much smaller than the default Parquet page size, so a
+        // page-count estimate based on uncompressed bytes can underallocate. Rewriting can
+        // grow a page header by at most four bytes for compressed_page_size plus one byte
+        // for Data Page V2's optional is_compressed flag. The original encoded page header
+        // is larger than that, so the complete on-disk column size is a conservative,
+        // page-count-independent upper bound for all header growth.
+        Math.addExact(c.getTotalUncompressedSize, c.getTotalSize)
+      } else if (compressCfg.shouldDecompress(c.getCodec)) {
         // Page headers need to be rewritten when CPU decompresses, and that may
         // increase the size of the page header. Guess how many pages there may be
         // and add a fudge factor per page to try to avoid a late realloc+copy.

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceCodecSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceCodecSuite.scala
@@ -19,9 +19,32 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
+import org.apache.parquet.column.ParquetProperties
+import org.apache.parquet.hadoop.ParquetOutputFormat
+
 import org.apache.spark.sql.execution.datasources.{OrcCodecSuite, ParquetCodecSuite}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
 
-class RapidsParquetCodecSuite extends ParquetCodecSuite with RapidsSQLTestsTrait
+class RapidsParquetCodecSuite extends ParquetCodecSuite with RapidsSQLTestsTrait {
+
+  testRapids("write and read - file source parquet - codec: lz4 - v2 pages") {
+    val activeSpark = spark
+    import activeSpark.implicits._
+
+    val data = Seq.tabulate(4096) { i =>
+      (i, if (i % 3 == 0) None else Some(s"value-$i"))
+    }.toDF("id", "value")
+    withSQLConf(
+      SQLConf.PARQUET_COMPRESSION.key -> "lz4",
+      ParquetOutputFormat.WRITER_VERSION ->
+        ParquetProperties.WriterVersion.PARQUET_2_0.toString) {
+      withTempPath { dir =>
+        data.repartition(3).write.parquet(dir.getCanonicalPath)
+        checkAnswer(activeSpark.read.parquet(dir.getCanonicalPath), data)
+      }
+    }
+  }
+}
 
 class RapidsOrcCodecSuite extends OrcCodecSuite with RapidsSQLTestsTrait

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceCodecSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceCodecSuite.scala
@@ -28,15 +28,18 @@ import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
 
 class RapidsParquetCodecSuite extends ParquetCodecSuite with RapidsSQLTestsTrait {
 
-  testRapids("write and read - file source parquet - codec: lz4 - v2 pages") {
+  testRapids("write and read - file source parquet - codec: lz4 - v2 small pages") {
     val activeSpark = spark
     import activeSpark.implicits._
 
-    val data = Seq.tabulate(4096) { i =>
+    val data = Seq.tabulate(512) { i =>
       (i, if (i % 3 == 0) None else Some(s"value-$i"))
     }.toDF("id", "value")
     withSQLConf(
       SQLConf.PARQUET_COMPRESSION.key -> "lz4",
+      ParquetOutputFormat.PAGE_SIZE -> "256",
+      ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK -> "1",
+      ParquetOutputFormat.MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK -> "1",
       ParquetOutputFormat.WRITER_VERSION ->
         ParquetProperties.WriterVersion.PARQUET_2_0.toString) {
       withTempPath { dir =>

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceCodecSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsFileSourceCodecSuite.scala
@@ -28,22 +28,25 @@ import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
 
 class RapidsParquetCodecSuite extends ParquetCodecSuite with RapidsSQLTestsTrait {
 
-  testRapids("write and read - file source parquet - codec: lz4 - v2 small pages") {
+  testRapids("write and read - file source parquet - codec: lz4 - v2 small pages no crc") {
     val activeSpark = spark
     import activeSpark.implicits._
 
+    val compressibleValue = "a" * 1000
     val data = Seq.tabulate(512) { i =>
-      (i, if (i % 3 == 0) None else Some(s"value-$i"))
-    }.toDF("id", "value")
+      if (i % 3 == 0) None else Some(compressibleValue)
+    }.toDF("value")
     withSQLConf(
       SQLConf.PARQUET_COMPRESSION.key -> "lz4",
       ParquetOutputFormat.PAGE_SIZE -> "256",
       ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK -> "1",
       ParquetOutputFormat.MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK -> "1",
+      ParquetOutputFormat.ENABLE_DICTIONARY -> "false",
+      ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED -> "false",
       ParquetOutputFormat.WRITER_VERSION ->
         ParquetProperties.WriterVersion.PARQUET_2_0.toString) {
       withTempPath { dir =>
-        data.repartition(3).write.parquet(dir.getCanonicalPath)
+        data.coalesce(1).write.parquet(dir.getCanonicalPath)
         checkAnswer(activeSpark.read.parquet(dir.getCanonicalPath), data)
       }
     }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -312,9 +312,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsFileSourceCharVarcharDDLTestSuite]
   enableSuite[RapidsDSV2CharVarcharDDLTestSuite]
   enableSuite[RapidsParquetCodecSuite]
-    .exclude("write and read - file source parquet - codec: lz4",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15550. " +
-        "Recovery trigger: GPU Parquet supports Hadoop LZ4 or safely falls back; P1."))
   enableSuite[RapidsOrcCodecSuite]
     .exclude("write and read - file source orc - codec: lzo",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15551. " +


### PR DESCRIPTION
**JaCoCo production line coverage: +70 lines** (`sql-plugin +70`; fix-line, Spark shim 330 / Scala 2.12, base `da9f672741111fd2b239f9cb5b0be46787073c41`)

Fixes #15550.

### Description

GPU Parquet reads fail for files that use the legacy Hadoop-framed `LZ4` codec because cuDF does not decode that framing and reports `Unsupported Parquet compression type: LZ4`.

This change CPU-decompresses only legacy `CompressionCodecName.LZ4` pages while assembling the Parquet input passed to cuDF, then rewrites their page headers and column metadata as `UNCOMPRESSED`. Data Page V2 repetition/definition-level prefixes are preserved, invalid sizes and column boundaries are rejected, and temporary buffers plus codec resources are released. `LZ4_RAW` behavior is unchanged, and non-LZ4 files retain the existing direct/vectored copy path.

Test traceability:
- RAPIDS inherited test `write and read - file source parquet - codec: lz4` maps to Spark's `FileSourceCodecSuite.testWithAllCodecs("write and read")` in `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCodecSuite.scala:33-66`.
- RAPIDS regression `write and read - file source parquet - codec: lz4 - v2 pages` extends the same Spark contract to Data Page V2 so level prefixes and the `is_compressed` flag are exercised.
- `test_parquet_testing_valid_files` now covers `hadoop_lz4_compressed.parquet` and `hadoop_lz4_compressed_larger.parquet` under both NATIVE and JAVA footer readers.

Validation:
- Spark 3.3 `RapidsParquetCodecSuite`: `Tests: succeeded 7, failed 0, canceled 0, ignored 0, pending 0`; `BUILD SUCCESS`.
- Two Hadoop-LZ4 fixtures with NATIVE and JAVA footer readers: `4 passed, 92 deselected`.
- Non-Hadoop LZ4 and LZ4_RAW error parity with NATIVE and JAVA footer readers: `6 passed, 90 deselected`.
- Spark 3.3 distribution and integration-test reactor: all 17 modules succeeded; `BUILD SUCCESS`.
- JaCoCo fix-line coverage: 70 of 127 added `sql-plugin` production lines covered.

Performance impact: this is a cold compatibility path. CPU decompression and page rewriting apply only to legacy Hadoop-LZ4 columns that cuDF cannot decode directly; all other codecs retain the existing direct/vectored path.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author at commit `71c44b4d69410b446dbad650e78d01f6312f8362` before submission.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
