### PR TITLE
Speed up Parquet write UT for the sorted partitioned write case [fast-ut] [reduced-it]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,16 @@ import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
   val rapidsConf = new RapidsConf(Map.empty[String, String])
+
+  test("coalesce preserves child output ordering") {
+    withGpuSparkSession { spark =>
+      val child = spark.range(1000).sort("id").queryExecution.executedPlan
+      assert(child.outputOrdering.nonEmpty)
+
+      val coalesce = GpuCoalesceBatches(child, TargetSize(1024))
+      assertResult(child.outputOrdering)(coalesce.outputOrdering)
+    }
+  }
 
   def getCapturedPlan(): SparkPlan = {
     val capturedPlans = ExecutionPlanCaptureCallback.getResultsWithTimeout()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -101,7 +101,7 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     try {
       SparkSessionHolder.withSparkSession(conf, spark => {
         import spark.implicits._
-        val df = spark.sparkContext.parallelize((1L to 10000000L))
+        val df = spark.sparkContext.parallelize(1L to 1000L, 2)
             .map{i => ("a", f"$i%010d", i)}.toDF("partkey", "val", "val2")
         df.repartition(1, $"partkey").sortWithinPartitions($"partkey", $"val", $"val2")
             .write.mode("overwrite").partitionBy("partkey").parquet(tempFile.getAbsolutePath)


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

### Description

Reduce the `ParquetWriterSuite` `sorted partitioned write` input from 10,000,000 rows to 1,000 rows and add a deterministic ordering-metadata regression test.

This keeps the partitioned-write test inexpensive while preserving coverage for the failure mode fixed by NVIDIA/cudf-spark#3009 independently of data volume.

This PR contains only the sorted partitioned-write input reduction and its ordering regression test. The max-records test optimization and parallel-runner scheduling change are proposed separately.

The write test still uses two input partitions, repartitions by `partkey`, sorts within the output partition, writes partitioned Parquet, and verifies that the first value is `0000000001`.

The new `GpuCoalesceBatchesSuite` test creates a sorted 1,000-row child plan and verifies that `GpuCoalesceBatches` preserves the child's non-empty `outputOrdering`. This directly checks the metadata that prevents a redundant write-side sort.

Validation:

- A/B was run on `c22f128be`, using Java 17 and Spark 3.4 `buildver=340`. Both sides used the same Maven command and differed by only the `GpuCoalesceBatches.outputOrdering` implementation.
- Buggy side (`super.outputOrdering`): `GpuCoalesceBatchesSuite` reported 18 passed and 1 failed. Only the new test failed, with `Expected List(id ASC NULLS FIRST), but got List()`.
- Fixed side (`child.outputOrdering`): the same build and test command completed successfully with exit status 0.
- The A/B demonstrates that the new 1,000-row test detects the ordering metadata regression without depending on a large input to expose incorrect output ordering.
- Scala 2.13 build validation passed in every configured `package-tests-scala213` matrix job. The Spark 3.5.0 job ran `mvn package -f scala2.13/ -pl integration_tests,tests,tools -am -P individual,pre-merge -Dbuildver=350 -Dmaven.scalastyle.skip=true -Drat.skip=true -Ddist.jar.compress=false -DskipTests -Dmaven.scaladoc.skip` successfully.
- `git diff --check` passed.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
