### PR TITLE
[BUG] Fix input bytes accounting for GPU file scans [databricks][fast-ut]

### DIFF
--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuSingleThreadIcebergParquetReader.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuSingleThreadIcebergParquetReader.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
 
 import ai.rapids.cudf.ParquetOptions
 import com.nvidia.spark.rapids.{CachedGpuBatchIterator, DateTimeRebaseCorrected, GpuSemaphore,
-  PartitionReaderWithBytesRead, RmmRapidsRetryIterator, SpillableHostBuffer}
+  RmmRapidsRetryIterator, SpillableHostBuffer}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergFileIO
 import com.nvidia.spark.rapids.iceberg.IcebergDeletionVector
@@ -186,7 +186,6 @@ private class SingleFileReader(
       }
     }
 
-    val parquetReader = new PartitionReaderWithBytesRead(parquetPartReader)
     val postProcessor = new GpuParquetReaderPostProcessor(filteredParquet,
       idToConstant,
       requiredSchema,
@@ -194,6 +193,6 @@ private class SingleFileReader(
       conf.metrics)
 
     inited = true
-    (parquetReader, postProcessor)
+    (parquetPartReader, postProcessor)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -364,8 +364,8 @@ case class GpuCSVPartitionReaderFactory(
 
   override def buildColumnarReader(partFile: PartitionedFile): PartitionReader[ColumnarBatch] = {
     val conf = broadcastedConf.value.value
-    val reader = new PartitionReaderWithBytesRead(new CSVPartitionReader(conf, partFile, dataSchema,
-      readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes, metrics))
+    val reader = new CSVPartitionReader(conf, partFile, dataSchema,
+      readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes, metrics)
     ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
       maxGpuColumnSizeBytes)
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -794,11 +794,11 @@ case class GpuOrcPartitionReaderFactory(
     } else {
       val conf = broadcastedConf.value.value
       OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.setBoolean(conf, isCaseSensitive)
-      val reader = new PartitionReaderWithBytesRead(new GpuOrcPartitionReader(conf, partFile, ctx,
+      val reader = new GpuOrcPartitionReader(conf, partFile, ctx,
         readDataSchema, debugDumpPrefix, debugDumpAlways,  maxReadBatchSizeRows,
         maxReadBatchSizeBytes, targetBatchSizeBytes,
         useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
-        metrics, filterHandler.isCaseSensitive))
+        metrics, filterHandler.isCaseSensitive)
       ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
         maxGpuColumnSizeBytes)
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/dataSourceUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/dataSourceUtil.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import java.util.concurrent.ConcurrentHashMap
+
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
@@ -52,19 +54,49 @@ class MetricsBatchIterator(iter: Iterator[ColumnarBatch]) extends Iterator[Colum
   }
 }
 
-/** Incrementally transfers task-thread Hadoop filesystem bytes into Spark input metrics. */
-class FileSystemBytesReadTracker {
-  private[this] val inputMetrics = TaskContext.get().taskMetrics().inputMetrics
+/**
+ * Incrementally transfers task-thread Hadoop filesystem bytes into Spark input metrics.
+ * All updates must run on the same task thread that constructed this tracker.
+ */
+class FileSystemBytesReadTracker(context: TaskContext = TaskContext.get()) {
+  private[this] val inputMetrics = context.taskMetrics().inputMetrics
   private[this] val getBytesRead = TrampolineUtil.getFSBytesReadOnThreadCallback()
   private[this] var previousBytesRead = 0L
 
-  def update(): Unit = synchronized {
+  def update(): Unit = {
     val currentBytesRead = getBytesRead()
     val newBytesRead = currentBytesRead - previousBytesRead
     if (newBytesRead > 0) {
       TrampolineUtil.incBytesRead(inputMetrics, newBytesRead)
     }
-    previousBytesRead = currentBytesRead
+    previousBytesRead = math.max(previousBytesRead, currentBytesRead)
+  }
+}
+
+object FileSystemBytesReadTracker {
+  private val taskTrackers = new ConcurrentHashMap[Long, FileSystemBytesReadTracker]()
+
+  private[rapids] def forTask(context: TaskContext): FileSystemBytesReadTracker = {
+    val taskId = context.taskAttemptId()
+    val existing = taskTrackers.get(taskId)
+    if (existing != null) {
+      existing
+    } else {
+      val created = new FileSystemBytesReadTracker(context)
+      val raced = taskTrackers.putIfAbsent(taskId, created)
+      if (raced != null) {
+        raced
+      } else {
+        ScalableTaskCompletion.onTaskCompletion(context) {
+          try {
+            created.update()
+          } finally {
+            taskTrackers.remove(taskId, created)
+          }
+        }
+        created
+      }
+    }
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/dataSourceUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/dataSourceUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,19 +52,42 @@ class MetricsBatchIterator(iter: Iterator[ColumnarBatch]) extends Iterator[Colum
   }
 }
 
+/** Incrementally transfers task-thread Hadoop filesystem bytes into Spark input metrics. */
+class FileSystemBytesReadTracker {
+  private[this] val inputMetrics = TaskContext.get().taskMetrics().inputMetrics
+  private[this] val getBytesRead = TrampolineUtil.getFSBytesReadOnThreadCallback()
+  private[this] var previousBytesRead = 0L
+
+  def update(): Unit = synchronized {
+    val currentBytesRead = getBytesRead()
+    val newBytesRead = currentBytesRead - previousBytesRead
+    if (newBytesRead > 0) {
+      TrampolineUtil.incBytesRead(inputMetrics, newBytesRead)
+    }
+    previousBytesRead = currentBytesRead
+  }
+}
+
 /** Wraps a columnar PartitionReader to update bytes read metric based on filesystem statistics. */
 class PartitionReaderWithBytesRead(reader: PartitionReader[ColumnarBatch])
     extends PartitionReader[ColumnarBatch] {
-  private[this] val inputMetrics = TaskContext.get.taskMetrics().inputMetrics
-  private[this] val getBytesRead = TrampolineUtil.getFSBytesReadOnThreadCallback()
+  private[this] val bytesReadTracker = new FileSystemBytesReadTracker
 
   override def next(): Boolean = {
-    val result = reader.next()
-    TrampolineUtil.incBytesRead(inputMetrics, getBytesRead())
-    result
+    try {
+      reader.next()
+    } finally {
+      bytesReadTracker.update()
+    }
   }
 
   override def get(): ColumnarBatch = reader.get()
 
-  override def close(): Unit = reader.close()
+  override def close(): Unit = {
+    try {
+      reader.close()
+    } finally {
+      bytesReadTracker.update()
+    }
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/dataSourceUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/dataSourceUtil.scala
@@ -58,7 +58,7 @@ class MetricsBatchIterator(iter: Iterator[ColumnarBatch]) extends Iterator[Colum
  * Incrementally transfers task-thread Hadoop filesystem bytes into Spark input metrics.
  * All updates must run on the same task thread that constructed this tracker.
  */
-class FileSystemBytesReadTracker(context: TaskContext = TaskContext.get()) {
+class FileSystemBytesReadTracker private(context: TaskContext) {
   private[this] val inputMetrics = context.taskMetrics().inputMetrics
   private[this] val getBytesRead = TrampolineUtil.getFSBytesReadOnThreadCallback()
   private[this] var previousBytesRead = 0L
@@ -96,30 +96,6 @@ object FileSystemBytesReadTracker {
         }
         created
       }
-    }
-  }
-}
-
-/** Wraps a columnar PartitionReader to update bytes read metric based on filesystem statistics. */
-class PartitionReaderWithBytesRead(reader: PartitionReader[ColumnarBatch])
-    extends PartitionReader[ColumnarBatch] {
-  private[this] val bytesReadTracker = new FileSystemBytesReadTracker
-
-  override def next(): Boolean = {
-    try {
-      reader.next()
-    } finally {
-      bytesReadTracker.update()
-    }
-  }
-
-  override def get(): ColumnarBatch = reader.get()
-
-  override def close(): Unit = {
-    try {
-      reader.close()
-    } finally {
-      bytesReadTracker.update()
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -1528,7 +1528,7 @@ abstract class GpuParquetPartitionReaderFactoryBase(
 
   override def buildColumnarReader(
       partitionedFile: PartitionedFile): PartitionReader[ColumnarBatch] = {
-    val reader = new PartitionReaderWithBytesRead(buildBaseColumnarParquetReader(partitionedFile))
+    val reader = buildBaseColumnarParquetReader(partitionedFile)
     ColumnarPartitionReaderWithPartitionValues.newReader(partitionedFile, reader, partitionSchema,
       maxGpuColumnSizeBytes)
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{MetricsBatchIterator, PartitionIterator}
+import com.nvidia.spark.rapids.{FileSystemBytesReadTracker, MetricsBatchIterator, PartitionIterator}
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, SparkException, TaskContext}
@@ -26,11 +26,9 @@ import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFacto
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
- * A replacement for DataSourceRDD that does NOT compute the bytes read input metric.
- * DataSourceRDD assumes all reads occur on the task thread, and some GPU input sources
- * use multithreaded readers that cannot generate proper metrics with DataSourceRDD.
- * @note It is the responsibility of users of this RDD to generate the bytes read input
- *       metric explicitly!
+ * A replacement for DataSourceRDD that combines task-thread filesystem bytes with explicit
+ * bytes reported by multithreaded GPU readers. Unlike Spark's DataSourceRDD, task-thread bytes
+ * are added as deltas so metric updates do not overwrite bytes reported by worker threads.
  */
 class GpuDataSourceRDD(
     sc: SparkContext,
@@ -55,17 +53,35 @@ class GpuDataSourceRDD(
   }
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
+    val bytesReadTracker = new FileSystemBytesReadTracker
+    onTaskCompletion(context)(bytesReadTracker.update())
 
     val iterator = new Iterator[Object] {
       private val inputPartitions = castPartition(split).inputPartitions
       private var currentIter: Option[Iterator[Object]] = None
       private var currentIndex: Int = 0
 
-      override def hasNext: Boolean = currentIter.exists(_.hasNext) || advanceToNextIter()
+      override def hasNext: Boolean = {
+        try {
+          val result = currentIter.exists(_.hasNext) || advanceToNextIter()
+          if (!result) {
+            bytesReadTracker.update()
+          }
+          result
+        } catch {
+          case t: Throwable =>
+            bytesReadTracker.update()
+            throw t
+        }
+      }
 
       override def next(): Object = {
-        if (!hasNext) throw new NoSuchElementException("No more elements")
-        currentIter.get.next()
+        try {
+          if (!hasNext) throw new NoSuchElementException("No more elements")
+          currentIter.get.next()
+        } finally {
+          bytesReadTracker.update()
+        }
       }
 
       private def advanceToNextIter(): Boolean = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
@@ -53,8 +53,7 @@ class GpuDataSourceRDD(
   }
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
-    val bytesReadTracker = new FileSystemBytesReadTracker
-    onTaskCompletion(context)(bytesReadTracker.update())
+    val bytesReadTracker = FileSystemBytesReadTracker.forTask(context)
 
     val iterator = new Iterator[Object] {
       private val inputPartitions = castPartition(split).inputPartitions
@@ -62,22 +61,18 @@ class GpuDataSourceRDD(
       private var currentIndex: Int = 0
 
       override def hasNext: Boolean = {
-        try {
-          val result = currentIter.exists(_.hasNext) || advanceToNextIter()
-          if (!result) {
-            bytesReadTracker.update()
-          }
-          result
-        } catch {
-          case t: Throwable =>
-            bytesReadTracker.update()
-            throw t
+        val result = currentIter.exists(_.hasNext) || advanceToNextIter()
+        if (!result) {
+          bytesReadTracker.update()
         }
+        result
       }
 
       override def next(): Object = {
         try {
-          if (!hasNext) throw new NoSuchElementException("No more elements")
+          if (!hasNext) {
+            throw new NoSuchElementException("No more elements")
+          }
           currentIter.get.next()
         } finally {
           bytesReadTracker.update()
@@ -98,7 +93,13 @@ class GpuDataSourceRDD(
               new PartitionIterator[ColumnarBatch](batchReader))
             (iter, batchReader)
           }
-          onTaskCompletion(reader.close())
+          onTaskCompletion {
+            try {
+              reader.close()
+            } finally {
+              bytesReadTracker.update()
+            }
+          }
 
           currentIter = Some(iter)
           hasNext

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -296,9 +296,9 @@ case class GpuJsonPartitionReaderFactory(
 
   override def buildColumnarReader(partFile: PartitionedFile): PartitionReader[ColumnarBatch] = {
     val conf = broadcastedConf.value.value
-    val reader = new PartitionReaderWithBytesRead(new JsonPartitionReader(conf, partFile,
+    val reader = new JsonPartitionReader(conf, partFile,
       dataSchema, readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes,
-      metrics))
+      metrics)
     ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
       maxGpuColumnSizeBytes)
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable.HashSet
 import scala.collection.mutable
 
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, RegexProgram, Scalar, Schema, Table}
-import com.nvidia.spark.rapids.{ColumnarPartitionReaderWithPartitionValues, CSVPartitionReaderBase, DateUtils, GpuColumnVector, GpuExec, GpuMetric, HostStringColBufferer, HostStringColBuffererFactory, NvtxIdWithMetrics, NvtxRegistry, PartitionReaderIterator, PartitionReaderWithBytesRead, RapidsConf}
+import com.nvidia.spark.rapids.{ColumnarPartitionReaderWithPartitionValues, CSVPartitionReaderBase, DateUtils, GpuColumnVector, GpuExec, GpuMetric, HostStringColBufferer, HostStringColBuffererFactory, NvtxIdWithMetrics, NvtxRegistry, PartitionReaderIterator, RapidsConf}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
@@ -470,11 +470,10 @@ case class GpuHiveTextPartitionReaderFactory(sqlConf: SQLConf,
 
   override def buildColumnarReader(partFile: PartitionedFile): PartitionReader[ColumnarBatch] = {
     val conf = broadcastConf.value.value
-    val reader = new PartitionReaderWithBytesRead(
-                   new GpuHiveDelimitedTextPartitionReader(
-                     conf, csvOptions, params, partFile, inputFileSchema,
-                     requestedOutputDataSchema, maxReaderBatchSizeRows,
-                     maxReaderBatchSizeBytes, metrics))
+    val reader = new GpuHiveDelimitedTextPartitionReader(
+      conf, csvOptions, params, partFile, inputFileSchema,
+      requestedOutputDataSchema, maxReaderBatchSizeRows,
+      maxReaderBatchSizeBytes, metrics)
     new AlphabeticallyReorderingColumnPartitionReader(reader,
                                                       partFile.partitionValues,
                                                       partitionSchema,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -183,9 +183,9 @@ case class GpuAvroPartitionReaderFactory(
     metrics.get(FILTER_TIME).foreach {
       _ += (System.nanoTime() - startTime)
     }
-    val reader = new PartitionReaderWithBytesRead(new GpuAvroPartitionReader(conf, partFile,
+    val reader = new GpuAvroPartitionReader(conf, partFile,
       blockMeta, readDataSchema, debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows,
-      maxReadBatchSizeBytes, metrics))
+      maxReadBatchSizeBytes, metrics)
     ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
       maxGpuColumnSizeBytes)
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/FileSystemBytesReadTrackerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/FileSystemBytesReadTrackerSuite.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import java.io.IOException
+import java.util.concurrent.atomic.AtomicLong
 
 import com.nvidia.spark.rapids.shims.GpuDataSourceRDD
 import org.apache.hadoop.fs.{FileSystem, RawLocalFileSystem}
@@ -31,15 +31,38 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class PartitionReaderMetricsTestFileSystem extends RawLocalFileSystem
 
-class PartitionReaderWithBytesReadSuite extends AnyFunSuite with MockitoSugar {
+object FileSystemBytesReadTrackerSuite {
+  private val nextTaskAttemptId = new AtomicLong(1L)
+}
+
+class FileSystemBytesReadTrackerSuite extends AnyFunSuite with MockitoSugar {
+  import FileSystemBytesReadTrackerSuite.nextTaskAttemptId
+
+  private class TestTaskContext(taskAttemptId: Long)
+      extends MockTaskContext(taskAttemptId, partitionId = 0) {
+    private var completed = false
+
+    override def isCompleted(): Boolean = completed
+
+    override def markTaskComplete(): Unit = {
+      if (!completed) {
+        completed = true
+        super.markTaskComplete()
+      }
+    }
+  }
 
   private def withTaskContext(testBody: MockTaskContext => Unit): Unit = {
-    val context = new MockTaskContext(taskAttemptId = 1L, partitionId = 0)
+    val context = new TestTaskContext(nextTaskAttemptId.getAndIncrement())
     TrampolineUtil.setTaskContext(context)
     try {
       testBody(context)
     } finally {
-      TrampolineUtil.unsetTaskContext()
+      try {
+        context.markTaskComplete()
+      } finally {
+        TrampolineUtil.unsetTaskContext()
+      }
     }
   }
 
@@ -49,7 +72,7 @@ class PartitionReaderWithBytesReadSuite extends AnyFunSuite with MockitoSugar {
 
   test("filesystem bytes are added only once and compose with explicit metrics") {
     withTaskContext { context =>
-      val tracker = new FileSystemBytesReadTracker
+      val tracker = FileSystemBytesReadTracker.forTask(context)
       statistics.incrementBytesRead(10L)
 
       tracker.update()
@@ -60,31 +83,6 @@ class PartitionReaderWithBytesReadSuite extends AnyFunSuite with MockitoSugar {
       statistics.incrementBytesRead(7L)
       tracker.update()
       assert(context.taskMetrics().inputMetrics.bytesRead == 22L)
-    }
-  }
-
-  test("partition reader flushes bytes when next or close fails") {
-    withTaskContext { context =>
-      val delegate = new PartitionReader[ColumnarBatch] {
-        override def next(): Boolean = {
-          statistics.incrementBytesRead(9L)
-          throw new IOException("injected next failure")
-        }
-
-        override def get(): ColumnarBatch = null
-
-        override def close(): Unit = {
-          statistics.incrementBytesRead(4L)
-          throw new IOException("injected close failure")
-        }
-      }
-      val reader = new PartitionReaderWithBytesRead(delegate)
-
-      intercept[IOException](reader.next())
-      assert(context.taskMetrics().inputMetrics.bytesRead == 9L)
-
-      intercept[IOException](reader.close())
-      assert(context.taskMetrics().inputMetrics.bytesRead == 13L)
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/PartitionReaderWithBytesReadSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/PartitionReaderWithBytesReadSuite.scala
@@ -34,10 +34,7 @@ class PartitionReaderMetricsTestFileSystem extends RawLocalFileSystem
 class PartitionReaderWithBytesReadSuite extends AnyFunSuite with MockitoSugar {
 
   private def withTaskContext(testBody: MockTaskContext => Unit): Unit = {
-    val context = new MockTaskContext(taskAttemptId = 1L, partitionId = 0) {
-      private val stableTaskMetrics = super.taskMetrics()
-      override def taskMetrics() = stableTaskMetrics
-    }
+    val context = new MockTaskContext(taskAttemptId = 1L, partitionId = 0)
     TrampolineUtil.setTaskContext(context)
     try {
       testBody(context)
@@ -161,6 +158,55 @@ class PartitionReaderWithBytesReadSuite extends AnyFunSuite with MockitoSugar {
       assert(context.taskMetrics().inputMetrics.bytesRead == 0L)
       context.markTaskComplete()
       assert(context.taskMetrics().inputMetrics.bytesRead == 10L)
+    }
+  }
+
+  test("GPU datasource RDD shares filesystem accounting across compute calls") {
+    withTaskContext { context =>
+      def newRdd(bytesRead: Long) = {
+        val inputPartition = new InputPartition {}
+        val factory = new PartitionReaderFactory {
+          override def createReader(partition: InputPartition) =
+            throw new UnsupportedOperationException
+
+          override def createColumnarReader(partition: InputPartition) =
+            new PartitionReader[ColumnarBatch] {
+              private var hasNext = true
+
+              override def next(): Boolean = {
+                if (hasNext) {
+                  hasNext = false
+                  statistics.incrementBytesRead(bytesRead)
+                  true
+                } else {
+                  false
+                }
+              }
+
+              override def get(): ColumnarBatch = new ColumnarBatch(Array.empty, 1)
+              override def close(): Unit = {}
+            }
+
+          override def supportColumnarReads(partition: InputPartition): Boolean = true
+        }
+        GpuDataSourceRDD(mock[SparkContext], Seq(inputPartition), factory)
+      }
+
+      val firstRdd = newRdd(10L)
+      val secondRdd = newRdd(20L)
+      val first = firstRdd.compute(firstRdd.partitions.head, context)
+      val second = secondRdd.compute(secondRdd.partitions.head, context)
+
+      assert(first.hasNext)
+      assert(second.hasNext)
+      assert(context.taskMetrics().inputMetrics.bytesRead == 0L)
+      first.next()
+      assert(context.taskMetrics().inputMetrics.bytesRead == 30L)
+      second.next()
+      assert(context.taskMetrics().inputMetrics.bytesRead == 30L)
+
+      context.markTaskComplete()
+      assert(context.taskMetrics().inputMetrics.bytesRead == 30L)
     }
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/PartitionReaderWithBytesReadSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/PartitionReaderWithBytesReadSuite.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.io.IOException
+
+import com.nvidia.spark.rapids.shims.GpuDataSourceRDD
+import org.apache.hadoop.fs.{FileSystem, RawLocalFileSystem}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.rapids.metrics.source.MockTaskContext
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class PartitionReaderMetricsTestFileSystem extends RawLocalFileSystem
+
+class PartitionReaderWithBytesReadSuite extends AnyFunSuite with MockitoSugar {
+
+  private def withTaskContext(testBody: MockTaskContext => Unit): Unit = {
+    val context = new MockTaskContext(taskAttemptId = 1L, partitionId = 0) {
+      private val stableTaskMetrics = super.taskMetrics()
+      override def taskMetrics() = stableTaskMetrics
+    }
+    TrampolineUtil.setTaskContext(context)
+    try {
+      testBody(context)
+    } finally {
+      TrampolineUtil.unsetTaskContext()
+    }
+  }
+
+  @scala.annotation.nowarn("msg=method getStatistics in class FileSystem is deprecated")
+  private def statistics = FileSystem.getStatistics(
+    "partition-reader-metrics", classOf[PartitionReaderMetricsTestFileSystem])
+
+  test("filesystem bytes are added only once and compose with explicit metrics") {
+    withTaskContext { context =>
+      val tracker = new FileSystemBytesReadTracker
+      statistics.incrementBytesRead(10L)
+
+      tracker.update()
+      tracker.update()
+      assert(context.taskMetrics().inputMetrics.bytesRead == 10L)
+
+      TrampolineUtil.incBytesRead(context.taskMetrics().inputMetrics, 5L)
+      statistics.incrementBytesRead(7L)
+      tracker.update()
+      assert(context.taskMetrics().inputMetrics.bytesRead == 22L)
+    }
+  }
+
+  test("partition reader flushes bytes when next or close fails") {
+    withTaskContext { context =>
+      val delegate = new PartitionReader[ColumnarBatch] {
+        override def next(): Boolean = {
+          statistics.incrementBytesRead(9L)
+          throw new IOException("injected next failure")
+        }
+
+        override def get(): ColumnarBatch = null
+
+        override def close(): Unit = {
+          statistics.incrementBytesRead(4L)
+          throw new IOException("injected close failure")
+        }
+      }
+      val reader = new PartitionReaderWithBytesRead(delegate)
+
+      intercept[IOException](reader.next())
+      assert(context.taskMetrics().inputMetrics.bytesRead == 9L)
+
+      intercept[IOException](reader.close())
+      assert(context.taskMetrics().inputMetrics.bytesRead == 13L)
+    }
+  }
+
+  test("GPU datasource RDD accounts for reader construction and preserves explicit bytes") {
+    withTaskContext { context =>
+      val inputPartition = new InputPartition {}
+      val factory = new PartitionReaderFactory {
+        override def createReader(partition: InputPartition) =
+          throw new UnsupportedOperationException
+
+        override def createColumnarReader(partition: InputPartition) = {
+          statistics.incrementBytesRead(3L)
+          new PartitionReader[ColumnarBatch] {
+            private var hasNext = true
+
+            override def next(): Boolean = {
+              if (hasNext) {
+                hasNext = false
+                statistics.incrementBytesRead(7L)
+                TrampolineUtil.incBytesRead(context.taskMetrics().inputMetrics, 5L)
+                true
+              } else {
+                false
+              }
+            }
+
+            override def get(): ColumnarBatch = new ColumnarBatch(Array.empty, 1)
+            override def close(): Unit = {}
+          }
+        }
+
+        override def supportColumnarReads(partition: InputPartition): Boolean = true
+      }
+      val rdd = GpuDataSourceRDD(mock[SparkContext], Seq(inputPartition), factory)
+      val iterator = rdd.compute(rdd.partitions.head, context)
+
+      assert(iterator.hasNext)
+      iterator.next()
+      assert(!iterator.hasNext)
+      assert(context.taskMetrics().inputMetrics.bytesRead == 15L)
+      context.markTaskComplete()
+    }
+  }
+
+  test("GPU datasource RDD flushes bytes when a task stops before consuming a batch") {
+    withTaskContext { context =>
+      val inputPartition = new InputPartition {}
+      val factory = new PartitionReaderFactory {
+        override def createReader(partition: InputPartition) =
+          throw new UnsupportedOperationException
+
+        override def createColumnarReader(partition: InputPartition) = {
+          statistics.incrementBytesRead(3L)
+          new PartitionReader[ColumnarBatch] {
+            override def next(): Boolean = {
+              statistics.incrementBytesRead(7L)
+              true
+            }
+
+            override def get(): ColumnarBatch = new ColumnarBatch(Array.empty, 1)
+            override def close(): Unit = {}
+          }
+        }
+
+        override def supportColumnarReads(partition: InputPartition): Boolean = true
+      }
+      val rdd = GpuDataSourceRDD(mock[SparkContext], Seq(inputPartition), factory)
+      val iterator = rdd.compute(rdd.partitions.head, context)
+
+      assert(iterator.hasNext)
+      assert(context.taskMetrics().inputMetrics.bytesRead == 0L)
+      context.markTaskComplete()
+      assert(context.taskMetrics().inputMetrics.bytesRead == 10L)
+    }
+  }
+}

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala
@@ -33,6 +33,7 @@ import org.apache.spark.util.{AccumulatorV2, TaskCompletionListener, TaskFailure
 abstract class MockTaskContextBase(taskAttemptId: Long, partitionId: Int) extends TaskContext {
 
   val listeners = new ListBuffer[TaskCompletionListener]
+  private val metrics = new TaskMetrics
 
   override def isCompleted(): Boolean = false
 
@@ -61,7 +62,7 @@ abstract class MockTaskContextBase(taskAttemptId: Long, partitionId: Int) extend
 
   override def resourcesJMap(): util.Map[String, ResourceInformation] = resources().asJava
 
-  override def taskMetrics(): TaskMetrics = new TaskMetrics
+  override def taskMetrics(): TaskMetrics = metrics
 
   override def getMetricsSources(sourceName: String): Seq[Source] = Seq.empty
 


### PR DESCRIPTION
Fixes #15791.
Fixes #10181.

### Description

DSv2 per-file scans and Iceberg scans using the PERFILE reader could report incorrect Spark input bytes. These paths run through `GpuDataSourceRDD`, which did not account for task-thread reads performed during reader construction, footer reads, empty scans, failures, and early task termination. The retained per-file reader wrapper also transferred the cumulative Hadoop filesystem counter after every `next`, rather than transferring deltas.

The cumulative wrapper behavior was not observable on V1 PERFILE scans because Spark `FileScanRDD` overwrites input bytes from its own filesystem counter after each batch and at task completion. This change therefore makes each RDD layer the single accounting owner:

- Spark `FileScanRDD` retains ownership for V1 scans, so nested per-reader wrappers are removed.
- `GpuDataSourceRDD` uses one task-scoped filesystem tracker shared by every `compute()` call in that task, adding task-thread deltas without overwriting explicit bytes reported by multithreaded readers.
- Reader-close and task-completion paths flush pending construction/footer and early-termination reads.
- The task-scoped factory is the only tracker construction path; the obsolete per-reader wrapper is removed.

Tests cover repeated updates, composition with explicit worker metrics, reader construction, early task completion, isolated task cleanup, and interleaved `compute()` calls in the same task.

Validation:

- Spark 3.5 / Scala 2.12: `FileSystemBytesReadTrackerSuite` — 4 passed.
- Spark 4.0 / Scala 2.13: `FileSystemBytesReadTrackerSuite` — 4 passed.
- Root Maven verify / all-modules Scalastyle (Spark 3.5, tests skipped) — 18 modules and 1,832 Scala files checked successfully.

Performance validation: per-file V2 scans retain one filesystem-statistics sample per emitted batch. Multithreaded and coalescing V2 scans add one constant-time sample per emitted batch plus completion-path flushes; the work is per batch rather than per row. V1 removes redundant wrapper samples and continues to rely on Spark `FileScanRDD`. No GPU kernels, I/O requests, batch sizes, or data transformations change, so a runtime benchmark is not required.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
