### PR TITLE
[BUG] Timestamp inputs from the csv file bring inconsistency when using the CPU and GPU engines

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -184,6 +184,12 @@ portion followed by one of the following formats:
 * `HH:mm:ss.SSS`
 * `HH:mm:ss[.SSS]`
 
+When `timestampFormat` is not specified, Spark also accepts time-only values in `HH:mm:ss` form
+with an optional 1-6 digit fractional-second part. The GPU CSV reader matches this behavior by
+filling in the current date for the configured CSV timezone before parsing the timestamp (GPU CSV
+timestamp scans currently require UTC). This compatibility handling is not applied when
+`timestampFormat` is explicitly specified.
+
 Just like with dates all timestamp formats are actually supported at the same time.  The plugin will
 disable itself if it sees a format it cannot support.
 

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from asserts import *
 from conftest import get_non_gpu_allowed, is_not_utc, is_gbk_supported
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
@@ -441,6 +441,87 @@ def test_ts_formats_round_trip(spark_tmp_path, date_format, ts_part, v1_enabled_
                     .option('timestampFormat', full_format)\
                     .csv(data_path),
             conf=updated_conf)
+
+
+@pytest.mark.skipif(is_before_spark_400(), reason='Issue #13704 reproducer requires Spark 4.0+')
+@pytest.mark.parametrize('v1_enabled_list,gpu_scan,cpu_scan', [
+    ('csv', 'GpuFileSourceScanExec', 'FileSourceScanExec'),
+    ('', 'GpuBatchScanExec', 'BatchScanExec'),
+])
+def test_csv_infer_schema_time_only_timestamp(
+        spark_tmp_path, v1_enabled_list, gpu_scan, cpu_scan):
+    # Spark fills in today's date when timestampFormat is not specified and a timestamp contains
+    # only a time. Avoid a CPU/GPU mismatch if this test happens to span midnight UTC.
+    current_time = datetime.now(timezone.utc)
+    if current_time.date() != (current_time + timedelta(minutes=5)).date():
+        pytest.skip('Too close to UTC midnight for a current-date timestamp test')
+
+    data_path = spark_tmp_path + '/CSV_TIME_ONLY_TIMESTAMP'
+    with_cpu_session(
+        lambda spark: spark.createDataFrame([('23:53:40.392',)], 'c0 string')
+            .coalesce(1)
+            .write
+            .option('header', 'true')
+            .csv(data_path))
+
+    def do_read(spark):
+        df = spark.read \
+            .option('header', 'true') \
+            .option('inferSchema', 'true') \
+            .csv(data_path)
+        assert isinstance(df.schema['c0'].dataType, TimestampType)
+        return df
+
+    conf = copy_and_update(_enable_all_types_conf, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.session.timeZone': 'UTC',
+    })
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_read,
+        exist_classes=gpu_scan,
+        non_exist_classes=cpu_scan,
+        conf=conf,
+        require_non_empty=True)
+
+    invalid_data_path = spark_tmp_path + '/CSV_INVALID_TIME_ONLY_TIMESTAMP'
+    with_cpu_session(
+        lambda spark: spark.createDataFrame([('29:99:99.999',)], 'c0 string')
+            .coalesce(1)
+            .write
+            .option('header', 'true')
+            .csv(invalid_data_path))
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.read
+            .schema(StructType([StructField('c0', TimestampType())]))
+            .option('header', 'true')
+            .csv(invalid_data_path),
+        exist_classes=gpu_scan,
+        non_exist_classes=cpu_scan,
+        conf=conf,
+        require_non_empty=True)
+
+
+@pytest.mark.parametrize('v1_enabled_list', ['', 'csv'])
+def test_csv_time_only_timestamp_with_explicit_format(spark_tmp_path, v1_enabled_list):
+    data_path = spark_tmp_path + '/CSV_TIME_ONLY_TIMESTAMP_EXPLICIT_FORMAT'
+    with_cpu_session(
+        lambda spark: spark.createDataFrame([('23:53:40.392',)], 'c0 string')
+            .coalesce(1)
+            .write
+            .option('header', 'true')
+            .csv(data_path))
+
+    conf = copy_and_update(_enable_all_types_conf, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.session.timeZone': 'UTC',
+    })
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read \
+            .schema(StructType([StructField('c0', TimestampType())])) \
+            .option('header', 'true') \
+            .option('timestampFormat', "yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]") \
+            .csv(data_path),
+        conf=conf)
 
 @pytest.mark.parametrize('v1_enabled_list', ["", "csv"])
 def test_input_meta(spark_tmp_path, v1_enabled_list):

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -18,12 +18,13 @@ package com.nvidia.spark.rapids
 
 import java.io.IOException
 import java.nio.charset.{Charset, StandardCharsets}
+import java.time.LocalDate
 import java.util.Locale
 
 import scala.collection.JavaConverters._
 
 import ai.rapids.cudf
