### PR TITLE
[DOC] sync gh-pages root files for cuDF plugin rename [skip ci]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Define the code of conduct followed and enforced by the RAPIDS Accelerator for Apache Spark project
+Define the code of conduct followed and enforced by the NVIDIA cuDF plugin for Apache Spark project
 
 ### Intended audience
 
@@ -42,7 +42,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at  [spark-rapids-conduct@nvidia.com](mailto:spark-rapids-conduct@nvidia.com)  All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at  [cudf-spark-conduct@nvidia.com](mailto:cudf-spark-conduct@nvidia.com)  All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ files, you must run the following command to sync the changes between the Scala 
 
 That way any new dependencies or other changes will also be picked up in the Scala 2.13 build.
 
-See the [scala2.13](scala2.13) directory for more information on how to build against
+See the [scala2.13](https://github.com/NVIDIA/cudf-spark/tree/main/scala2.13) directory
+for more information on how to build against
 Scala 2.13.
 
 To get an uber jar with more than 1 version you have to `mvn package` each version
@@ -107,7 +108,7 @@ If you want to create a jar with multiple versions we have the following options
 
 1. Build for all Apache Spark versions and CDH with no SNAPSHOT versions of Spark, only released. Use `-PnoSnapshots`.
 2. Build for all Apache Spark versions and CDH including SNAPSHOT versions of Spark we have supported for. Use `-Psnapshots`.
-3. Build for all Apache Spark versions, CDH and Databricks with no SNAPSHOT versions of Spark, only released. Use `-PnoSnaphsotsWithDatabricks`.
+3. Build for all Apache Spark versions, CDH and Databricks with no SNAPSHOT versions of Spark, only released. Use `-PnoSnapshotsWithDatabricks`.
 4. Build for all Apache Spark versions, CDH and Databricks including SNAPSHOT versions of Spark we have supported for. Use `-PsnapshotsWithDatabricks`
 5. Build for an arbitrary combination of comma-separated build versions using `-Dincluded_buildvers=<CSV list of build versions>`.
    E.g., `-Dincluded_buildvers=330,331`
@@ -295,7 +296,7 @@ the IDEA Resolve Symlinks plugin via `Marketplace` tab.
 
 To start working with the project in IDEA is as easy as
 [opening](https://blog.jetbrains.com/idea/2008/03/opening-maven-projects-is-easy-as-pie/) the top level (parent)
-[pom.xml](pom.xml).
+[pom.xml](https://github.com/NVIDIA/cudf-spark/blob/main/pom.xml).
 
 In IDEA 2022.3.1 [unselect](https://www.jetbrains.com/help/idea/2022.3/maven-importing.html)
 "Import using the new IntelliJ Workspace Model API (experimental)". After 2023.1.2 the default
@@ -552,7 +553,9 @@ By making a contribution to this project, I certify that:
 ```
 
 ### Testing Your Code
-Please visit the [testing doc](tests/README.md) for details about how to run tests
+Please visit the
+[testing doc](https://github.com/NVIDIA/cudf-spark/blob/main/tests/README.md)
+for details about how to run tests
 
 
 ### Pre-commit hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
-# Contributing to RAPIDS Accelerator for Apache Spark
+# Contributing to the NVIDIA cuDF plugin for Apache Spark
 
-Contributions to RAPIDS Accelerator for Apache Spark fall into the following three categories.
+Contributions to the NVIDIA cuDF plugin for Apache Spark fall into the following three categories.
 
 1. To report a bug, request a new feature, or report a problem with
-    documentation, please file an [issue](https://github.com/NVIDIA/spark-rapids/issues/new/choose)
+    documentation, please file an [issue](https://github.com/NVIDIA/cudf-spark/issues/new/choose)
     describing in detail the problem or new feature. The project team evaluates
     and triages issues, and schedules them for a release. If you believe the
     issue needs priority attention, please comment on the issue to notify the
     team.
 2. To propose and implement a new Feature, please file a new feature request
-    [issue](https://github.com/NVIDIA/spark-rapids/issues/new/choose). Describe the
+    [issue](https://github.com/NVIDIA/cudf-spark/issues/new/choose). Describe the
     intended feature and discuss the design and implementation with the team and
     community. Once the team agrees that the plan looks good, go ahead and
     implement it using the [code contributions](#code-contributions) guide below.
@@ -28,9 +28,19 @@ There are two types of branches in this repository:
   is held here. `main` will change with new releases, but otherwise it should not change with
   every pull request merged, making it a more stable branch.
 
+## Git Submodules
+
+This repository uses git submodules. The submodules may need to be updated after the repository
+is cloned or after moving to a new commit via `git submodule update --init`. See the
+[Git documentation on submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for more
+information.
+
 ## Building From Source
 
-We use [Maven](https://maven.apache.org) for most aspects of the build. Some important parts
+We use [Maven](https://maven.apache.org) for most aspects of the build. We test the build with latest
+patch versions for Maven 3.6.x, 3.8.x and 3.9.x. Maven version 3.6.0 or more recent is enforced.
+
+Some important parts
 of the build execute in the `verify` phase of the Maven build lifecycle.  We recommend when
 building at least running to the `verify` phase, e.g.:
 
@@ -38,28 +48,413 @@ building at least running to the `verify` phase, e.g.:
 mvn verify
 ```
 
-After a successful build the RAPIDS Accelerator jar will be in the `dist/target/` directory.
+After a successful build, the cuDF plugin jar will be in the `dist/target/` directory.
+This will build the plugin for a single version of Spark.  By default, this is Apache Spark
+3.3.0. To build against other versions of Spark you use the `-Dbuildver=XXX` command line option
+to Maven. For instance to build Spark 3.3.0 you would use:
+
+```shell script
+mvn -Dbuildver=330 verify
+```
+You can find all available build versions in the top level pom.xml file. If you are building
+for Databricks then you should use the `jenkins/databricks/build.sh` script and modify it for
+the version you want.
+
+Note that we build against both Scala 2.12 and 2.13. Any contribution you make to the
+codebase should compile with both Scala 2.12 and 2.13 for Apache Spark versions 3.3.0 and
+higher.
+
+Also, if you make changes in the parent `pom.xml` or any other of the module `pom.xml`
+files, you must run the following command to sync the changes between the Scala 2.12 and
+2.13 pom files:
+
+```shell script
+./build/make-scala-version-build-files.sh 2.13
+```
+
+That way any new dependencies or other changes will also be picked up in the Scala 2.13 build.
+
+See the [scala2.13](scala2.13) directory for more information on how to build against
+Scala 2.13.
+
+To get an uber jar with more than 1 version you have to `mvn package` each version
+and then use one of the defined profiles in the dist module, or a comma-separated list of
+build versions. See the next section for more details.
+
+You might see a warning during scala-maven-plugin compile goal invocation.
+```
+[INFO] Compiling 94 Scala sources and 1 Java source to /home/user/gits/NVIDIA/cudf-spark/tests/target/spark3XY/test-classes ...
+OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
+OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
+CodeCache: size=245760Kb used=236139Kb max_used=243799Kb free=9620Kb
+ bounds [0x00007f9681000000, 0x00007f9690000000, 0x00007f9690000000]
+ total_blobs=60202 nmethods=59597 adapters=504
+ compilation: disabled (not enough contiguous free space left)
+```
+
+It can be mitigated by increasing [ReservedCodeCacheSize](https://spark.apache.org/docs/latest/building-spark.html#setting-up-mavens-memory-usage)
+passed in the `MAVEN_OPTS` environment variable.
+
+### Building a Distribution for Multiple Versions of Spark
+
+By default, the distribution jar only includes code for a single version of Spark, albeit the jar file
+layout will be such that it can be accessed only using the Shim loading logic for
+[multiple Spark versions](./docs/dev/shims.md#run-time-issues). See
+[below](#building-a-distribution-for-a-single-spark-release) for dist jar creation without
+the need for a special shim class loader.
+
+If you want to create a jar with multiple versions we have the following options.
+
+1. Build for all Apache Spark versions and CDH with no SNAPSHOT versions of Spark, only released. Use `-PnoSnapshots`.
+2. Build for all Apache Spark versions and CDH including SNAPSHOT versions of Spark we have supported for. Use `-Psnapshots`.
+3. Build for all Apache Spark versions, CDH and Databricks with no SNAPSHOT versions of Spark, only released. Use `-PnoSnaphsotsWithDatabricks`.
+4. Build for all Apache Spark versions, CDH and Databricks including SNAPSHOT versions of Spark we have supported for. Use `-PsnapshotsWithDatabricks`
+5. Build for an arbitrary combination of comma-separated build versions using `-Dincluded_buildvers=<CSV list of build versions>`.
+   E.g., `-Dincluded_buildvers=330,331`
+
+You must first build each of the versions of Spark and then build one final time using the profile for the option you want.
+
+You can also install some manually and build a combined jar. For instance to build non-snapshot versions:
+
+```shell script
+mvn clean
+mvn -Dbuildver=330 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=331 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=332 install -Drat.skip=true -DskipTests
+mvn -pl dist -PnoSnapshots package -DskipTests
+```
+
+Verify that shim-specific classes are hidden from a conventional classloader.
+
+```bash
+$ javap -cp dist/target/rapids-4-spark_2.12-26.10.0-SNAPSHOT-cuda12.jar com.nvidia.spark.rapids.shims.SparkShimImpl
+Error: class not found: com.nvidia.spark.rapids.shims.SparkShimImpl
+```
+
+However, its bytecode can be loaded if prefixed with `spark3XY` not contained in the package name
+
+```bash
+$ javap -cp dist/target/rapids-4-spark_2.12-26.10.0-SNAPSHOT-cuda12.jar spark330.com.nvidia.spark.rapids.shims.SparkShimImpl | head -2
+Warning: File dist/target/rapids-4-spark_2.12-26.10.0-SNAPSHOT-cuda12.jar(/spark330/com/nvidia/spark/rapids/shims/SparkShimImpl.class) does not contain class spark330.com.nvidia.spark.rapids.shims.SparkShimImpl
+Compiled from "SparkShims.scala"
+public final class com.nvidia.spark.rapids.shims.SparkShimImpl {
+```
+
+#### Building with buildall script
+
+There is a build script `build/buildall` that automates the local build process. Use
+`./build/buildall --help` for up-to-date use information.
+
+By default, it builds everything that is needed to create a distribution jar for all released (noSnapshots) Spark versions except for Databricks. Other profiles that you can pass using `--profile=<distribution profile>` include
+- `snapshots` that includes all released (noSnapshots) and snapshots Spark versions except for Databricks
+- `minimumFeatureVersionMix` that currently includes 330 is recommended for catching incompatibilities already in the local development cycle
+
+For initial quick iterations we can use `--profile=<buildver>` to build a single-shim version. e.g., `--profile=330` for Spark 3.3.0.
+
+The option `--module=<module>` allows to limit the number of build steps. When iterating, we often don't have the need for the entire build. We may be interested in building everything necessary just to run integration tests (`--module=integration_tests`), or we may want to just rebuild the distribution jar (`--module=dist`)
+
+By default, `buildall` builds up to 4 shims in parallel using `xargs -P <n>`. This can be adjusted by
+specifying the environment variable `BUILD_PARALLEL=<n>`.
 
 ### Building against different CUDA Toolkit versions
 
-You can build against different versions of the CUDA Toolkit by using one of the following profiles:
-* `-Pcuda10-1` (CUDA 10.1, default)
-* `-Pcuda10-2` (CUDA 10.2)
-* `-Pcuda11` (CUDA 11.0)
+You can build against different versions of the CUDA Toolkit by modifying the variable `cuda.version`:
+* `-Dcuda.version=cuda12` (CUDA 12.x, default)
+
+### Building a Distribution for a Single Spark Release
+
+In many situations the user knows that the Plugin jar will be deployed for a single specific Spark
+release. It is most commonly the case when a container image for a cloud or local deployment includes
+Spark binaries as well. In such a case it is advantageous to create a jar with
+a conventional class directory structure avoiding complications such as
+[#3704](https://github.com/NVIDIA/cudf-spark/issues/3704). To this end add
+`-DallowConventionalDistJar=true` when invoking Maven.
+
+```bash
+mvn package -pl dist -am -Dbuildver=340 -DallowConventionalDistJar=true
+```
+
+Verify `com.nvidia.spark.rapids.shims.SparkShimImpl` is conventionally loadable:
+
+```bash
+$ javap -cp dist/target/rapids-4-spark_2.12-26.10.0-SNAPSHOT-cuda12.jar com.nvidia.spark.rapids.shims.SparkShimImpl | head -2
+Compiled from "SparkShims.scala"
+public final class com.nvidia.spark.rapids.shims.SparkShimImpl {
+```
+
+### Building and Testing
+
+We support JDK17 as our main JDK version, and test JDK8, JDK11 and JDK17. It is possible to build and run
+with more modern JDK versions, however these are untested. The first step is to set `JAVA_HOME` in
+the environment to your JDK root directory.
+If you need to build with a JDK version that we do not test internally add
+`-Denforcer.skipRules=requireJavaVersion` to the Maven invocation.
+
+### Building and Testing with ARM
+
+To build our project on ARM platform, please add `-Parm64` to your Maven commands.
+NOTE: Build process does not require an ARM machine, so if you want to build the artifacts only
+on X86 machine, please also add `-DskipTests` in commands.
+
+```bash
+mvn clean verify -Dbuildver=330 -Parm64
+```
+
+### Iterative development during local testing
+
+When iterating on changes impacting the `dist` module artifact directly or via
+dependencies you might find the jar creation step unacceptably slow. Due to the
+current size of the artifact `rapids-4-spark_2.12` Maven Jar Plugin spends the
+bulk of the time compressing the artifact content.
+Since the JAR file specification focuses on the file entry layout in a ZIP
+archive without requiring file entries to be compressed it is possible to skip
+compression, and increase the speed of creating `rapids-4-spark_2.12` jar ~3x
+for a single Spark version Shim alone.
+
+To this end in a pre-production build you can set the Boolean property
+`dist.jar.compress` to `false`, its default value is `true`.
+
+Furthermore, after the first build execution on the clean repository the cudf-spark-jni
+SNAPSHOT dependency typically does not change until the next nightly CI build, or the next install
+to the local Maven repo if you are working on a change to the native code. So you can save
+significant time spent on repeated unpacking these dependencies by adding `-Drapids.jni.unpack.skip`
+to the `dist` build command.
+
+The time saved is more significant if you are merely changing
+the `aggregator` module, or the `dist` module, or just incorporating changes from
+[cudf-spark-jni](https://github.com/NVIDIA/cudf-spark-jni/blob/branch-23.04/CONTRIBUTING.md#local-testing-of-cross-repo-contributions-cudf-spark-rapids-jni-and-spark-rapids)
+
+For example, to quickly repackage `rapids-4-spark` after the
+initial `./build/buildall` you can iterate by invoking
+```Bash
+mvn package -pl dist -PnoSnapshots -Ddist.jar.compress=false -Drapids.jni.unpack.skip
+```
+
+or similarly
+```Bash
+ ./build/buildall --rebuild-dist-only --option="-Ddist.jar.compress=false -Drapids.jni.unpack.skip"
+```
 
 ## Code contributions
 
+### Source code layout
+
+Conventional code locations in Maven modules are found under `src/main/<language>`. In addition to
+that and in order to support multiple versions of Apache Spark with the minimum amount of source
+code we maintain Spark-version-specific locations within non-shim modules if necessary. This allows
+us to switch between incompatible parent classes inside without copying the shared code to
+dedicated shim modules.
+
+Thus, the conventional source code root directories `src/main/<language>` contain the files that
+are source-compatible with all supported Spark releases, both upstream and vendor-specific.
+
+The following acronyms may appear in directory names:
+
+|Acronym|Definition  |Example|Example Explanation                           |
+|-------|------------|-------|----------------------------------------------|
+|db     |Databricks  |350db143|Databricks Spark based on Spark 3.5.0        |
+|cdh    |Cloudera CDH|(removed)|Cloudera CDH shims have been removed         |
+
+The version-specific directory names have one of the following forms / use cases:
+
+* `src/main/spark${buildver}`, example: `src/main/spark350db143`
+* `src/test/spark${buildver}`, example: `src/test/spark340`
+
+with a special shim descriptor as a Scala/Java comment. See [shimplify.md][1]
+
+[1]: ./docs/dev/shimplify.md
+
+### Setting up an Integrated Development Environment
+
+Our project currently uses `build-helper-maven-plugin` for shimming against conflicting definitions of superclasses
+in upstream versions that cannot be resolved without significant code duplication otherwise. To this end different
+source directories with differently implemented same-named classes are
+[added](https://www.mojohaus.org/build-helper-maven-plugin/add-source-mojo.html)
+for compilation depending on the targeted Spark version.
+
+This may require some modifications to IDEs' standard Maven import functionality.
+
+#### IntelliJ IDEA
+
+Last tested with IntelliJ IDEA 2023.1.2 (Community Edition)
+
+##### Manual Maven Install for a target Spark build
+
+Before proceeding with importing cudf-spark into IDEA or switching to a different Spark release
+profile, execute the install phase with the corresponding `buildver`, e.g. for Spark 3.4.0:
+
+```bash
+ mvn clean install -Dbuildver=340 -Dmaven.scaladoc.skip -DskipTests
+```
+
+##### Importing the project
+
+Our build relies on [symlink generation](./docs/dev/shimplify.md#symlinks--ide) for Spark
+release-specific sources. It is recommended to install
+the IDEA Resolve Symlinks plugin via `Marketplace` tab.
+
+To start working with the project in IDEA is as easy as
+[opening](https://blog.jetbrains.com/idea/2008/03/opening-maven-projects-is-easy-as-pie/) the top level (parent)
+[pom.xml](pom.xml).
+
+In IDEA 2022.3.1 [unselect](https://www.jetbrains.com/help/idea/2022.3/maven-importing.html)
+"Import using the new IntelliJ Workspace Model API (experimental)". After 2023.1.2 the default
+"Enable fast import" can be used.
+
+In order to make sure that IDEA handles profile-specific source code roots within a single Maven module correctly,
+[unselect](https://www.jetbrains.com/help/idea/2022.3/maven-importing.html) "Keep source and test folders on reimport".
+
+If you develop a feature that has to interact with the Shim layer or simply need to test the Plugin with a different
+Spark version, open [Maven tool window](https://www.jetbrains.com/help/idea/2022.3/maven-projects-tool-window.html) and
+select one of the `release3xx` profiles (e.g, `release330`) for Apache Spark 3.3.0.
+Make sure [Manual Maven Install](#manual-maven-install-for-a-target-spark-build) for that profile
+has been executed.
+
+Go to `File | Settings | Build, Execution, Deployment | Build Tools | Maven | Importing` and make sure
+that `Generated sources folders` is set to `Detect automatically` and `Phase to be used for folders update`
+is changed to `process-test-resources`.
+
+In the Maven tool window hit
+
+1. `Reload all projects`
+1. `Generate Sources and Update Folders For all Projects`.
+
+Known Issues:
+
+* With the old "slow" Maven importer it might be necessary to bump up maximum Java Heap size `-Xmx`
+via
+`File | Settings | Build, Execution, Deployment | Build Tools | Maven | Importing | VM options for importer`
+
+* When IDEA is upgraded, it might be necessary to remove `.idea` from the local git repository root.
+
+* There is a known issue that the test sources added via the `build-helper-maven-plugin` are not handled
+[properly](https://youtrack.jetbrains.com/issue/IDEA-100532). The workaround is to `mark` the affected
+folders such as `tests/src/test/spark3*` manually as `Test Sources Root`
+
+* There is a known issue where, even after selecting a different Maven profile in the Maven submenu,
+the source folders from a previously selected profile may remain active. As a workaround,
+when switching to a different profile, go to
+`File | Project Structure ... | Modules`, select the `rapids-4-spark-sql_2.12` module,
+click `Sources`, and delete all the shim source roots from the `Source Folders` list. Make sure
+the right test source folders are in `rapids-4-spark-sql_2.12` and `rapids-4-spark-tests_2.12`.
+Re-execute the steps above: reload, and `Generate Sources ...`.
+
+If you see Scala symbols unresolved (highlighted red) in IDEA please try the following steps to resolve it:
+
+* Make sure there are no relevant poms in
+`File | Settings | Build, Execution, Deployment | Build Tools | Maven | Ignored Files`
+
+* Restart IDEA and click `Reload All Maven Projects` again
+
+#### Bloop Build Server
+
+[Bloop](https://scalacenter.github.io/bloop/) is a build server and a set of tools around Build
+Server Protocol (BSP) for Scala providing an integration path with IDEs that support it. In fact,
+you can generate a Bloop project from Maven just for the Maven modules and profiles you are
+interested in. For example, to generate the Bloop projects for the Spark 3.3.0 dependency
+just for the production code run:
+
+```shell script
+mvn -B clean install \
+    -DbloopInstall \
+    -DdownloadSources=true \
+    -Dbuildver=330
+```
+
+With `--generate-bloop` we integrated Bloop project generation into `buildall`. It makes it easier
+to generate projects for multiple Spark dependencies using the same profiles as our regular build.
+It makes sure that the project files belonging to different Spark dependencies are
+not clobbered by repeated `bloopInstall` Maven plugin invocations, and it uses
+[jq](https://stedolan.github.io/jq/) to post-process JSON-formatted project files such that they
+compile project classes into non-overlapping set of output directories.
+
+To activate the Spark dependency version 3XY you currently are working with update
+the symlink `.bloop` to point to the corresponding directory `.bloop-spark3XY`
+
+Example usage:
+```Bash
+./build/buildall --generate-bloop --profile=330
+rm -vf .bloop
+ln -s .bloop-spark330 .bloop
+```
+
+You can now open the cudf-spark as a
+[BSP project in IDEA](https://www.jetbrains.com/help/idea/bsp-support.html)
+
+Read on for VS Code Scala Metals instructions.
+
+#### Bloop, Scala Metals, and Visual Studio Code
+
+_Last tested with 1.63.0-insider (Universal) Commit: bedf867b5b02c1c800fbaf4d6ce09cefba_
+
+Another, and arguably more popular, use of Bloop arises in connection with
+[Scala Metals](https://scalameta.org/metals/) and [VS @Code](https://code.visualstudio.com/).
+Scala Metals implements the
+[Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) for Scala,
+and enables features such as context-aware autocomplete, and code browsing between Scala symbol
+definitions, references and vice versa. LSP is supported by many editors including Vim and Emacs.
+
+Here we document the integration with VS code. It makes development on a remote node almost
+as easy as local development, which comes very handy when working in Cloud environments.
+
+Run `./build/buildall --generate-bloop --profile=<profile>` to generate Bloop projects
+for required Spark dependencies, e.g. `--profile=330` for Spark 3.3.0. When developing
+remotely this is done on the remote node.
+
+Install [Scala Metals extension](https://scalameta.org/metals/docs/editors/vscode) in VS Code,
+either locally or into a Remote-SSH extension destination depending on your target environment.
+When your project folder is open in VS Code, it may prompt you to import Maven project.
+IMPORTANT: always decline with "Don't ask again", otherwise it will overwrite the Bloop projects
+generated with the default `330` profile. If you need to use a different profile, always rerun the
+command above manually. When regenerating projects it's recommended to proceed to Metals
+"Build commands" View, and click:
+1. "Restart build server"
+1. "Clean compile workspace"
+to avoid stale class files.
+
+Now you should be able to see Scala class members in the Explorer's Outline view and in the
+Breadcrumbs view at the top of the Editor with a Scala file open.
+
+Check Metals logs, "Run Doctor" etc. if something is not working as expected. You can also verify
+that the Bloop build server and the Metals language server are running by executing `jps` in the
+Terminal window:
+```shell script
+jps -l
+72960 sun.tools.jps.Jps
+72356 bloop.Server
+72349 scala.meta.metals.Main
+```
+
+##### Known Issues
+
+###### java.lang.RuntimeException: boom
+
+Metals background compilation process status appears to be resetting to 0% after reaching 99%
+and you see a peculiar error message [`java.lang.RuntimeException: boom`][1]. This is a known issue
+when running Metals/Bloop on Java 8. To work around it, ensure Metals and Bloop are both running on
+Java 17 (minimum Java version for our project):
+
+1. The `-DbloopInstall` profile will enforce Java 11+ compliance.
+
+1. Add [`metals.javaHome`][2] to VSCode preferences to point to Java 11+.
+
+[1]: https://github.com/sourcegraph/scip-java/blob/b7d268233f1a303f66b6d9804a68f64b1e5d7032/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java#L76
+
+[2]: https://github.com/scalameta/metals-vscode/pull/644/files#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R132
+#### Other IDEs
+We welcome pull requests with tips on how to setup your favorite IDE!
+
 ### Your first issue
 
-1. Read the [Developer Overview](docs/dev/README.md) to understand how the RAPIDS Accelerator
+1. Read the [Developer Overview](docs/dev/README.md) to understand how the cuDF
     plugin works.
 2. Find an issue to work on. The best way is to look for the
-    [good first issue](https://github.com/NVIDIA/spark-rapids/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-    or [help wanted](https://github.com/NVIDIA/spark-rapids/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+    [good first issue](https://github.com/NVIDIA/cudf-spark/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+    or [help wanted](https://github.com/NVIDIA/cudf-spark/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
     labels.
 3. Comment on the issue stating that you are going to work on it.
 4. Code! Make sure to update unit tests and integration tests if needed! [refer to test section](#testing-your-code)
-5. When done, [create your pull request](https://github.com/NVIDIA/spark-rapids/compare).
+5. When done, [create your pull request](https://github.com/NVIDIA/cudf-spark/compare).
 6. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/).
     Fix if needed.
 7. Wait for other developers to review your code and update code as needed.
@@ -69,7 +464,7 @@ Remember, if you are unsure about anything, don't hesitate to comment on issues
 and ask for clarifications!
 
 ### Code Formatting
-RAPIDS Accelerator for Apache Spark follows the same coding style guidelines as the Apache Spark
+The NVIDIA cuDF plugin for Apache Spark follows the same coding style guidelines as the Apache Spark
 project.  For IntelliJ IDEA users, an
 [example code style settings file](docs/dev/idea-code-style-settings.xml) is available in the
 `docs/dev/` directory.
@@ -80,6 +475,13 @@ This project follows the official
 [Scala style guide](https://docs.scala-lang.org/style/) and the
 [Databricks Scala guide](https://github.com/databricks/scala-style-guide), preferring the latter.
 
+Direct `println` calls should not be used in normal implementation or test code. Use project
+logging for optional diagnostics, ScalaTest `info` for meaningful test metadata, and `withClue`
+for context that should appear only when an assertion fails. `ConsoleOutput` is reserved for
+tools, CLI entry points, report generators, benchmarks, and process protocols where stdout or
+stderr is an intentional interface. If that helper is not available to a module, scope
+`scalastyle:off/on println` tightly around the intentional output block rather than an entire file.
+
 #### Java
 
 This project follows the
@@ -88,7 +490,7 @@ and the Scala conventions detailed above, preferring the latter.
 
 ### Sign your work
 
-We require that all contributors sign-off on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
+We require that all contributors sign-off on their commits. This certifies that the contribution is your original work, or you have the rights to submit it under the same license, or a compatible license.
 
 Any contribution which contains commits that are not signed off will not be accepted.
 
@@ -107,7 +509,7 @@ Signed-off-by: Your Name <your@email.com>
 The sign-off is a simple line at the end of the explanation for the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. Use your real name, no pseudonyms or anonymous contributions.  If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with `git commit -s`.
 
 
-The signoff means you certify the below (from [developercertificate.org](https://developercertificate.org)):
+The sign-off means you certify the below (from [developercertificate.org](https://developercertificate.org)):
 
 ```
 Developer Certificate of Origin
@@ -150,7 +552,123 @@ By making a contribution to this project, I certify that:
 ```
 
 ### Testing Your Code
-Please visit the [testing doc](https://github.com/NVIDIA/spark-rapids/blob/main/tests/README.md) for details about how to run tests
+Please visit the [testing doc](tests/README.md) for details about how to run tests
+
+
+### Pre-commit hooks
+We provide a basic config `.pre-commit-config.yaml` for [pre-commit](https://pre-commit.com/) to
+automate some aspects of the development process. As a convenience you can enable automatic
+copyright year updates by following the installation instructions on the
+[pre-commit homepage](https://pre-commit.com/).
+
+To this end, first install `pre-commit` itself using the method most suitable for your development
+environment. Then you will need to run `pre-commit install` to enable it in your local git
+repository. Using `--allow-missing-config` will make it easy to work with older branches
+that do not have `.pre-commit-config.yaml`.
+
+```bash
+pre-commit install --allow-missing-config
+```
+
+and setting the environment variable:
+
+```bash
+export SPARK_RAPIDS_AUTO_COPYRIGHTER=ON
+```
+The default value of `SPARK_RAPIDS_AUTO_COPYRIGHTER` is `OFF`.
+
+When automatic copyright updater is enabled and you modify a file with a prior
+year in the copyright header it will be updated on `git commit` to the current year automatically.
+However, this will abort the [commit process](https://github.com/pre-commit/pre-commit/issues/532)
+with the following error message:
+```
+Update copyright year....................................................Failed
+- hook id: auto-copyrighter
+- duration: 0.01s
+- files were modified by this hook
+```
+You can confirm that the update has actually happened by either inspecting its effect with
+`git diff` first or simply re-executing `git commit` right away. The second time no file
+modification should be triggered by the copyright year update hook and the commit should succeed.
+
+There is a known issue for macOS users if they use the default version of `sed`. The copyright update
+script may fail and generate an unexpected file named `source-file-E`. As a workaround, please
+install GNU sed
+
+```bash
+brew install gnu-sed
+# and add to PATH to make it as default sed for your shell
+export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+```
+
+### Creating a Pull Request
+
+Here are some guidelines to follow when creating a pull request:
+
+1. Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md): Fill it in rather than replacing it
+   with another format.
+
+2. Label your PR. Labels are what make the queue filterable. Changes that touch only tests get the
+   `test` label so reviewers know no production logic changed.
+
+3. If your pull request is not ready for review but you want to make use of the
+   continuous integration testing facilities, please make it as a draft and prefix the title with
+   `[WIP]`. Please do not use other title prefixes that mean the same thing as `[WIP]` such as
+   `[DO NOT REVIEW]` and `[DRAFT]`.
+
+   - When the PR is ready to be reviewed without requiring additional work on top of it,
+     then convert it to a regular pull request and remove the `[WIP]` prefix from the title.
+
+   - **Bound draft lifetime**. A draft is for CI runs and early feedback, not for parking work
+     indefinitely: state in the description what makes it a draft (a TODO checklist is preferred,
+     since it also shows how far along the work is), and if it stops progressing,
+     close it and open a new PR when the work resumes.
+
+4. Once the review has taken place:
+
+   - Please do not add features or make changes out of the scope of those even if the reviewer
+     requests them. Instead, please consider filing new issues for those changes.
+
+   - Please avoid rebasing your branch during the review process, as this causes the context
+     of any comments made by reviewers to be lost. If conflicts occur during
+     review, then they should be resolved by merging into the branch used for
+     making the pull request.
+
+5. **Closing a PR**. When closing an unmerged PR, leave a comment saying why, covering which case
+   applies: `superseded` (link the replacement), `abandoned` (say what ruled out the approach),
+   or `deferred` (link the tracking issue). A closed PR with no explanation is a dead end for
+   anyone who reaches it from a design doc or issue link months later.
+
+### Pull request status checks
+A pull request should pass all status checks before being merged.
+#### sign-off check
+Please follow the steps in the [Sign your work](#sign-your-work) section,
+and make sure at least one commit in your pull request is signed-off.
+#### blossom-ci
+The check runs on NVIDIA self-hosted runner, a [project committer](.github/workflows/blossom-ci.yml#L36) can
+manually trigger it by commenting `build`. It includes the following steps,
+1. Mergeable check
+2. Blackduck vulnerability scan
+3. Fetch merged code (merge the pull request HEAD into BASE branch, e.g. fea-001 into branch-x)
+4. Run `mvn verify` and unit tests for multiple Spark versions in parallel.
+Ref: [spark-premerge-build.sh](jenkins/spark-premerge-build.sh)
+
+If it fails, you can click the `Details` link of this check, and go to `Upload log -> Jenkins log for pull request xxx (click here)` to
+find the uploaded log.
+
+Options:
+1. Skip tests run by adding `[skip ci]` to the title. This should only be used for doc-only changes.
+2. Run build and tests in Databricks runtimes by adding `[databricks]` to the title. This adds around 30-40 minutes.
+3. Run Scala unit tests in parallel by adding `[fast-ut]` to the title. This does not reduce test coverage, but is opt-in while the parallel runner is still being evaluated. Parallel mode does not support `-Dsuffixes` or `-Dtests`; use `-DwildcardSuites` instead. GPU memory is divided across test forks, and each suite has a 1800-second timeout.
+4. Reduce pre-commit integration-test parameter combinations by adding `[reduced-it]` to the title. This is appropriate for documentation, CI, build, script, and other low-risk localized changes, but should not be used when correctness may depend on parameter combinations such as types, formats, time zones, ANSI mode, code generation, or shims. Nightly runs still exercise the full parameter product.
+
+CI title tags (`[skip ci]`, `[databricks]`, `[fast-ut]`, and `[reduced-it]`) should be placed at the end of the pull request title, separated from the subject and from each other by a single space. Category prefixes such as `[DOC]` remain at the beginning of the title.
+
+
+### Code Review Guidelines
+
+We have [code review guidelines](CODE_REVIEW_GUIDELINES.md) that outline how we collaborate during code review. Please read them before opening or reviewing a pull request.
+
 
 ## Attribution
-Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/master/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md  
+Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/master/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,406 @@
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+This code is dual-licensed with documentation/skills under the CC-BY-4.0 AND source code under Apache-2.0 license terms.
+
+
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +581,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +589,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 nvspark
+   Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NVIDIA cuDF plugin for Apache Spark
-NOTE: For the latest stable [README.md](https://github.com/nvidia/cudf-spark/blob/main/README.md) ensure you are on the main branch.
+NOTE: For the latest stable [README.md](https://github.com/NVIDIA/cudf-spark/blob/main/README.md) ensure you are on the main branch.
 
 The NVIDIA cuDF plugin for [Apache Spark](https://spark.apache.org) provides a plugin library that
-leverages GPUs to accelerate processing via the [cuDF](https://github.com/rapidsai/cudf) (CUDA
+leverages GPUs to accelerate processing via the [cuDF](https://github.com/NVIDIA/cudf) (CUDA
 DataFrame) libraries.
 
 Documentation on the current release can be found [here](https://nvidia.github.io/cudf-spark/).
@@ -12,7 +12,7 @@ To get started and try the plugin out use the [getting started guide](https://do
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/cudf-spark)
 
 Note: The NVIDIA cuDF plugin for Apache Spark was formerly known as the RAPIDS Accelerator for
-Apache Spark.  The RAPIDS name will be sunset over time.  Github links from `spark-rapids` will
+Apache Spark.  The RAPIDS name will be sunset over time.  GitHub links from `spark-rapids` will
 redirect to `cudf-spark`.  Artifact names will remain the same for now.
 
 ## Compatibility
@@ -62,8 +62,8 @@ access to any of the memory that RMM is holding.
 
 ## Qualification and Profiling tools
 
-The Qualification and Profiling tools have been moved to
-[NVIDIA/cudf-spark-tools](https://github.com/NVIDIA/cudf-spark-tools) repo.
+The Qualification and Profiling tools are available in the
+[NVIDIA/cudf-spark-tools](https://github.com/NVIDIA/cudf-spark-tools) repository.
 
 Please refer to [Qualification tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/overview.html)
 and [Profiling tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/profiling/overview.html)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# RAPIDS Accelerator For Apache Spark
-NOTE: For the latest stable [README.md](https://github.com/nvidia/spark-rapids/blob/main/README.md) ensure you are on the main branch. The RAPIDS Accelerator for Apache Spark provides a set of plugins for Apache Spark that leverage GPUs to accelerate processing via the RAPIDS libraries and UCX. Documentation on the current release can be found [here](https://nvidia.github.io/spark-rapids/). 
+# NVIDIA cuDF plugin for Apache Spark
+NOTE: For the latest stable [README.md](https://github.com/nvidia/cudf-spark/blob/main/README.md) ensure you are on the main branch.
 
-The RAPIDS Accelerator for Apache Spark provides a set of plugins for 
-[Apache Spark](https://spark.apache.org) that leverage GPUs to accelerate processing
-via the [RAPIDS](https://rapids.ai) libraries and [UCX](https://www.openucx.org/).
+The NVIDIA cuDF plugin for [Apache Spark](https://spark.apache.org) provides a plugin library that
+leverages GPUs to accelerate processing via the [cuDF](https://github.com/rapidsai/cudf) (CUDA
+DataFrame) libraries.
 
-To get started and try the plugin out use the [getting started guide](./docs/get-started/getting-started.md).
+Documentation on the current release can be found [here](https://nvidia.github.io/cudf-spark/).
+
+To get started and try the plugin out use the [getting started guide](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html).
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/cudf-spark)
+
+Note: The NVIDIA cuDF plugin for Apache Spark was formerly known as the RAPIDS Accelerator for
+Apache Spark.  The RAPIDS name will be sunset over time.  Github links from `spark-rapids` will
+redirect to `cudf-spark`.  Artifact names will remain the same for now.
 
 ## Compatibility
 
@@ -15,38 +23,62 @@ Operator compatibility is documented [here](./docs/compatibility.md)
 ## Tuning
 
 To get started tuning your job and get the most performance out of it please start with the
-[tuning guide](./docs/tuning-guide.md).
+[tuning guide](https://docs.nvidia.com/spark-rapids/user-guide/latest/tuning-guide.html).
 
 ## Configuration
 
-The plugin has a set of Spark configs that control its behavior and are documented 
+The plugin has a set of Spark configs that control its behavior and are documented
 [here](docs/configs.md).
 
-## Issues
+## Issues & Questions
 
-We use github issues to track bugs, feature requests, and to try and answer questions. You
-may file one [here](https://github.com/NVIDIA/spark-rapids/issues/new/choose).
+We use github to track bugs, feature requests, and answer questions. File an
+[issue](https://github.com/NVIDIA/cudf-spark/issues/new/choose) for a bug or feature request. Ask
+or answer a question on the [discussion board](https://github.com/NVIDIA/cudf-spark/discussions).
 
 ## Download
 
-The jar files for the most recent release can be retrieved from the [download](docs/download.md)
-page. 
+The jar files for the most recent release can be retrieved from the [download](https://nvidia.github.io/cudf-spark/docs/download.html)
+page.
 
 ## Building From Source
 
 See the [build instructions in the contributing guide](CONTRIBUTING.md#building-from-source).
 
-## Testing 
+## Testing
 
-Tests are described [here](https://github.com/NVIDIA/spark-rapids/blob/main/tests/README.md).
+Tests are described [here](tests/README.md).
 
 ## Integration
-The RAPIDS Accelerator For Apache Spark does provide some APIs for doing zero copy data
-transfer into other GPU enabled applications.  It is described
-[here](docs/additional-functionality/ml-integration.md).
+The cuDF plugin provides some APIs for doing zero copy data transfer into other GPU enabled
+applications.  It is described
+[here](https://docs.nvidia.com/spark-rapids/user-guide/latest/additional-functionality/ml-integration.html).
 
-Currently, we are working with XGBoost to try to provide this integration out of the box. 
+Currently, we are working with XGBoost to try to provide this integration out of the box.
 
 You may need to disable RMM caching when exporting data to an ML library as that library
 will likely want to use all of the GPU's memory and if it is not aware of RMM it will not have
 access to any of the memory that RMM is holding.
+
+## Qualification and Profiling tools
+
+The Qualification and Profiling tools have been moved to
+[NVIDIA/cudf-spark-tools](https://github.com/NVIDIA/cudf-spark-tools) repo.
+
+Please refer to [Qualification tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/overview.html)
+and [Profiling tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/profiling/overview.html)
+for more details on how to use the tools.
+
+## Dependency for External Projects
+
+If you develop functionality on top of the cuDF plugin (we currently limit support to
+GPU-accelerated UDFs) we recommend you declare the distribution artifact as a `provided` dependency.
+
+```xml
+<dependency>
+    <groupId>com.nvidia</groupId>
+    <artifactId>rapids-4-spark_2.12</artifactId>
+    <version>26.10.0-SNAPSHOT</version>
+    <scope>provided</scope>
+</dependency>
+```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See the [build instructions in the contributing guide](CONTRIBUTING.md#building-
 
 ## Testing
 
-Tests are described [here](tests/README.md).
+Tests are described [here](https://github.com/NVIDIA/cudf-spark/blob/main/tests/README.md).
 
 ## Integration
 The cuDF plugin provides some APIs for doing zero copy data transfer into other GPU enabled

--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,8 @@ remote_theme: pmarsceill/just-the-docs
 aux_links:
   "NVIDIA cuDF plugin for Apache Spark User Guide":
     - "//docs.nvidia.com/spark-rapids/user-guide/latest/index.html"
-  "NVIDIA cuDF plugin for Apache Spark on Github":
-    - "//github.com/nvidia/cudf-spark"
+  "NVIDIA cuDF plugin for Apache Spark on GitHub":
+    - "//github.com/NVIDIA/cudf-spark"
 
 plugins:
   - jekyll-optional-front-matter # GitHub Pages

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@
 
 remote_theme: pmarsceill/just-the-docs
 
-color_scheme: emerald
-
 aux_links:
-  "Spark Rapids Plugin on Github":
-    - "//github.com/nvidia/spark-rapids"
+  "NVIDIA cuDF plugin for Apache Spark User Guide":
+    - "//docs.nvidia.com/spark-rapids/user-guide/latest/index.html"
+  "NVIDIA cuDF plugin for Apache Spark on Github":
+    - "//github.com/nvidia/cudf-spark"
 
 plugins:
   - jekyll-optional-front-matter # GitHub Pages

--- a/index.md
+++ b/index.md
@@ -3,13 +3,13 @@ layout: default
 title: Home
 nav_order: 1
 permalink: /
-description: This site serves as a collection of documentation about the RAPIDS accelerator for Apache Spark
+description: This site serves as a collection of documentation about the NVIDIA cuDF plugin for Apache Spark
 ---
 # Overview
-**If you are a customer looking for information on how to adopt RAPIDS Accelerator for Apache Spark
+**If you are a customer looking for information on how to adopt the cuDF plugin
 for your Spark workloads, please go to our User Guide for more information: [link](https://docs.nvidia.com/spark-rapids/user-guide/latest/index.html).**
 
-The RAPIDS Accelerator for Apache Spark leverages GPUs to accelerate processing via the
+The cuDF plugin leverages GPUs to accelerate processing via the
 [RAPIDS libraries](http://rapids.ai).
 
 As data scientists shift from using traditional analytics to leveraging AI(DL/ML) applications that 
@@ -17,8 +17,7 @@ better model complex market demands, traditional CPU-based processing can no lon
 compromising either speed or cost. The growing adoption of AI in analytics has created the need for 
 a new framework to process data quickly and cost-efficiently with GPUs.
 
-The RAPIDS Accelerator for Apache Spark combines the power of the [RAPIDS cuDF](https://github.com/rapidsai/cudf/) library and
-the scale of the Spark distributed computing framework.  The RAPIDS Accelerator library also has a
-built-in accelerated shuffle based on [UCX](https://github.com/openucx/ucx/) that can be configured to leverage GPU-to-GPU
-communication and RDMA capabilities.
-
+The cuDF plugin combines the power of the [cuDF](https://github.com/rapidsai/cudf/) library and the
+scale of the Spark distributed computing framework.  The cuDF plugin also has a built-in accelerated
+shuffle based on [UCX](https://github.com/openucx/ucx/) that can be configured to leverage
+GPU-to-GPU communication and RDMA capabilities.


### PR DESCRIPTION
Contributes to [#15107](https://github.com/NVIDIA/cudf-spark/issues/15107).

### Description

Completes the cuDF plugin rename for the non-generated files stored separately at the root of the `gh-pages` branch.

Changes include:
- Synchronize `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `LICENSE`, and `README.md` with their latest `main` content.
- Map `main:docs/_config.yml` and `main:docs/index.md` to the corresponding `gh-pages` root files.
- Update the remaining Qualification and Profiling tools link from the redirected `NVIDIA/spark-rapids-tools` name to `NVIDIA/cudf-spark-tools`.
- Update the Code of Conduct contact address to `cudf-spark-conduct@nvidia.com` as part of the synchronized content.
- Point source-only links in `README.md` and `CONTRIBUTING.md` to canonical files on `main`, since those files are absent from `gh-pages`.
- Correct the Maven profile spelling to `-PnoSnapshotsWithDatabricks`.

The relatively large diff in `CONTRIBUTING.md` and `LICENSE` is because these root-level `gh-pages` copies had not been synchronized with `main`; no generated documentation is included.

Validation:
- `git diff --check`
- IDE lints on all six modified files
- Verified `_config.yml` and `index.md` exactly match their `main:docs/` source files
- Verified `CODE_OF_CONDUCT.md` and `LICENSE` exactly match `main`; `README.md` and `CONTRIBUTING.md` include only the documented gh-pages-safe link/profile corrections beyond the synchronized content
- Audited the six files for stale product names, repository URLs, site URLs, and conduct email references
- Verified the corrected `scala2.13`, `pom.xml`, and `tests/README.md` links return HTTP 200
- Verified `NVIDIA/cudf-spark-tools` is the active repository

`[skip ci]` because this updates documentation and static site metadata only.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required