### PR TITLE
Move Iceberg write access bridge to root-safe module [fast-ut][reduced-it]

### DIFF
--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -34,7 +34,6 @@ org/apache/iceberg/parquet/GpuParquetIOAccess.class
 org/apache/iceberg/spark/source/GpuBaseReader.class
 org/apache/iceberg/spark/source/GpuSparkPlanningUtil.class
 org/apache/iceberg/spark/source/GpuSparkScanAccess.class
-org/apache/iceberg/spark/source/GpuSparkWriteAccess.class
 org/apache/spark/sql/rapids/AdaptiveSparkPlanHelperShim*
 org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback*
 rapids/*.py

--- a/docs/dev/shims.md
+++ b/docs/dev/shims.md
@@ -194,6 +194,20 @@ jar:file:/home/spark/rapids-4-spark_2.12-26.10.0.jar!/spark-shared/
 jar:file:/home/spark/rapids-4-spark_2.12-26.10.0.jar!/spark351/
 ```
 
+### Classloader Coupling for Package-Private Integrations
+
+The cuDF Plugin directly accesses package-private APIs in some dependency runtimes, including
+Apache Iceberg. The JVM treats classes as members of the same runtime package only when they have
+the same package name and defining classloader. Therefore, the cuDF Plugin distribution jar and the
+dependency runtime jar must be deployed so the relevant classes are defined by the same classloader.
+
+For Iceberg, deploy both jars through `spark.driver.extraClassPath` and
+`spark.executor.extraClassPath`, or deploy both through `spark.jars`/`--jars`/`--packages`. Mixed
+deployment, with one jar on an extra classpath and the other added as a Spark jar, is unsupported for
+package-private access paths and can fail with `IllegalAccessError`. Placing an access bridge in the
+conventional root of the cuDF Plugin jar allows it to share the application classloader when both
+jars use an extra classpath; root placement does not remove the classloader-coupling requirement.
+
 ### Late Inheritance in Public Classes
 
 Most classes needed by the plugin can be disambiguated using Parallel World locations without

--- a/iceberg-common/src/main/java/org/apache/iceberg/spark/source/GpuSparkWriteAccess.java
+++ b/iceberg-common/src/main/java/org/apache/iceberg/spark/source/GpuSparkWriteAccess.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.io.DeleteWriteResult;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.connector.write.DeltaWrite;
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
@@ -94,24 +93,24 @@ public final class GpuSparkWriteAccess {
     return readField(sparkWrite(write), "writeProperties", Map.class);
   }
 
-  public static Table table(DeltaWrite write) {
+  public static Table deltaTable(Write write) {
     return readField(positionDeltaWrite(write), "table", Table.class);
   }
 
-  public static JavaSparkContext sparkContext(DeltaWrite write) {
+  public static JavaSparkContext deltaSparkContext(Write write) {
     return readField(positionDeltaWrite(write), "sparkContext", JavaSparkContext.class);
   }
 
-  public static Command command(DeltaWrite write) {
+  public static Command deltaCommand(Write write) {
     return readField(positionDeltaWrite(write), "command", Command.class);
   }
 
   @SuppressWarnings("unchecked")
-  public static Map<String, String> writeProperties(DeltaWrite write) {
+  public static Map<String, String> deltaWriteProperties(Write write) {
     return readField(positionDeltaWrite(write), "writeProperties", Map.class);
   }
 
-  public static Object context(DeltaWrite write) {
+  public static Object deltaContext(Write write) {
     return readField(positionDeltaWrite(write), "context", Object.class);
   }
 
@@ -181,7 +180,7 @@ public final class GpuSparkWriteAccess {
     return (SparkWrite) write;
   }
 
-  private static SparkPositionDeltaWrite positionDeltaWrite(DeltaWrite write) {
+  private static SparkPositionDeltaWrite positionDeltaWrite(Write write) {
     return (SparkPositionDeltaWrite) write;
   }
 

--- a/iceberg-common/src/main/java/org/apache/iceberg/spark/source/GpuSparkWriteAccess.java
+++ b/iceberg-common/src/main/java/org/apache/iceberg/spark/source/GpuSparkWriteAccess.java
@@ -35,9 +35,10 @@ import org.apache.spark.sql.types.StructType;
 /**
  * Package-local access to Iceberg Spark write classes.
  *
- * <p>Iceberg keeps SparkWrite and SparkPositionDeltaWrite package-private. Resolve those
- * classes from a conventional-root helper so runtime package access is checked in the same
- * class loader as Iceberg itself.
+ * <p>Iceberg keeps SparkWrite and SparkPositionDeltaWrite package-private. This helper lives
+ * in the conventional root so it can share Iceberg's defining classloader when the cuDF Plugin
+ * and Iceberg runtime jars use the same deployment mechanism. Mixed classloader deployments
+ * remain unsupported for package-private access paths.
  */
 public final class GpuSparkWriteAccess {
   private GpuSparkWriteAccess() {

--- a/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuSparkPositionDeltaWrite.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuSparkPositionDeltaWrite.scala
@@ -66,7 +66,7 @@ class GpuSparkPositionDeltaWrite(cpu: DeltaWrite)
   extends GpuDeltaWrite with RequiresDistributionAndOrdering {
   private val writeRequirements = cpu.asInstanceOf[RequiresDistributionAndOrdering]
 
-  private[source] val table = GpuSparkWriteAccess.table(cpu)
+  private[source] val table = GpuSparkWriteAccess.deltaTable(cpu)
 
   override def toBatch: DeltaBatchWrite = {
     // Call the CPU version's toBatch to get PositionDeltaBatchWrite
@@ -88,11 +88,11 @@ class GpuSparkPositionDeltaWrite(cpu: DeltaWrite)
     writeRequirements.advisoryPartitionSizeInBytes()
 
   private[source] def createDeltaWriterFactory: DeltaWriterFactory = {
-    val sparkContext: JavaSparkContext = GpuSparkWriteAccess.sparkContext(cpu)
+    val sparkContext: JavaSparkContext = GpuSparkWriteAccess.deltaSparkContext(cpu)
     val tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table))
-    val command = GpuSparkWriteAccess.command(cpu)
-    val context = GpuWriteContext(GpuSparkWriteAccess.context(cpu))
-    val writeProps = GpuSparkWriteAccess.writeProperties(cpu)
+    val command = GpuSparkWriteAccess.deltaCommand(cpu)
+    val context = GpuWriteContext(GpuSparkWriteAccess.deltaContext(cpu))
+    val writeProps = GpuSparkWriteAccess.deltaWriteProperties(cpu)
       .asScala
       .toMap
 
@@ -159,7 +159,7 @@ object GpuSparkPositionDeltaWrite {
   }
 
   def tableOf(deltaWrite: DeltaWrite): Table = {
-    GpuSparkWriteAccess.table(deltaWrite)
+    GpuSparkWriteAccess.deltaTable(deltaWrite)
   }
 
   def tagForGpu(deltaWrite: DeltaWrite, meta: SparkPlanMeta[_]): Unit = {
@@ -169,7 +169,7 @@ object GpuSparkPositionDeltaWrite {
         s"but got: ${deltaWrite.getClass.getName}")
       return
     }
-    val context = GpuWriteContext(GpuSparkWriteAccess.context(deltaWrite))
+    val context = GpuWriteContext(GpuSparkWriteAccess.deltaContext(deltaWrite))
 
     val table: Table = tableOf(deltaWrite)
     val partitionSpec = table.spec()
@@ -189,7 +189,8 @@ object GpuSparkPositionDeltaWrite {
 
     // Merge-on-read writes both data files and position-delete files, so the resolved
     // delete codec matters too.
-    GpuSparkWrite.tagParquetCompressionForGpu(GpuSparkWriteAccess.writeProperties(deltaWrite),
+    GpuSparkWrite.tagParquetCompressionForGpu(
+      GpuSparkWriteAccess.deltaWriteProperties(deltaWrite),
       hasDeleteFiles = true, meta)
   }
 

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -247,8 +247,10 @@ run_iceberg_extra_classpath_tests() {
         PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
         PYSP_TEST_spark_sql_catalog_spark__catalog_type="hadoop" \
         PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="/tmp/spark-warehouse-$RANDOM" \
-        ./integration_tests/run_pyspark_from_build.sh -m iceberg --iceberg \
-        -k test_iceberg_read_appended_table
+        TESTS="iceberg/iceberg_test.py::test_iceberg_read_appended_table \
+iceberg/iceberg_append_test.py::test_insert_into_unpartitioned_table \
+noop_write_test.py" \
+        ./integration_tests/run_pyspark_from_build.sh --iceberg
 }
 
 ci_2() {


### PR DESCRIPTION
Fixes #15828.

Related to #15821.

### Description

Move `org.apache.iceberg.spark.source.GpuSparkWriteAccess` from the versioned
Iceberg sources into the root-safe `iceberg-common` module. This gives the
package-private Iceberg access bridge conventional-root ownership instead of
relying on the single-shim unshim allowlist to promote it out of
`spark-shared` during distribution assembly.

Spark 3.3 exposes `DeltaWrite` from a different package than later Spark
versions. Use its stable `Write` supertype at the root-safe bridge boundary and
give the position-delta accessors distinct names. The casts and direct
package-private Iceberg access remain unchanged inside the bridge.

Because this bridge directly references package-private Iceberg runtime
classes, the cuDF Plugin and Iceberg runtime jars must be deployed through the
same classloader. This change does not add support for mixed `extraClassPath`
and `spark.jars` deployment of those two jars. Document this constraint
centrally in the shim development guide; user-facing Iceberg deployment
guidance is maintained in the separate documentation repository.

Expand the existing Spark 4.0 premerge `extraClassPath` smoke stage to run one
Iceberg read, one GPU Iceberg append, and all four noop V2-write tests. This
keeps the supported coupled deployment covered while the remaining Iceberg
root-safe work proceeds.

AI assistance: Codex assisted with implementation and validation. The author
reviewed the complete diff and this description before the PR was opened.

TODO before marking ready for review:
- Confirm the new premerge smoke selection in CI.
- Address CI and review feedback.

Validation:
- Built `iceberg-common` and its matched Iceberg consumer for Spark 3.5.7 /
  Iceberg 1.10.1 and Scala 2.13 Spark 4.1.2 / Iceberg 1.11.0.
- Built `iceberg-common` with the Spark 3.3 stub consumer, confirming that the
  root-safe bridge compiles across the older `DeltaWrite` package boundary.
- Built complete distribution and integration-test reactors for Spark 3.5.7,
  Scala 2.13 Spark 4.0.0, and Scala 2.13 Spark 4.0.1.
- Verified the bridge is present in the `iceberg-common` artifact and at the
  distribution jar root, and absent from the versioned Iceberg artifact.
- At the exact current `origin/main` HEAD, the supported coupled
  `extraClassPath` Iceberg append smoke already passed because the existing
  single-class allowlist promoted the bridge to the distribution root. This PR
  replaces that packaging workaround with root-safe module ownership; the new
  smoke selection guards the placement against future regressions.
- Spark 3.5.7 / Iceberg 1.10.1 coupled `extraClassPath` GPU smoke: Iceberg append
  plus the four noop-write cases passed (5 tests).
- Spark 4.0.1 / Iceberg 1.10.1 coupled `extraClassPath` premerge selection:
  Iceberg read, Iceberg append, and the four noop-write cases passed (6 tests).
- `bash -n jenkins/spark-premerge-build.sh`
- `git diff --check origin/main...HEAD`

Performance: Not required because this changes class placement, bridge method
signatures, and premerge coverage only; it does not change runtime algorithms
or executed operations.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
