### PR TITLE
Fix bridge lambda reference test across Spark versions[databricks][fast-ut][reduced-it]

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/BridgeHostColumnProjectionSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/BridgeHostColumnProjectionSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.rapids
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import ai.rapids.cudf.{DType, HostColumnVector}
-import com.nvidia.spark.rapids.{GpuColumnVector, RapidsHostColumnBuilder}
+import com.nvidia.spark.rapids.{ClouderaShimVersion, DatabricksShimVersion, GpuColumnVector,
+  RapidsHostColumnBuilder, ShimLoader, SparkShimVersion}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.{GpuScalarSubqueryShims, ShimExpression}
 import org.scalatest.funsuite.AnyFunSuite
@@ -110,6 +111,16 @@ private case class LambdaVariableReferenceTrackingExpression(
  */
 class BridgeHostColumnProjectionSuite extends AnyFunSuite {
 
+  // SPARK-58204 marked NamedLambdaVariable stateful in Spark 4.3.
+  private def supportsStatefulNamedLambdaVariable: Boolean = {
+    val (major, minor) = ShimLoader.getShimVersion match {
+      case SparkShimVersion(major, minor, _) => (major, minor)
+      case DatabricksShimVersion(major, minor, _, _) => (major, minor)
+      case ClouderaShimVersion(major, minor, _, _) => (major, minor)
+    }
+    major > 4 || (major == 4 && minor >= 3)
+  }
+
   test("projection owns a cloned expression tree") {
     val seenIds = new ConcurrentLinkedQueue[Int]()
     val expr = IdentityTrackingExpression(seenIds)
@@ -149,8 +160,14 @@ class BridgeHostColumnProjectionSuite extends AnyFunSuite {
     val seen = seenIds.iterator()
     val firstValueId = seen.next()
     val secondValueId = seen.next()
-    assert(firstValueId == secondValueId)
+    // Before SPARK-58204, references with the same exprId retain the same value reference.
+    if (!supportsStatefulNamedLambdaVariable) {
+      assert(firstValueId == secondValueId)
+    }
+    // Spark 4.3+ may fresh-copy each stateful NamedLambdaVariable independently during codegen.
+    // All versions must keep projection state isolated from the caller's expression tree.
     assert(firstValueId != originalValueId)
+    assert(secondValueId != originalValueId)
   }
 
   test("projection preserves prepared subquery state") {

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/BridgeHostColumnProjectionSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/BridgeHostColumnProjectionSuite.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.rapids
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import ai.rapids.cudf.{DType, HostColumnVector}
-import com.nvidia.spark.rapids.{ClouderaShimVersion, DatabricksShimVersion, GpuColumnVector,
-  RapidsHostColumnBuilder, ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids.{GpuColumnVector, RapidsHostColumnBuilder}
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.shims.{GpuScalarSubqueryShims, ShimExpression}
+import com.nvidia.spark.rapids.shims.{GpuScalarSubqueryShims, ShimExpression, SparkShimImpl}
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -111,16 +110,6 @@ private case class LambdaVariableReferenceTrackingExpression(
  */
 class BridgeHostColumnProjectionSuite extends AnyFunSuite {
 
-  // SPARK-58204 marked NamedLambdaVariable stateful in Spark 4.3.
-  private def supportsStatefulNamedLambdaVariable: Boolean = {
-    val (major, minor) = ShimLoader.getShimVersion match {
-      case SparkShimVersion(major, minor, _) => (major, minor)
-      case DatabricksShimVersion(major, minor, _, _) => (major, minor)
-      case ClouderaShimVersion(major, minor, _, _) => (major, minor)
-    }
-    major > 4 || (major == 4 && minor >= 3)
-  }
-
   test("projection owns a cloned expression tree") {
     val seenIds = new ConcurrentLinkedQueue[Int]()
     val expr = IdentityTrackingExpression(seenIds)
@@ -161,7 +150,7 @@ class BridgeHostColumnProjectionSuite extends AnyFunSuite {
     val firstValueId = seen.next()
     val secondValueId = seen.next()
     // Before SPARK-58204, references with the same exprId retain the same value reference.
-    if (!supportsStatefulNamedLambdaVariable) {
+    if (!SparkShimImpl.isExpressionStateful(variable)) {
       assert(firstValueId == secondValueId)
     }
     // Spark 4.3+ may fresh-copy each stateful NamedLambdaVariable independently during codegen.


### PR DESCRIPTION
Fixes #15812.

### Description

SPARK-58204 marks `NamedLambdaVariable` as stateful starting in Spark 4.3. As a result,
Spark may fresh-copy references with the same expression ID independently, invalidating the test's
previous assumption that they always share the same value reference.

This change keeps the shared-reference assertion for Spark versions before 4.3 and verifies on all
versions that the projection's copied references are isolated from the caller's expression tree.
There is no change to production code or user-facing behavior.

Tested with:
- `mvn -s <settings.xml> -f scala2.13/pom.xml -pl tests -am -Dbuildver=420 -Dcuda.version=cuda13 -DwildcardSuites=org.apache.spark.sql.rapids.BridgeHostColumnProjectionSuite package` — 38 tests passed
- `mvn -s <settings.xml> -f scala2.13/pom.xml -pl tests -am -Dbuildver=500 -Dcuda.version=cuda13 -DwildcardSuites=org.apache.spark.sql.rapids.BridgeHostColumnProjectionSuite package` — 38 tests passed

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required