### PR TITLE
Reuse sorted GroupPartitionsExec input in GPU external merge [databricks][fast-ut][reduced-it]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,6 +235,41 @@ object GpuSpillableProjectedSortEachBatchIterator {
 }
 
 /**
+ * Create an iterator for batches whose rows already satisfy the sort ordering. Temporary columns
+ * required to evaluate computed sort keys are appended, but the rows are not sorted again.
+ */
+object GpuSpillableProjectedEachBatchIterator {
+  def apply(
+      iter: Iterator[ColumnarBatch],
+      sorter: GpuSorter,
+      opTime: GpuMetric = NoopMetric): Iterator[SpillableColumnarBatch] = {
+    val spillableIter = iter.flatMap { cb =>
+      // Filter out empty batches and make them spillable.
+      if (cb.numRows() > 0) {
+        Some(SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
+      } else {
+        cb.close()
+        None
+      }
+    }
+
+    spillableIter.flatMap { scb =>
+      // Splitting by contiguous row ranges preserves the input ordering on retry.
+      withRetry(scb, splitSpillableInHalfByRows) { attemptScb =>
+        opTime.ns {
+          val projected = withResource(attemptScb.getColumnarBatch()) { attemptCb =>
+            sorter.appendProjectedColumns(attemptCb)
+          }
+          closeOnExcept(projected) { cb =>
+            SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
  * Holds data for the out of core sort. It includes the batch of data and the first row in that
  * batch so we can sort the batches.
  */
@@ -302,14 +337,19 @@ case class GpuOutOfCoreSortIterator(
     opTime: GpuMetric,
     sortTime: GpuMetric,
     outputBatches: GpuMetric,
-    outputRows: GpuMetric) extends Iterator[ColumnarBatch]
+    outputRows: GpuMetric,
+    inputAlreadySorted: Boolean = false) extends Iterator[ColumnarBatch]
     with AutoCloseable {
 
   /**
    * This has already sorted the data, and it still has the projected columns in it that need to
    * be removed before it is returned.
    */
-  val alreadySortedIter = GpuSpillableProjectedSortEachBatchIterator(iter, sorter, opTime, sortTime)
+  val alreadySortedIter = if (inputAlreadySorted) {
+    GpuSpillableProjectedEachBatchIterator(iter, sorter, opTime)
+  } else {
+    GpuSpillableProjectedSortEachBatchIterator(iter, sorter, opTime, sortTime)
+  }
 
   private val cpuOrd = new LazilyGeneratedOrdering(sorter.cpuOrdering)
   // A priority queue of data that is not merged yet.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -246,7 +246,9 @@ object GpuSpillableProjectedEachBatchIterator {
     val spillableIter = iter.flatMap { cb =>
       // Filter out empty batches and make them spillable.
       if (cb.numRows() > 0) {
-        Some(SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
+        Some(closeOnExcept(cb) { cb =>
+          SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+        })
       } else {
         cb.close()
         None

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsExec.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsExec.scala
@@ -190,9 +190,9 @@ case class GpuGroupPartitionsExec(
 
   private def sortCoalescedPartitions(
       coalesced: RDD[ColumnarBatch]): RDD[ColumnarBatch] = {
-    // Concatenate each partition group first and then perform a spillable full GPU sort. This
-    // is a correctness-first implementation of Spark's row-based k-way merge and reuses the
-    // same retry and resource-management path as GpuSortExec.
+    // Coalescing concatenates the ordered parent streams, which can invalidate global ordering.
+    // Each input batch remains sorted, so reuse GpuSortExec's spillable external merge while
+    // skipping its redundant per-batch sort.
     val partitionsNeedingSort = partitionGroups.map(_.size > 1).toArray
     val sorter = new GpuSorter(groupInfo.gpuOutputOrdering, output, allMetrics)
     val targetSize = GpuSortExec.targetSize(conf)
@@ -210,7 +210,8 @@ case class GpuGroupPartitionsExec(
           opTime,
           sortTime,
           outputBatches,
-          outputRows)
+          outputRows,
+          inputAlreadySorted = true)
         onTaskCompletion(sorted.close())
         sorted
       } else {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSortRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSortRetrySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,12 @@ class GpuSortRetrySuite extends RmmSparkRetrySuiteBase with MockitoSugar {
         // only one batch
         assertResult(NUM_ROWS * 2)(cb.numRows())
         assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+        withResource(cb.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { host =>
+          (0 until NUM_ROWS).foreach { value =>
+            assertResult(value)(host.getInt(value * 2))
+            assertResult(value)(host.getInt(value * 2 + 1))
+          }
+        }
       }
     }
   }

--- a/tests/src/test/spark420/scala/com/nvidia/spark/rapids/GroupPartitionsExecSuite.scala
+++ b/tests/src/test/spark420/scala/com/nvidia/spark/rapids/GroupPartitionsExecSuite.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.execution.{LocalTableScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
 import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.GpuAdd
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
 import org.apache.spark.sql.types.{IntegerType, LongType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -302,29 +303,26 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
   }
 
   Seq(
-    (Ascending, (0L until 8L)),
-    (Descending, (0L until 8L).reverse)
-  ).foreach { case (direction, expected) =>
+    (Ascending,
+      Seq(Seq[Integer](0, 2, 4, 6), Seq[Integer](1, 3, 5, 7)),
+      (0 until 8)),
+    (Descending,
+      Seq(Seq[Integer](7, 5, 3, 1), Seq[Integer](6, 4, 2, 0)),
+      (0 until 8).reverse)
+  ).foreach { case (direction, partitionValues, expected) =>
     test(s"GpuGroupPartitionsExec sorted merge orders rows $direction") {
       withGpuSparkSession { spark =>
         spark.conf.set(RapidsConf.METRICS_LEVEL.key, "DEBUG")
-        val attr = AttributeReference("id", LongType, nullable = false)()
+        val attr = AttributeReference("id", IntegerType, nullable = false)()
         val ordering = Seq(SortOrder(attr, direction))
-        val child = GpuRangeExec(
-          start = 0,
-          end = 8,
-          step = 1,
-          numSlices = 2,
-          output = Seq(attr),
-          targetSizeBytes = 1024)
+        val child = GroupPartitionsTestGpuLeaf(Seq(attr), partitionValues, ordering)
         val groupPartitions = GpuGroupPartitionsExec(
           child,
           GpuGroupPartitionsExecInfo(
             UnknownPartitioning(1),
             ordering,
             ordering,
-            // Reverse the two input partitions so the ascending case is not already ordered.
-            Seq(Seq(1, 0)),
+            Seq(Seq(0, 1)),
             joinKeyPositions = None,
             expectedPartitionKeyCount = None,
             reducerNames = None,
@@ -333,7 +331,7 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
 
         val actual = GpuColumnarToRowExec(groupPartitions)
           .executeCollect()
-          .map(_.getLong(0))
+          .map(_.getInt(0))
           .toSeq
         assert(actual == expected)
         assert(groupPartitions.metrics(GpuMetric.SORT_TIME).value > 0)
@@ -353,7 +351,8 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
           Seq(
             Seq[Integer](1, 3),
             Seq[Integer](2, 4),
-            Seq[Integer](5, 6)),
+            Seq[Integer](5, 6),
+            Seq.empty[Integer]),
           ordering)
         GpuGroupPartitionsExec(
           child,
@@ -361,7 +360,7 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
             UnknownPartitioning(3),
             ordering,
             ordering,
-            Seq(Seq.empty, Seq(0, 1), Seq(2)),
+            Seq(Seq.empty, Seq(0, 1), Seq(2, 3)),
             joinKeyPositions = None,
             expectedPartitionKeyCount = None,
             reducerNames = None,
@@ -391,6 +390,39 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
         Seq(2))
       assert(singletonOutput.head.toSeq == Seq(5, 6))
       assert(singletonGroupPartitions.allMetrics(GpuMetric.SORT_TIME).value == 0)
+    }
+  }
+
+  test("GpuGroupPartitionsExec projects computed keys without re-sorting sorted input") {
+    withGpuSparkSession { _ =>
+      val attr = AttributeReference("value", IntegerType, nullable = false)()
+      val ordering = Seq(SortOrder(attr, Ascending))
+      val gpuOrdering = Seq(SortOrder(
+        GpuAdd(attr, GpuLiteral(1, IntegerType), failOnError = false)(),
+        Ascending))
+      val child = GroupPartitionsTestGpuLeaf(
+        Seq(attr),
+        Seq(Seq[Integer](1, 2, 3), Seq.empty[Integer]),
+        ordering)
+      val groupPartitions = GpuGroupPartitionsExec(
+        child,
+        GpuGroupPartitionsExecInfo(
+          UnknownPartitioning(1),
+          ordering,
+          gpuOrdering,
+          Seq(Seq(0, 1)),
+          joinKeyPositions = None,
+          expectedPartitionKeyCount = None,
+          reducerNames = None,
+          distributePartitions = false,
+          enableSortedMerge = true))
+
+      val actual = GpuColumnarToRowExec(groupPartitions)
+        .executeCollect()
+        .map(_.getInt(0))
+        .toSeq
+      assert(actual == Seq(1, 2, 3))
+      assert(groupPartitions.allMetrics(GpuMetric.SORT_TIME).value == 0)
     }
   }
 
@@ -477,6 +509,9 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
     withGpuSparkSession { _ =>
       val attr = AttributeReference("value", IntegerType, nullable = false)()
       val ordering = Seq(SortOrder(attr, Ascending))
+      val gpuOrdering = Seq(SortOrder(
+        GpuAdd(attr, GpuLiteral(1, IntegerType), failOnError = false)(),
+        Ascending))
       val child = GroupPartitionsTestGpuLeaf(
         Seq(attr),
         Seq(
@@ -489,7 +524,7 @@ class GroupPartitionsExecSuite extends SparkQueryCompareTestSuite {
         GpuGroupPartitionsExecInfo(
           UnknownPartitioning(1),
           ordering,
-          ordering,
+          gpuOrdering,
           Seq(Seq(0, 1)),
           joinKeyPositions = None,
           expectedPartitionKeyCount = None,


### PR DESCRIPTION
Fixes #15798.

### Description
- Adds an opt-in `inputAlreadySorted` path to `GpuOutOfCoreSortIterator`; existing callers retain the current per-batch sort behavior by default.
- Projects temporary columns required by computed sort keys while skipping redundant sorting for batches that already satisfy the child ordering contract.
- Keeps the existing spillable external merge, GPU OOM retry, resource ownership, and target-sized output behavior.
- Enables the sorted-input path only for sorted-merge `GpuGroupPartitionsExec`, where Spark guarantees each child partition is ordered.
- Adds coverage for interleaved ascending and descending streams, empty batches, computed sort keys, retry behavior, output ordering, and zero local sort time when no merge work is needed.

Validation:
- `mvn -s settings.xml -Dbuildver=330 -Dcuda.version=cuda13 -DskipTests validate`
- `mvn -s settings.xml -f scala2.13/pom.xml -Dbuildver=420 -Dcuda.version=cuda13 -DskipTests validate`
- Spark 4.2 `GroupPartitionsExecSuite`: 17 passed
- Spark 4.2 `GpuSortRetrySuite`: 9 passed

### Performance

Compared CPU sorted merge, the existing GPU full-sort implementation, and this sorted-input optimization. The setup used Spark 4.2, Scala 2.13, `local[4]`, an 8 GiB driver heap, one concurrent GPU task, AQE and broadcast joins disabled, four keys, and 16 million rows per join side.

The variants ran in fresh Spark processes in the order CPU/full-sort/sorted-input/CPU/full-sort/sorted-input. Each process performed two warm-ups and five measured actions. Every action created a fresh query plan to prevent shuffle-output reuse, producing ten measurements per variant and scenario.

```sql
SELECT /*+ MERGE(l, r) */ count(*) AS matched_rows
FROM group_partitions_perf_left l
JOIN group_partitions_perf_right r
  ON l.id = r.id AND l.value = r.value
```

| Scenario | CPU median | GPU full-sort median | Sorted-input GPU median | vs full-sort | vs CPU |
| --- | ---: | ---: | ---: | ---: | ---: |
| 8 streams/key, 500,000 rows/stream | 7.671 s | 4.856 s | 4.515 s | 1.076x | 1.699x |
| 32 streams/key, 125,000 rows/stream | 31.002 s | 34.739 s | 29.962 s | 1.159x | 1.035x |

The optimization improves both scenarios and removes the previously observed high-fan-in regression against CPU sorted merge.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required