### PR TITLE
Speed up Parquet write UT for cases write with max records per file [fast-ut]  [reduced-it]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol
+import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.hive.rapids.GpuHiveParquetFileFormat
 import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker
 import org.apache.spark.sql.rapids.shims.SparkUpgradeExceptionShims
@@ -316,6 +317,16 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
 
   private case class ParquetRowGroup(rowCount: Long, totalByteSize: Long)
 
+  private def parquetFileRowCounts(spark: SparkSession, parquetPath: File): Seq[Long] = {
+    spark.read.parquet(parquetPath.getAbsolutePath)
+      .select(input_file_name().as("file"))
+      .groupBy("file")
+      .count()
+      .collect()
+      .map(_.getLong(1))
+      .toSeq
+  }
+
   private def getSingleParquetFileRowGroups(
       spark: SparkSession,
       parquetPath: File): Seq[ParquetRowGroup] = {
@@ -363,15 +374,13 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     try {
       SparkSessionHolder.withSparkSession(conf, spark => {
         import spark.implicits._
-        val df = (1 to 16000).toDF()
+        val df = (1 to 200).toDF().repartition(1)
         df.write.mode("overwrite").parquet(tempFile.getAbsolutePath())
 
-        listAllFiles(tempFile)
-          .map(f => f.getAbsolutePath())
-          .filter(p => p.endsWith("parquet"))
-          .map(p => {
-            assertRowCount50 (spark.read.parquet(p).count()) 
-          })
+        val rowCounts = parquetFileRowCounts(spark, tempFile)
+        assertResult(4)(rowCounts.size)
+        assertResult(200)(rowCounts.sum)
+        rowCounts.foreach(assertRowCount50)
       })
     } finally {
       fullyDelete(tempFile)
@@ -389,15 +398,13 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     try {
       SparkSessionHolder.withSparkSession(conf, spark => {
         import spark.implicits._
-        val df = (1 to 16000).map(i => (i, i % 2)).toDF()
+        val df = (1 to 200).map(i => (i, i % 2)).toDF().repartition(1)
         df.write.mode("overwrite").partitionBy("_2").parquet(tempFile.getAbsolutePath())
 
-        listAllFiles(tempFile)
-          .map(f => f.getAbsolutePath())
-          .filter(p => p.endsWith("parquet"))
-          .map(p => {
-            assertRowCount50 (spark.read.parquet(p).count()) 
-          })
+        val rowCounts = parquetFileRowCounts(spark, tempFile)
+        assertResult(4)(rowCounts.size)
+        assertResult(200)(rowCounts.sum)
+        rowCounts.foreach(assertRowCount50)
       })
     } finally {
       fullyDelete(tempFile)
@@ -424,14 +431,10 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
             .partitionBy("_2")
             .parquet(tempFile.getAbsolutePath())
           // check the whole number of rows
-          assertResult(1600) (spark.read.parquet(tempFile.getAbsolutePath()).count())
+          val rowCounts = parquetFileRowCounts(spark, tempFile)
+          assertResult(1600)(rowCounts.sum)
           // check number of rows in each file
-          listAllFiles(tempFile)
-            .map(f => f.getAbsolutePath())
-            .filter(p => p.endsWith("parquet"))
-            .map(p => {
-              assertResult(expectedRecordsPerFile) (spark.read.parquet(p).count())
-            })
+          rowCounts.foreach(assertResult(expectedRecordsPerFile))
         })
       } finally {
         fullyDelete(tempFile)
@@ -459,14 +462,10 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
               .partitionBy("_2")
               .parquet(tempFile.getAbsolutePath())
           // check the whole number of rows
-          assertResult(1600)(spark.read.parquet(tempFile.getAbsolutePath()).count())
+          val rowCounts = parquetFileRowCounts(spark, tempFile)
+          assertResult(1600)(rowCounts.sum)
           // check number of rows in each file
-          listAllFiles(tempFile)
-              .map(f => f.getAbsolutePath())
-              .filter(p => p.endsWith("parquet"))
-              .map(p => {
-                assertResult(expectedRecordsPerFile)(spark.read.parquet(p).count())
-              })
+          rowCounts.foreach(assertResult(expectedRecordsPerFile))
         })
       } finally {
         fullyDelete(tempFile)


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/15346.

### Description

Reduce `ParquetWriterSuite` max-records test runtime by using minimal inputs and validating all output files with one grouped Spark read.

This preserves the original single-directory, dynamic-partition, concurrent-writer, and concurrent-writer-fallback coverage while making the suite substantially faster.

This PR contains only the max-records test optimization. The sorted partitioned-write reduction and parallel-runner scheduling change are proposed separately.

On an NVIDIA L4 with Spark 3.3.0, Scala 2.12, JDK 17, `local[1]`, and one ScalaTest suite worker, `ParquetWriterSuite` time decreased by `67.37%`.

| Workload | Metric | Baseline | Head | Improvement |
| --- | --- | ---: | ---: | ---: |
| `ParquetWriterSuite` (17 tests) | ScalaTest time | `6m20s` | `2m04s` | `67.37%` |

- The two basic `maxRecordsPerFile` tests reduce their inputs from `16,000` rows to `200` rows and explicitly use one input partition. They assert exactly four output files and 200 total rows, so file rollover remains exercised more than once without weakening data-completeness coverage.
- The partitioned single-writer test retains `spark.rapids.sql.batchSizeBytes=1`, so file rollover is still exercised across multiple input batches for both partition values.
- The concurrent-writer tests retain their original `1,600` rows, 20 output partitions, concurrent-writer limits, `maxRecordsPerFile` values, and total/per-file row-count assertions. Both the normal concurrent path and the fallback path remain covered.
- All four tests obtain per-file row counts from one directory read grouped by `input_file_name()` instead of launching one Spark read/count action per output file.

Validation:

- `mvn clean package -pl tests -am -Dbuildver=330 -DwildcardSuites=com.nvidia.spark.rapids.ParquetWriterSuite -Drat.skip=true` passed all 17 tests for both baseline and head.
- Scala 2.13 build validation passed in every configured `package-tests-scala213` matrix job. The Spark 3.5.0 job ran `mvn package -f scala2.13/ -pl integration_tests,tests,tools -am -P individual,pre-merge -Dbuildver=350 -Dmaven.scalastyle.skip=true -Drat.skip=true -Ddist.jar.compress=false -DskipTests -Dmaven.scaladoc.skip` successfully.
- `git diff --check` passed.

Existing coverage comes from `set max records per file no partition`, `set max records per file with partition`, `set maxRecordsPerFile with partition concurrently`, and `set maxRecordsPerFile with partition concurrently fallback`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
