### PR TITLE
Use returned cuDF Parquet footer for Iceberg writes [fast-ut]

### DIFF
--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/fileio/iceberg/IcebergFileIO.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/fileio/iceberg/IcebergFileIO.java
@@ -63,16 +63,6 @@ public class IcebergFileIO implements RapidsFileIO {
     return IcebergS3InputFile.maybeCreate(inputFile, delegate);
   }
 
-  /**
-   * Always returns a plain {@link IcebergInputFile}, bypassing the S3 PerfIO
-   * fast-path. Use this from internal call sites that need the iceberg
-   * {@link InputFile} accessor on the read side (e.g. writers re-reading the
-   * footer of a just-written file) and do not benefit from PerfIO.
-   */
-  public IcebergInputFile newIcebergInputFile(String path) throws IOException {
-    return new IcebergInputFile(delegate.newInputFile(path));
-  }
-
   @Override
   public IcebergOutputFile newOutputFile(String path) throws IOException {
     return new IcebergOutputFile(delegate.newOutputFile(path));

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
@@ -26,8 +26,8 @@ import com.nvidia.spark.rapids.iceberg.parquet.converter.ToIcebergShaded
 import com.nvidia.spark.rapids.parquet.HMBInputFile
 import org.apache.iceberg.{FieldMetrics, Metrics, MetricsConfig}
 import org.apache.iceberg.io.FileAppender
-import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.iceberg.parquet.ParquetUtil
+import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.metadata.ParquetMetadata
 
 

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
@@ -22,9 +22,12 @@ import java.util.stream.{Stream => JStream}
 
 import com.nvidia.spark.rapids.{GpuParquetWriter, SpillableColumnarBatch}
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.fileio.iceberg.IcebergFileIO
+import com.nvidia.spark.rapids.iceberg.parquet.converter.ToIcebergShaded
+import com.nvidia.spark.rapids.parquet.HMBInputFile
 import org.apache.iceberg.{FieldMetrics, Metrics, MetricsConfig}
 import org.apache.iceberg.io.FileAppender
+import org.apache.iceberg.shaded.org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.iceberg.parquet.ParquetUtil
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.metadata.ParquetMetadata
 
@@ -39,8 +42,7 @@ import org.apache.iceberg.shaded.org.apache.parquet.hadoop.metadata.ParquetMetad
  */
 class GpuIcebergParquetAppender(
   val inner: GpuParquetWriter,
-  val metricsConfig: MetricsConfig,
-  val fileIO: IcebergFileIO) extends FileAppender[SpillableColumnarBatch] {
+  val metricsConfig: MetricsConfig) extends FileAppender[SpillableColumnarBatch] {
   private var closed = false
   private var footer: ParquetMetadata = _
 
@@ -58,12 +60,10 @@ class GpuIcebergParquetAppender(
 
   override def close(): Unit = {
     if (!closed) {
-      inner.close()
-      footer = withResource(
-          IcebergPartitionedFile(fileIO.newIcebergInputFile(inner.path)).newReader()) {
-        reader =>
-          // TODO: Remove the read after https://github.com/rapidsai/cudf/issues/18886 got fixed.
-          reader.getFooter
+      footer = withResource(inner.closeAndGetFooter()) { footerBuffer =>
+        ParquetFileReader.readFooter(
+          ToIcebergShaded.shade(new HMBInputFile(footerBuffer)),
+          ParquetMetadataConverter.NO_FILTER)
       }
       closed = true
     }

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
@@ -26,7 +26,6 @@ import com.nvidia.spark.rapids.iceberg.parquet.converter.ToIcebergShaded
 import com.nvidia.spark.rapids.parquet.HMBInputFile
 import org.apache.iceberg.{FieldMetrics, Metrics, MetricsConfig}
 import org.apache.iceberg.io.FileAppender
-import org.apache.iceberg.shaded.org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.iceberg.parquet.ParquetUtil
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.metadata.ParquetMetadata
@@ -61,9 +60,10 @@ class GpuIcebergParquetAppender(
   override def close(): Unit = {
     if (!closed) {
       footer = withResource(inner.closeAndGetFooter()) { footerBuffer =>
-        ParquetFileReader.readFooter(
-          ToIcebergShaded.shade(new HMBInputFile(footerBuffer)),
-          ParquetMetadataConverter.NO_FILTER)
+        withResource(ParquetFileReader.open(
+          ToIcebergShaded.shade(new HMBInputFile(footerBuffer)))) { reader =>
+          reader.getFooter
+        }
       }
       closed = true
     }

--- a/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuSparkFileWriterFactory.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/spark/source/GpuSparkFileWriterFactory.scala
@@ -107,8 +107,7 @@ class GpuSparkFileWriterFactory(val table: Table,
 
     new GpuIcebergParquetAppender(
       gpuWriter,
-      metricsConfig = MetricsConfig.forTable(table),
-      fileIO = new IcebergFileIO(table.io())
+      metricsConfig = MetricsConfig.forTable(table)
     )
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
@@ -281,18 +281,34 @@ abstract class ColumnarOutputWriter(context: TaskAttemptContext,
    * Closes the [[ColumnarOutputWriter]]. Invoked on the executor side after all columnar batches
    * are persisted, before the task output is committed.
    */
-  def close(): Unit = {
+  private def prepareToClose(): Unit = {
     if (!anythingWritten) {
       // This prevents writing out bad files
       bufferBatchAndClose(GpuColumnVector.emptyBatch(dataSchema))
     }
-    tableWriter.close()
+  }
+
+  private def finishClose(): Unit = {
     GpuSemaphore.releaseIfNecessary(TaskContext.get())
     writeBufferedData()
     outputStream.close()
     debugDumpOutputStream.foreach { os =>
       os.close()
     }
+  }
+
+  protected final def closeAndReturn[T <: AutoCloseable](closeWriter: => T): T = {
+    prepareToClose()
+    closeOnExcept(closeWriter) { result =>
+      finishClose()
+      result
+    }
+  }
+
+  def close(): Unit = {
+    prepareToClose()
+    tableWriter.close()
+    finishClose()
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -478,7 +478,7 @@ class GpuParquetWriter(
     }
   }
 
-  override val tableWriter: TableWriter = {
+  override val tableWriter: ParquetTableWriter = {
     val writeContext = new ParquetWriteSupport().init(conf)
     // Use the value resolved in prepareWrite. Reading SQLConf here would discard
     // a per-write option.
@@ -502,5 +502,9 @@ class GpuParquetWriter(
       builder.withDictionaryPolicy(dictionaryPolicy)
     }
     Table.writeParquetChunked(builder.build(), this)
+  }
+
+  private[rapids] def closeAndGetFooter(): HostMemoryBuffer = {
+    closeAndReturn(tableWriter.closeAndGetFooter())
   }
 }


### PR DESCRIPTION
Related to NVIDIA/cudf#18886.

### Description

Iceberg GPU writes currently reopen each Parquet output file after closing it to obtain footer metadata for file metrics and split offsets. This causes an unnecessary read from the output filesystem, which is especially costly for remote storage.

This change uses the new cuDF `ParquetTableWriter.closeAndGetFooter()` API to return the metadata-only Parquet footer during writer finalization. `GpuParquetWriter` exposes the returned host buffer to the Iceberg appender, which parses it through Iceberg's shaded Parquet reader without reopening the output file.

The shared columnar writer close path preserves the existing finalization sequence and closes the returned buffer if output finalization fails.

Validation:

- Spark 4.1.1 / Scala 2.13 build: all 19 modules succeeded.
- Spark 4.1.1 with Iceberg 1.11.0 local Hadoop catalog: 432 passed, 19 skipped, 6 xfailed, and 3 xpassed.
- The existing Iceberg integration suite exercises append, overwrite, merge, schema and partition evolution, metrics, and split-offset paths.

This change and PR description were prepared with AI assistance from OpenAI Codex.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Iceberg integration suite with Spark 4.1.1 and Iceberg 1.11.0.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
