### PR TITLE
Work around Spark signed-zero percentile bug in exact percentile tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -420,11 +420,20 @@ NEG_FLOAT_NAN_MIN_VALUE = struct.unpack('f', struct.pack('I', 0xffffffff))[0]
 NEG_FLOAT_NAN_MAX_VALUE = struct.unpack('f', struct.pack('I', 0xff800001))[0]
 POS_FLOAT_NAN_MIN_VALUE = struct.unpack('f', struct.pack('I', 0x7f800001))[0]
 POS_FLOAT_NAN_MAX_VALUE = struct.unpack('f', struct.pack('I', 0x7fffffff))[0]
+
+
+def _normalize_negative_zero(value):
+    if value == 0.0 and math.copysign(1.0, value) < 0:
+        return 0.0
+    return value
+
+
 class FloatGen(DataGen):
     """Generate floats, which some built in corner cases."""
     def __init__(self, nullable=True,
-            no_nans=False, special_cases=None):
+            no_nans=False, special_cases=None, normalize_negative_zero=False):
         self._no_nans = no_nans
+        self._normalize_negative_zero = normalize_negative_zero
         if special_cases is None:
             special_cases = [FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, 1.0, -1.0]
             if not no_nans:
@@ -440,7 +449,14 @@ class FloatGen(DataGen):
         return v
     
     def _cache_repr(self):
-        return super()._cache_repr() + '(' + str(self._no_nans) + ')'
+        return super()._cache_repr() + '({},{})'.format(
+            self._no_nans, self._normalize_negative_zero)
+
+    def gen(self, force_no_nulls=False):
+        value = super().gen(force_no_nulls=force_no_nulls)
+        if self._normalize_negative_zero:
+            return _normalize_negative_zero(value)
+        return value
 
     def start(self, rand):
         def gen_float():
