### PR TITLE
Fix ConsoleOutput visibility in standalone integration test builds [fast-ut] [reduced-it] [databricks]

### DIFF
--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -1,6 +1,8 @@
 META-INF/DEPENDENCIES
 META-INF/LICENSE
 META-INF/NOTICE
+com/nvidia/spark/rapids/ConsoleOutput.class
+com/nvidia/spark/rapids/ConsoleOutput$.class
 com/nvidia/spark/rapids/ExplainPlan.class
 com/nvidia/spark/rapids/ExplainPlan$.class
 com/nvidia/spark/rapids/ExplainPlanBase.class


### PR DESCRIPTION
**JaCoCo production line coverage: +0 lines** (measured scope: no applicable JVM production modules; dist packaging-manifest-only change, shim 352)

Contributes to #15843.

### Description

The Scala 2.13 nightly completes the shim reactor and then compiles `integration_tests` again against the packaged distribution. In build 816, that second compile produced 18 `ConsoleOutput`-not-found errors across `DebugRange`, `MortgageSpark`, `ScaleTest`, and `TestReport`. Before this change, the shim-352 dist JAR stored the two helper classes only under `spark-shared/`, so a conventional classloader could not resolve `com.nvidia.spark.rapids.ConsoleOutput`.

Promote the existing, shim-independent `ConsoleOutput` module and static-forwarder classes to the distribution root. Shim-specific classes remain isolated in the parallel-world layout. This changes no query behavior, expected values, assertions, or test semantics.

Validation:

- `mvn -f scala2.13/pom.xml package -pl dist,integration_tests -am -Dbuildver=352 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm -DskipTests -Drat.skip=true -Dmaven.scaladoc.skip=true -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0`: `BUILD SUCCESS`; all 16 reactor modules succeeded.
- `mvn package -pl dist,integration_tests -am -Dbuildver=352 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm -DskipTests -Drat.skip=true -Dmaven.scaladoc.skip=true -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0`: `BUILD SUCCESS`; all 16 Scala 2.12 reactor modules succeeded.
- Final Scala 2.12 and 2.13 dist JAR inspection: exactly two root `ConsoleOutput` class entries and zero duplicate JAR entries in each artifact.
- Standalone Scala 2.13 compiler probe using only the final dist JAR and Scala library: passed.
- `git diff --check`: passed.

No runtime test is applicable because the change only controls placement of already-built bytecode in the distribution JAR.

AI assistance: The change and pull request description were prepared with Codex assistance.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