-import ai.rapids.cudf.{ColumnVector, DType, Scalar, Schema, Table}
+import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, RegexProgram, Scalar, Schema, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, ShimFilePartitionReaderFactory}
@@ -436,6 +437,38 @@ abstract class CSVPartitionReaderBase[BUFF <: LineBufferer, FACT <: LineBufferer
 
   override def dateFormat: Option[String] = Some(GpuCsvUtils.dateFormatInRead(parsedOptions))
   override def timestampFormat: String = GpuCsvUtils.timestampFormatInRead(parsedOptions)
+
+  override def castStringToTimestamp(
+      input: ColumnVector,
+      sparkFormat: String,
+      dtype: DType): ColumnVector = {
+    if (parsedOptions.timestampFormatInRead.isEmpty) {
+      // When no timestampFormat is specified Spark falls back to its string-to-timestamp parser.
+      // That parser accepts time-only values by filling in the current date in the configured
+      // timezone. Normalize the time-only forms supported here so the existing GPU timestamp
+      // parser sees the same complete timestamp.
+      val currentDatePrefix = LocalDate.now(parsedOptions.zoneId).toString + "T"
+      val timeOnly = new RegexProgram(
+        raw"\A\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?\Z", CaptureGroups.NON_CAPTURE)
+      withResource(input.strip()) { stripped =>
+        withResource(stripped.matchesRe(timeOnly)) { isTimeOnly =>
+          withResource(Scalar.fromString(currentDatePrefix)) { prefixScalar =>
+            withResource(ColumnVector.fromScalar(prefixScalar, input.getRowCount.toInt)) {
+              prefixColumn =>
+                withResource(ColumnVector.stringConcatenate(Array(prefixColumn, stripped))) {
+                  normalizedTimeOnly =>
+                    withResource(isTimeOnly.ifElse(normalizedTimeOnly, input)) { normalized =>
+                      super.castStringToTimestamp(normalized, sparkFormat, dtype)
+                    }
+                }
+            }
+          }
+        }
+      }
+    } else {
+      super.castStringToTimestamp(input, sparkFormat, dtype)
+    }
+  }
 }
 
 


### PR DESCRIPTION
Fixes #13704.

### Description

Spark's default CSV timestamp parser accepts time-only values such as `23:53:40.392` when `timestampFormat` is omitted by filling in the current date for the configured timestamp timezone. The GPU CSV reader previously required a date-prefixed timestamp, causing the same inferred value to become `NULL`.

This change keeps the compatibility handling scoped to CSV reads without an explicit `timestampFormat`. Supported time-only values (`HH:mm:ss` with an optional 1-6 digit fractional-second part) are identified on the GPU, prefixed with `LocalDate.now(parsedOptions.zoneId)`, and then passed through the existing GPU timestamp validation and parsing path. Invalid clock values therefore remain invalid. Explicit `timestampFormat` parsing, JSON parsing, TimestampNTZ behavior, and the existing non-UTC `TimestampType` CPU fallback are unchanged.

Regression coverage exercises inferred time-only timestamps through both V1 (`GpuFileSourceScanExec`) and V2 (`GpuBatchScanExec`) CSV scans and explicitly verifies that the corresponding CPU scan is not used. It also covers an invalid time-only value and verifies that an explicitly configured timestamp format does not opt into the new fallback. The CSV timestamp compatibility documentation has been updated accordingly.

### Testing

- `python3 -m py_compile integration_tests/src/main/python/csv_test.py` — passed.
- `git diff --check` — passed.
- `mvn -f scala2.13 -Dbuildver=401 -DaddScalacArgs='-Wconf:cat=deprecation:s' -pl integration_tests -am package -DskipTests` — passed; all 16 reactor modules built for Spark 4.0.1 / Scala 2.13. The warning override suppresses only unrelated existing `applyBooleanMask` deprecations that the current snapshot otherwise promotes to errors.
- `mvn -f scala2.13 -Dbuildver=401 -DaddScalacArgs='-Wconf:cat=deprecation:s' -pl sql-plugin -am package -DskipTests` — passed after the final source change.
- `mvn -Dbuildver=330 -DaddScalacArgs='-Wconf:cat=deprecation:s' -pl sql-plugin -am package -DskipTests` — passed after the final source change, validating the common source with Scala 2.12 / Spark 3.3.
- `TEST_PARALLEL=1 TESTS="csv_test.py::test_csv_infer_schema_time_only_timestamp" ./integration_tests/run_pyspark_from_build.sh` — could not execute the test because the host has no usable CUDA driver; RAPIDS initialization failed with `libcuda.so.1` / `cudaErrorInsufficientDriver` before pytest execution.
- `TEST_PARALLEL=1 ./integration_tests/run_pyspark_from_build.sh -k 'csv_test.py and (test_ts_formats_round_trip or test_csv_infer_schema_timestamp_ntz or test_csv_datetime_parsing_fallback)'` — blocked by the same CUDA-driver limitation during RAPIDS initialization.
- `mvn package -pl tests -am -Dbuildver=330 -DwildcardSuites="com.nvidia.spark.rapids.CsvScanSuite" -DaddScalacArgs='-Wconf:cat=deprecation:s'` — compiled successfully through the tests module and discovered the 10 `CsvScanSuite` tests, but test execution failed at RAPIDS executor initialization with `cudaErrorInsufficientDriver`.
- A Spark 4.0.1 CPU reference check confirmed that `23:53:40.392` is inferred as `TimestampType` and receives the current date in the configured UTC timezone, while `29:99:99.999` parses as `NULL` with a timestamp schema.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required