@@ -461,10 +477,11 @@ POS_DOUBLE_NAN_MAX_VALUE = struct.unpack('d', struct.pack('L', 0x7ffffffffffffff
 class DoubleGen(DataGen):
     """Generate doubles, which some built in corner cases."""
     def __init__(self, min_exp=DOUBLE_MIN_EXP, max_exp=DOUBLE_MAX_EXP, no_nans=False,
-            nullable=True, special_cases = None):
+            nullable=True, special_cases = None, normalize_negative_zero=False):
         self._min_exp = min_exp
         self._max_exp = max_exp
         self._no_nans = no_nans
+        self._normalize_negative_zero = normalize_negative_zero
         self._use_full_range = (self._min_exp == DOUBLE_MIN_EXP) and (self._max_exp == DOUBLE_MAX_EXP)
         if special_cases is None:
             special_cases = [
@@ -487,7 +504,14 @@ class DoubleGen(DataGen):
         super().__init__(DoubleType(), nullable=nullable, special_cases=special_cases)
 
     def _cache_repr(self):
-        return super()._cache_repr() + '(' + str(self._min_exp) + ',' + str(self._max_exp) + ',' + str(self._no_nans) + ')'
+        return super()._cache_repr() + '({},{},{},{})'.format(
+            self._min_exp, self._max_exp, self._no_nans, self._normalize_negative_zero)
+
+    def gen(self, force_no_nulls=False):
+        value = super().gen(force_no_nulls=force_no_nulls)
+        if self._normalize_negative_zero:
+            return _normalize_negative_zero(value)
+        return value
 
     @staticmethod
     def make_from(sign, exp, fraction):

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -420,20 +420,11 @@ NEG_FLOAT_NAN_MIN_VALUE = struct.unpack('f', struct.pack('I', 0xffffffff))[0]
 NEG_FLOAT_NAN_MAX_VALUE = struct.unpack('f', struct.pack('I', 0xff800001))[0]
 POS_FLOAT_NAN_MIN_VALUE = struct.unpack('f', struct.pack('I', 0x7f800001))[0]
 POS_FLOAT_NAN_MAX_VALUE = struct.unpack('f', struct.pack('I', 0x7fffffff))[0]
-
-
-def _normalize_negative_zero(value):
-    if value == 0.0 and math.copysign(1.0, value) < 0:
-        return 0.0
-    return value
-
-
 class FloatGen(DataGen):
     """Generate floats, which some built in corner cases."""
     def __init__(self, nullable=True,
-            no_nans=False, special_cases=None, normalize_negative_zero=False):
+            no_nans=False, special_cases=None):
         self._no_nans = no_nans
-        self._normalize_negative_zero = normalize_negative_zero
         if special_cases is None:
             special_cases = [FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, 1.0, -1.0]
             if not no_nans:
@@ -449,14 +440,7 @@ class FloatGen(DataGen):
         return v
     
     def _cache_repr(self):
-        return super()._cache_repr() + '({},{})'.format(
-            self._no_nans, self._normalize_negative_zero)
-
-    def gen(self, force_no_nulls=False):
-        value = super().gen(force_no_nulls=force_no_nulls)
-        if self._normalize_negative_zero:
-            return _normalize_negative_zero(value)
-        return value
+        return super()._cache_repr() + '(' + str(self._no_nans) + ')'
 
     def start(self, rand):
         def gen_float():
@@ -477,11 +461,10 @@ POS_DOUBLE_NAN_MAX_VALUE = struct.unpack('d', struct.pack('L', 0x7ffffffffffffff
 class DoubleGen(DataGen):
     """Generate doubles, which some built in corner cases."""
     def __init__(self, min_exp=DOUBLE_MIN_EXP, max_exp=DOUBLE_MAX_EXP, no_nans=False,
-            nullable=True, special_cases = None, normalize_negative_zero=False):
+            nullable=True, special_cases = None):
         self._min_exp = min_exp
         self._max_exp = max_exp
         self._no_nans = no_nans
-        self._normalize_negative_zero = normalize_negative_zero
         self._use_full_range = (self._min_exp == DOUBLE_MIN_EXP) and (self._max_exp == DOUBLE_MAX_EXP)
         if special_cases is None:
             special_cases = [
@@ -504,14 +487,7 @@ class DoubleGen(DataGen):
         super().__init__(DoubleType(), nullable=nullable, special_cases=special_cases)
 
     def _cache_repr(self):
-        return super()._cache_repr() + '({},{},{},{})'.format(
-            self._min_exp, self._max_exp, self._no_nans, self._normalize_negative_zero)
-
-    def gen(self, force_no_nulls=False):
-        value = super().gen(force_no_nulls=force_no_nulls)
-        if self._normalize_negative_zero:
-            return _normalize_negative_zero(value)
-        return value
+        return super()._cache_repr() + '(' + str(self._min_exp) + ',' + str(self._max_exp) + ',' + str(self._no_nans) + ')'
 
     @staticmethod
     def make_from(sign, exp, fraction):

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -27,7 +27,7 @@ from pyspark.sql.types import *
 from marks import *
 import pyspark.sql.functions as f
 from spark_session import is_databricks104_or_later, with_cpu_session, is_spark_340_or_later, \
-    is_spark_420_or_later, is_spark_500_or_later
+    is_spark_420_or_later, is_spark_500_or_later, is_before_spark_352
 
 pytestmark = pytest.mark.nightly_resource_consuming_test
 
@@ -1446,17 +1446,26 @@ def test_hash_groupby_collect_partial_replace_with_distinct_fallback(data_gen,
         conf=conf)
 
 
-exact_percentile_data_gen = [ByteGen(), ShortGen(), IntegerGen(), LongGen(), FloatGen(), DoubleGen(),
-                             RepeatSeqGen(ByteGen(), length=100),
-                             RepeatSeqGen(ShortGen(), length=100),
-                             RepeatSeqGen(IntegerGen(), length=100),
-                             RepeatSeqGen(LongGen(), length=100),
-                             RepeatSeqGen(FloatGen(), length=100),
-                             RepeatSeqGen(DoubleGen(), length=100),
-                             FloatGen().with_special_case(math.nan, 500.0)
-                             .with_special_case(math.inf, 500.0),
-                             DoubleGen().with_special_case(math.nan, 500.0)
-                             .with_special_case(math.inf, 500.0)]
+# Spark before 3.5.2 can lose percentile counts when +0.0 and -0.0 are mixed.
+# See https://issues.apache.org/jira/browse/SPARK-45599 and issue #12886.
+_exact_percentile_fp_gen_kwargs = {
+    'normalize_negative_zero': is_before_spark_352()
+}
+
+exact_percentile_data_gen = [
+    ByteGen(), ShortGen(), IntegerGen(), LongGen(),
+    FloatGen(**_exact_percentile_fp_gen_kwargs),
+    DoubleGen(**_exact_percentile_fp_gen_kwargs),
+    RepeatSeqGen(ByteGen(), length=100),
+    RepeatSeqGen(ShortGen(), length=100),
+    RepeatSeqGen(IntegerGen(), length=100),
+    RepeatSeqGen(LongGen(), length=100),
+    RepeatSeqGen(FloatGen(**_exact_percentile_fp_gen_kwargs), length=100),
+    RepeatSeqGen(DoubleGen(**_exact_percentile_fp_gen_kwargs), length=100),
+    FloatGen(**_exact_percentile_fp_gen_kwargs).with_special_case(math.nan, 500.0)
+    .with_special_case(math.inf, 500.0),
+    DoubleGen(**_exact_percentile_fp_gen_kwargs).with_special_case(math.nan, 500.0)
+    .with_special_case(math.inf, 500.0)]
 
 exact_percentile_reduction_data_gen = [
     [('val', data_gen),
@@ -1493,7 +1502,6 @@ _exact_percentile_tolerance_reason = \
 
 @pytest.mark.skipif(is_spark_500_or_later(),
                     reason=_exact_percentile_strict_skip_reason)
-@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10233")
 @pytest.mark.parametrize('data_gen', exact_percentile_reduction_data_gen, ids=idfn)
 def test_exact_percentile_reduction(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -1501,7 +1509,6 @@ def test_exact_percentile_reduction(data_gen):
 
 @pytest.mark.skipif(not is_spark_500_or_later(),
                     reason=_exact_percentile_tolerance_reason)
-@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10233")
 @approximate_float
 @pytest.mark.parametrize('data_gen', exact_percentile_reduction_data_gen, ids=idfn)
 def test_exact_percentile_reduction_spark500(data_gen):
@@ -1512,7 +1519,7 @@ exact_percentile_reduction_cpu_fallback_data_gen = [
     [('val', data_gen),
      ('freq', LongGen(min_val=0, max_val=1000000, nullable=False)
       .with_special_case(0, weight=100))]
-    for data_gen in [IntegerGen(), DoubleGen()]]
+    for data_gen in [IntegerGen(), DoubleGen(**_exact_percentile_fp_gen_kwargs)]]
 
 def _assert_exact_percentile_reduction_partial_fallback_to_cpu(
         data_gen, replace_mode, use_obj_hash_agg):
@@ -1657,11 +1664,11 @@ def _exact_percentile_groupby_cpu_fallback_spark500_data_gen(data_gen):
 
 exact_percentile_groupby_cpu_fallback_data_gen = [
     _exact_percentile_groupby_cpu_fallback_gen(data_gen)
-    for data_gen in [IntegerGen(), DoubleGen()]]
+    for data_gen in [IntegerGen(), DoubleGen(**_exact_percentile_fp_gen_kwargs)]]
 
 exact_percentile_groupby_cpu_fallback_spark500_data_gen = [
     _exact_percentile_groupby_cpu_fallback_spark500_data_gen(data_gen)
-    for data_gen in [IntegerGen(), DoubleGen()]]
+    for data_gen in [IntegerGen(), DoubleGen(**_exact_percentile_fp_gen_kwargs)]]
 
 @ignore_order
 @pytest.mark.skipif(is_spark_500_or_later(),

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1448,23 +1448,28 @@ def test_hash_groupby_collect_partial_replace_with_distinct_fallback(data_gen,
 
 # Spark before 3.5.2 can lose percentile counts when +0.0 and -0.0 are mixed.
 # See https://issues.apache.org/jira/browse/SPARK-45599 and issue #12886.
-_exact_percentile_fp_gen_kwargs = {
-    'normalize_negative_zero': is_before_spark_352()
-}
+def _normalize_negative_zero(value):
+    return 0.0 if value == 0.0 else value
+
+
+def _exact_percentile_fp_gen(gen_class):
+    if is_before_spark_352():
+        return ConvertGen(gen_class(nullable=False), _normalize_negative_zero)
+    return gen_class()
 
 exact_percentile_data_gen = [
     ByteGen(), ShortGen(), IntegerGen(), LongGen(),
-    FloatGen(**_exact_percentile_fp_gen_kwargs),
-    DoubleGen(**_exact_percentile_fp_gen_kwargs),
+    _exact_percentile_fp_gen(FloatGen),
+    _exact_percentile_fp_gen(DoubleGen),
     RepeatSeqGen(ByteGen(), length=100),
     RepeatSeqGen(ShortGen(), length=100),
     RepeatSeqGen(IntegerGen(), length=100),
     RepeatSeqGen(LongGen(), length=100),
-    RepeatSeqGen(FloatGen(**_exact_percentile_fp_gen_kwargs), length=100),
-    RepeatSeqGen(DoubleGen(**_exact_percentile_fp_gen_kwargs), length=100),
-    FloatGen(**_exact_percentile_fp_gen_kwargs).with_special_case(math.nan, 500.0)
+    RepeatSeqGen(_exact_percentile_fp_gen(FloatGen), length=100),
+    RepeatSeqGen(_exact_percentile_fp_gen(DoubleGen), length=100),
+    _exact_percentile_fp_gen(FloatGen).with_special_case(math.nan, 500.0)
     .with_special_case(math.inf, 500.0),
-    DoubleGen(**_exact_percentile_fp_gen_kwargs).with_special_case(math.nan, 500.0)
+    _exact_percentile_fp_gen(DoubleGen).with_special_case(math.nan, 500.0)
     .with_special_case(math.inf, 500.0)]
 
 exact_percentile_reduction_data_gen = [
@@ -1519,7 +1524,7 @@ exact_percentile_reduction_cpu_fallback_data_gen = [
     [('val', data_gen),
      ('freq', LongGen(min_val=0, max_val=1000000, nullable=False)
       .with_special_case(0, weight=100))]
-    for data_gen in [IntegerGen(), DoubleGen(**_exact_percentile_fp_gen_kwargs)]]
+    for data_gen in [IntegerGen(), _exact_percentile_fp_gen(DoubleGen)]]
 
 def _assert_exact_percentile_reduction_partial_fallback_to_cpu(
         data_gen, replace_mode, use_obj_hash_agg):
@@ -1664,11 +1669,11 @@ def _exact_percentile_groupby_cpu_fallback_spark500_data_gen(data_gen):
 
 exact_percentile_groupby_cpu_fallback_data_gen = [
     _exact_percentile_groupby_cpu_fallback_gen(data_gen)
-    for data_gen in [IntegerGen(), DoubleGen(**_exact_percentile_fp_gen_kwargs)]]
+    for data_gen in [IntegerGen(), _exact_percentile_fp_gen(DoubleGen)]]
 
 exact_percentile_groupby_cpu_fallback_spark500_data_gen = [
     _exact_percentile_groupby_cpu_fallback_spark500_data_gen(data_gen)
-    for data_gen in [IntegerGen(), DoubleGen(**_exact_percentile_fp_gen_kwargs)]]
+    for data_gen in [IntegerGen(), _exact_percentile_fp_gen(DoubleGen)]]
 
 @ignore_order
 @pytest.mark.skipif(is_spark_500_or_later(),

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -207,6 +207,9 @@ def is_before_spark_350():
 def is_before_spark_351():
     return spark_version() < "3.5.1"
 
+def is_before_spark_352():
+    return spark_version() < "3.5.2"
+
 def is_before_spark_353():
     return spark_version() < "3.5.3"
 


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — measured +0 lines in `sql-plugin`, `delta-lake` (stub), `shuffle-plugin`, and `udf-compiler`; `iceberg` is N/A because nightly b19 execution data does not match the locally rebuilt Iceberg 1.6.x class IDs** (anchor `d2f4fe24`, Scala 2.12, shim 350, Spark 3.5.0, nightly b19)

Fixes #12886.

### Description

Apache Spark's CPU `percentile` implementation before Spark 3.5.2 has a signed-zero bug. It can merge `+0.0` and `-0.0` as equal while building frequency counts but order them separately while selecting the percentile, causing the CPU reference result to be incorrect when both values occur.

This is [SPARK-45599](https://issues.apache.org/jira/browse/SPARK-45599) in Apache Spark itself, not a RAPIDS percentile calculation defect. Spark 3.3 is affected.

This change:

- adds an exact-percentile-local `ConvertGen` wrapper that normalizes negative zero on Spark versions before 3.5.2;
- keeps the child floating-point generator non-nullable and lets the outer `ConvertGen` provide nullable output;
- applies the wrapper to the main exact-percentile data matrix and its three partial CPU-fallback matrices without changing the shared `FloatGen`/`DoubleGen` API;
- preserves existing `-0.0` coverage on Spark 3.5.2 and later;
- removes the fixed-seed workaround so these tests can resume normal randomized coverage.

AI assistance: Codex helped investigate the issue, implement and validate the change, and draft this PR description. The author reviewed the exact commit and diff before submission.

Validation performed:

- `buildver=330`: 17/17 Maven modules, `BUILD SUCCESS`.
- Spark 3.3 focused exact-percentile `ConvertGen` GPU/CPU run, seed `1749332659`: `20 passed, 20 skipped, 35008 deselected`.
- `buildver=355`: 16/16 Maven modules, `BUILD SUCCESS`.
- Spark 3.5.5 focused exact-percentile Float/Double GPU/CPU run, seed `1749332659`: `20 passed, 44 skipped, 34993 deselected`.
- Python byte-compilation, targeted pre-commit checks, and `git diff --check` passed.

Performance impact: none. This changes integration-test data generation only; no production runtime code is modified.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
