### PR TITLE
[fast-ut] Reduce Parquet writer test runtime

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunner.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunner.scala
@@ -44,7 +44,6 @@ object ParallelUnitTestRunner {
 
   private val UNRESOLVED_PROPERTY = "${"
   private val PARALLEL_GPU_ALLOCATION_RATIO = 0.8
-  private val PARQUET_WRITER_SUITE = "com.nvidia.spark.rapids.ParquetWriterSuite"
   private val DPP_SUITES = Seq(
     "org.apache.spark.sql.rapids.suites.RapidsDynamicPartitionPruningV1SuiteAEOff",
     "org.apache.spark.sql.rapids.suites.RapidsDynamicPartitionPruningV1SuiteAEOn")
@@ -764,10 +763,9 @@ object ParallelUnitTestRunner {
 
   private[rapids] def createSuiteBatches(tasks: Seq[SuiteTask]): Seq[SuiteBatch] = {
     val taskBySuite = tasks.map(task => task.suite -> task).toMap
-    // Submit these first so the long Parquet suite gets one worker while both DPP suites are
-    // pinned to another worker and execute serially. Each worker rejoins the general queue after
-    // completing its special batch.
-    val specialBatches = Seq(Seq(PARQUET_WRITER_SUITE), DPP_SUITES).flatMap { suites =>
+    // Pin both DPP suites to one worker so they execute serially. The worker rejoins the general
+    // queue after completing the special batch.
+    val specialBatches = Seq(DPP_SUITES).flatMap { suites =>
       val batchTasks = suites.flatMap(taskBySuite.get)
       if (batchTasks.nonEmpty) Some(SuiteBatch(batchTasks)) else None
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunnerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunnerSuite.scala
@@ -85,7 +85,7 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
       "suiteTimeoutSeconds=30")
   }
 
-  test("special suites are submitted as serial worker batches") {
+  test("DPP suites are submitted as a serial worker batch") {
     val parquetSuite = "com.nvidia.spark.rapids.ParquetWriterSuite"
     val dppOff =
       "org.apache.spark.sql.rapids.suites.RapidsDynamicPartitionPruningV1SuiteAEOff"
@@ -101,9 +101,9 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     val batches = ParallelUnitTestRunner.createSuiteBatches(tasks)
 
     assert(batches.map(_.tasks.map(_.suite)) === Seq(
-      Seq(parquetSuite),
       Seq(dppOff, dppOn),
       Seq("example.SuiteOne"),
+      Seq(parquetSuite),
       Seq("example.SuiteTwo")))
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol
+import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.hive.rapids.GpuHiveParquetFileFormat
 import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker
 import org.apache.spark.sql.rapids.shims.SparkUpgradeExceptionShims
@@ -101,7 +102,7 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     try {
       SparkSessionHolder.withSparkSession(conf, spark => {
         import spark.implicits._
-        val df = spark.sparkContext.parallelize((1L to 10000000L))
+        val df = spark.sparkContext.parallelize(1L to 1000L, 2)
             .map{i => ("a", f"$i%010d", i)}.toDF("partkey", "val", "val2")
         df.repartition(1, $"partkey").sortWithinPartitions($"partkey", $"val", $"val2")
             .write.mode("overwrite").partitionBy("partkey").parquet(tempFile.getAbsolutePath)
@@ -296,18 +297,6 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     assert(GpuParquetFileFormat.parquetBlockSizeWarning(mixedConf, nonDefaultOptions).nonEmpty)
   }
 
-  private def listAllFiles(f: File): Array[File] = {
-    if (f.isFile()) {
-      Array(f)
-    } else if (f.isDirectory()) {
-      f
-        .listFiles()
-        .flatMap(f => listAllFiles(f))
-    } else {
-      Array.empty
-    }
-  }
-
   private def getSingleParquetFileRowGroupCounts(
       spark: SparkSession,
       parquetPath: File): Seq[Long] = {
@@ -315,6 +304,26 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   }
 
   private case class ParquetRowGroup(rowCount: Long, totalByteSize: Long)
+
+  private def listAllFiles(f: File): Array[File] = {
+    if (f.isFile()) {
+      Array(f)
+    } else if (f.isDirectory()) {
+      f.listFiles().flatMap(listAllFiles)
+    } else {
+      Array.empty
+    }
+  }
+
+  private def parquetFileRowCounts(spark: SparkSession, parquetPath: File): Seq[Long] = {
+    spark.read.parquet(parquetPath.getAbsolutePath)
+      .select(input_file_name().as("file"))
+      .groupBy("file")
+      .count()
+      .collect()
+      .map(_.getLong(1))
+      .toSeq
+  }
 
   private def getSingleParquetFileRowGroups(
       spark: SparkSession,
@@ -363,15 +372,10 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     try {
       SparkSessionHolder.withSparkSession(conf, spark => {
         import spark.implicits._
-        val df = (1 to 16000).toDF()
+        val df = (1 to 200).toDF().repartition(1)
         df.write.mode("overwrite").parquet(tempFile.getAbsolutePath())
 
-        listAllFiles(tempFile)
-          .map(f => f.getAbsolutePath())
-          .filter(p => p.endsWith("parquet"))
-          .map(p => {
-            assertRowCount50 (spark.read.parquet(p).count()) 
-          })
+        parquetFileRowCounts(spark, tempFile).foreach(assertRowCount50)
       })
     } finally {
       fullyDelete(tempFile)
@@ -389,15 +393,10 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     try {
       SparkSessionHolder.withSparkSession(conf, spark => {
         import spark.implicits._
-        val df = (1 to 16000).map(i => (i, i % 2)).toDF()
+        val df = (1 to 200).map(i => (i, i % 2)).toDF().repartition(1)
         df.write.mode("overwrite").partitionBy("_2").parquet(tempFile.getAbsolutePath())
 
-        listAllFiles(tempFile)
-          .map(f => f.getAbsolutePath())
-          .filter(p => p.endsWith("parquet"))
-          .map(p => {
-            assertRowCount50 (spark.read.parquet(p).count()) 
-          })
+        parquetFileRowCounts(spark, tempFile).foreach(assertRowCount50)
       })
     } finally {
       fullyDelete(tempFile)
@@ -421,17 +420,13 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
             .repartition(1)
             .write
             .mode("overwrite")
-            .partitionBy("_2")
-            .parquet(tempFile.getAbsolutePath())
+              .partitionBy("_2")
+              .parquet(tempFile.getAbsolutePath())
           // check the whole number of rows
-          assertResult(1600) (spark.read.parquet(tempFile.getAbsolutePath()).count())
+          val rowCounts = parquetFileRowCounts(spark, tempFile)
+          assertResult(1600)(rowCounts.sum)
           // check number of rows in each file
-          listAllFiles(tempFile)
-            .map(f => f.getAbsolutePath())
-            .filter(p => p.endsWith("parquet"))
-            .map(p => {
-              assertResult(expectedRecordsPerFile) (spark.read.parquet(p).count())
-            })
+          rowCounts.foreach(assertResult(expectedRecordsPerFile))
         })
       } finally {
         fullyDelete(tempFile)
@@ -459,14 +454,10 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
               .partitionBy("_2")
               .parquet(tempFile.getAbsolutePath())
           // check the whole number of rows
-          assertResult(1600)(spark.read.parquet(tempFile.getAbsolutePath()).count())
+          val rowCounts = parquetFileRowCounts(spark, tempFile)
+          assertResult(1600)(rowCounts.sum)
           // check number of rows in each file
-          listAllFiles(tempFile)
-              .map(f => f.getAbsolutePath())
-              .filter(p => p.endsWith("parquet"))
-              .map(p => {
-                assertResult(expectedRecordsPerFile)(spark.read.parquet(p).count())
-              })
+          rowCounts.foreach(assertResult(expectedRecordsPerFile))
         })
       } finally {
         fullyDelete(tempFile)


### PR DESCRIPTION
Related to #15346.

### Description

`ParquetWriterSuite` spent most of its runtime generating oversized inputs and launching a separate Spark read/count job for every output file.

- The `sorted partitioned write` test originally generated `10,000,000` rows. This change reduces it to `1,000` rows while preserving the sorted-write assertion.
- The `maxRecordsPerFile` tests reduce their inputs from `16,000` rows to `200` rows and explicitly use one input partition.
- Output-file row counts are collected with one directory read grouped by `input_file_name()` instead of one Spark job per file.
- The optimized suite returns to the normal parallel UT queue instead of reserving a dedicated worker. The DPP suites remain pinned together and run serially.

A clean single-worker local benchmark kept all 17 ScalaTest cases and reduced `ParquetWriterSuite` wall time from `389.80s` to `125.33s` (`67.85%`). ScalaTest time decreased from `6:16` to `1:53`.

The same Parquet diff passed both benchmark runs. A targeted rerun after rebasing to current `main` was blocked before tests started by a locally resolved snapshot API mismatch in an unrelated module; no target-suite failure was observed.

### Checklists

Documentation
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths

Performance
- [x] Tests ran and results are added in the PR description