### PR TITLE
[BUG]25.08.0 com.nvidia.spark.rapids.RapidsHostColumnVector cannot be cast to com.nvidia.spark.rapids.GpuColumnVector

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -1484,6 +1484,39 @@ def test_delta_write_aqe_join(spark_tmp_path, enable_deletion_vectors):
 
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
+
+@allow_non_gpu("InMemoryTableScanExec", *delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(not is_databricks_runtime() and is_before_spark_353(),
+                    reason="TableCacheQueryStageExec is supported on Apache Spark 3.5.3+")
+def test_delta_write_from_cached_parquet_with_aqe(spark_tmp_path):
+    parquet_path = spark_tmp_path + "/PARQUET_DATA"
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    confs = copy_and_update(delta_writes_enabled_conf, {
+        "spark.sql.adaptive.enabled": "true",
+        "spark.sql.cache.serializer": "com.nvidia.spark.ParquetCachedBatchSerializer"
+    })
+
+    with_cpu_session(
+        lambda spark: spark.range(1, 1000).write.mode("overwrite").parquet(parquet_path),
+        conf=confs)
+
+    def do_write(spark, path):
+        cached = spark.read.parquet(parquet_path).cache()
+        try:
+            cached.count()
+            cached.write.format("delta").mode("overwrite").save(path)
+        finally:
+            cached.unpersist()
+
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        do_write,
+        read_delta_path,
+        data_path,
+        conf=confs)
+
+
 def do_test_optimize_write(spark_tmp_path, aqe_enabled, do_write, num_chunks):
     confs=copy_and_update(delta_writes_enabled_conf, {
         "spark.sql.adaptive.enabled" : str(aqe_enabled)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -714,6 +714,10 @@ object GpuOverrides extends Logging {
   def probablyGpuPlan(adaptivePlan: AdaptiveSparkPlanExec, conf: RapidsConf): Boolean = {
     def findRootProcessingNode(plan: SparkPlan): SparkPlan = plan match {
       case p: AdaptiveSparkPlanExec => findRootProcessingNode(p.executedPlan)
+      // A TableCache query stage is already fixed around the plan Spark chose for the cache
+      // read. Keep the wrapper here so we can classify that actual plan below instead of
+      // predicting whether the wrapped CPU plan could be replaced on a new conversion pass.
+      case p if SparkShimImpl.getTableCacheNonQueryStagePlan(p).nonEmpty => p
       case p: QueryStageExec => findRootProcessingNode(p.plan)
       case p: ReusedSubqueryExec => findRootProcessingNode(p.child)
       case p: ReusedExchangeExec => findRootProcessingNode(p.child)
@@ -721,13 +725,15 @@ object GpuOverrides extends Logging {
     }
 
     val aqeSubPlan = findRootProcessingNode(adaptivePlan.executedPlan)
-    aqeSubPlan match {
-      case _: GpuExec =>
+    SparkShimImpl.getTableCacheNonQueryStagePlan(aqeSubPlan) match {
+      case Some(tableCachePlan) =>
+        tableCachePlan.isInstanceOf[GpuExec]
+      case None if aqeSubPlan.isInstanceOf[GpuExec] =>
         // plan is already on the GPU
         true
-      case p =>
+      case None =>
         // see if the root processing node of the current subplan will translate to the GPU
-        val meta = GpuOverrides.wrapAndTagPlan(p, conf)
+        val meta = GpuOverrides.wrapAndTagPlan(aqeSubPlan, conf)
         meta.canThisBeReplaced
     }
   }


### PR DESCRIPTION
Fixes #13878.

### Description

`GpuOverrides.probablyGpuPlan` previously recursed through an already-created TableCache query stage and re-evaluated its wrapped CPU `InMemoryTableScanExec` as if that plan could still be replaced. With AQE and `ParquetCachedBatchSerializer`, this could classify host cache output as GPU output and skip the existing `HostColumnarToGpu` transition, allowing `RapidsHostColumnVector` batches to reach GPU-only sort/spill code.

This change detects materialized TableCache stages through `SparkShimImpl.getTableCacheNonQueryStagePlan` before generic query-stage recursion and classifies them from the actual wrapped plan's `GpuExec` state. Other AQE query-stage prediction behavior is unchanged, and no spill or host-column ownership semantics are modified.

A Spark 3.5.3+ Delta integration regression now covers parquet input, cache materialization with `ParquetCachedBatchSerializer`, AQE, cached Delta overwrite, CPU/GPU result comparison, and cache cleanup with `unpersist()`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

### Testing

- `python3 -m py_compile integration_tests/src/main/python/delta_lake_write_test.py` — passed.
- Spark 3.5.3 Scala 2.12 compilation passed with `-DaddScalacArgs=-Wconf:cat=deprecation:s`. The unmodified project command is currently blocked by four pre-existing cuDF `applyBooleanMask` deprecation warnings treated as fatal. `AdaptiveQueryExecSuite` then reached runtime but could not execute because RAPIDS initialization failed with `cudaErrorInsufficientDriver`.
- Spark 3.5.3 Scala 2.13 compilation also passed with the same deprecation-warning suppression; the tests module compiled 225 Scala and 2 Java sources and its 9 non-GPU Surefire tests passed. `AdaptiveQueryExecSuite` was again blocked by `cudaErrorInsufficientDriver`.
- `PYSP_TEST_spark_sql_cache_serializer=com.nvidia.spark.ParquetCachedBatchSerializer TESTS="delta_lake_write_test.py::test_delta_write_from_cached_parquet_with_aqe" ./integration_tests/run_pyspark_from_build.sh --delta_lake` — selected the new regression and started Spark 3.5.3, but the executor failed before test execution with `cudaErrorInsufficientDriver`.
- `PYSP_TEST_spark_sql_cache_serializer=com.nvidia.spark.ParquetCachedBatchSerializer ./integration_tests/run_pyspark_from_build.sh -k 'cache_test.py and test_aqe_cache_version_specific_behavior'` — likewise blocked during RAPIDS executor initialization by `cudaErrorInsufficientDriver`.