### PR TITLE
Fix ClassInitializationSuite JaCoCo deadlock [fast-ut] [reduced-it]

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ClassInitializationSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ClassInitializationSuite.scala
@@ -26,6 +26,9 @@ import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.funsuite.AnyFunSuite
 
 class ClassInitializationSuite extends AnyFunSuite with FQSuiteName {
+  private val JvmOptionEnvironmentVariables =
+    Seq("_JAVA_OPTIONS", "JAVA_TOOL_OPTIONS", "JDK_JAVA_OPTIONS")
+
   test("SparkShimImpl and GpuOverrides can be initialized concurrently") {
     assume(VersionUtils.isDataBricks ||
         (VersionUtils.isSpark && VersionUtils.cmpSparkVersion(3, 4, 0) >= 0),
@@ -47,6 +50,17 @@ class ClassInitializationSuite extends AnyFunSuite with FQSuiteName {
         result.output)
   }
 
+  test("class-initialization child does not inherit JVM option environment variables") {
+    val processBuilder = new ProcessBuilder("java")
+    JvmOptionEnvironmentVariables.foreach { variable =>
+      processBuilder.environment().put(variable, "test-options")
+    }
+
+    removeInheritedJvmOptions(processBuilder)
+
+    assert(!JvmOptionEnvironmentVariables.exists(processBuilder.environment().containsKey))
+  }
+
   private def runChild(): ChildResult = {
     val java = new File(System.getProperty("java.home"), "bin/java").getAbsolutePath
     val classPath = System.getProperty("java.class.path")
@@ -55,15 +69,22 @@ class ClassInitializationSuite extends AnyFunSuite with FQSuiteName {
     // which closes the Process streams on some JDKs.
     val outputFile = Files.createTempFile("class-initialization-child-", ".log")
     try {
-      val process = new ProcessBuilder(
+      val processBuilder = new ProcessBuilder(
         java,
         "-Dcom.nvidia.spark.rapids.runningTests=true",
         "-cp",
         classPath,
         mainClass)
-          .redirectErrorStream(true)
-          .redirectOutput(outputFile.toFile)
-          .start()
+
+      // This child deliberately suspends a thread during class initialization. Java agents can
+      // hold process-wide locks at the suspension point and deadlock the reproducer itself, so do
+      // not propagate inherited JVM options that can inject agents into the child.
+      removeInheritedJvmOptions(processBuilder)
+
+      val process = processBuilder
+        .redirectErrorStream(true)
+        .redirectOutput(outputFile.toFile)
+        .start()
 
       val finished = process.waitFor(30, TimeUnit.SECONDS)
       if (!finished) {
@@ -82,6 +103,10 @@ class ClassInitializationSuite extends AnyFunSuite with FQSuiteName {
     } finally {
       Files.deleteIfExists(outputFile)
     }
+  }
+
+  private def removeInheritedJvmOptions(processBuilder: ProcessBuilder): Unit = {
+    JvmOptionEnvironmentVariables.foreach(processBuilder.environment().remove)
   }
 
   private case class ChildResult(finished: Boolean, exitCode: Int, output: String)


### PR DESCRIPTION
Fixes #15804.

### Description

`ClassInitializationSuite` deliberately suspends a child thread while reproducing class-initialization lock ordering. When a Java agent is inherited by that child through a JVM option environment variable, the suspended thread can own an agent-runtime lock and deadlock the test harness itself.

This change prevents the disposable reproducer child from inheriting `_JAVA_OPTIONS`, `JAVA_TOOL_OPTIONS`, or `JDK_JAVA_OPTIONS`. The parent test JVM remains instrumented. A deterministic regression test verifies that all three environment variables are removed before child launch. There is no user-facing behavior change.

Validation:

- Spark 3.5.6, CUDA 13, Java 17, and JaCoCo 0.8.8 inherited by the parent: 20/20 fresh-JVM runs passed
- Spark 3.5.6/CUDA 13 without inherited agents: 10/10 fresh-JVM runs passed
- Spark 3.4.4/CUDA 12 smoke test passed
- Spark 3.5.1/CUDA 12 smoke test passed
- Maven `validate` passed
- `git diff --check` passed

AI assistance: Codex assisted with diagnosis, implementation, testing, independent review, and PR drafting.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required