### PR TITLE
Fix nested date scalar normalization

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -919,6 +919,31 @@ def _date_to_iso_string(data):
     return data.strftime("%Y-%m-%d").zfill(10)
 
 
+def _normalize_pyspark_scalar(data, data_type):
+    if data is None:
+        return None
+
+    if isinstance(data_type, ArrayType):
+        assert isinstance(data, (list, tuple))
+        return type(data)(_normalize_pyspark_scalar(x, data_type.elementType) for x in data)
+    elif isinstance(data_type, StructType):
+        assert isinstance(data, tuple) and len(data) == len(data_type.fields)
+        return tuple(
+            _normalize_pyspark_scalar(x, field.dataType)
+            for x, field in zip(data, data_type.fields))
+    elif isinstance(data_type, DateType):
+        return _date_to_iso_string(data)
+    elif isinstance(data_type, MapType):
+        assert isinstance(data, dict)
+        return {
+            _normalize_pyspark_scalar(key, data_type.keyType):
+                _normalize_pyspark_scalar(value, data_type.valueType)
+            for key, value in data.items()
+        }
+    else:
+        return data
+
+
 def _mark_as_lit(data, data_type):
     # To support nested types, 'data_type' is required.
     assert data_type is not None
@@ -985,9 +1010,7 @@ def gen_scalar_values(data_gen, count, seed=None, force_no_nulls=False):
 
     def gen_value():
         value = src.gen(force_no_nulls=force_no_nulls)
-        if value is not None and isinstance(data_type, DateType):
-            return _date_to_iso_string(value)
-        return value
+        return _normalize_pyspark_scalar(value, data_type)
 
     return (gen_value() for i in range(0, count))
 

--- a/integration_tests/src/main/python/data_gen_test.py
+++ b/integration_tests/src/main/python/data_gen_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import date
+
+from pyspark.sql.types import ArrayType, DateType, MapType, StringType, StructField, StructType
+
+from data_gen import SetValuesGen, gen_scalar_value
+
+
+def test_gen_scalar_value_normalizes_nested_dates():
+    data_type = StructType([
+        StructField("dates", ArrayType(DateType(), containsNull=True)),
+        StructField(
+            "dates_by_day",
+            MapType(
+                DateType(),
+                ArrayType(DateType(), containsNull=True),
+                valueContainsNull=True)),
+        StructField("label", StringType()),
+    ])
+    value = (
+        [date(4, 3, 1), None],
+        {
+            date(4, 3, 2): [date(4, 3, 3), None],
+            date(4, 3, 4): None,
+        },
+        "unchanged",
+    )
+
+    result = gen_scalar_value(SetValuesGen(data_type, [value]))
+
+    assert result == (
+        ["0004-03-01", None],
+        {
+            "0004-03-02": ["0004-03-03", None],
+            "0004-03-04": None,
+        },
+        "unchanged",
+    )
+
+
+def test_gen_scalar_value_preserves_array_container_type():
+    value = (date(4, 3, 1), None)
+
+    result = gen_scalar_value(SetValuesGen(ArrayType(DateType()), [value]))
+
+    assert result == ("0004-03-01", None)
+    assert isinstance(result, tuple)
+
+
+def test_gen_scalar_value_preserves_top_level_null():
+    assert gen_scalar_value(SetValuesGen(DateType(), [None])) is None


### PR DESCRIPTION
Fixes #15794.

### Description

`gen_scalar_values` only normalized top-level `DateType` values, leaving dates nested inside arrays, structs, and maps as Python `date` objects. This recursively normalizes nested dates before passing scalar values to PySpark while preserving nulls and container types.


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

Performance testing is not required because this helper only generates integration-test inputs and is not used during plugin runtime execution.