### PR TITLE
Work around Dataproc Py4J weak container references [reduced-it] [databricks]

### DIFF
--- a/integration_tests/src/main/python/py4j_workaround_test.py
+++ b/integration_tests/src/main/python/py4j_workaround_test.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import weakref
+
+from spark_init_internal import (
+    _apply_py4j_strong_ref_workaround_if_needed,
+    get_spark_i_know_what_i_am_doing,
+)
+
+
+class _Container:
+    pass
+
+
+def test_py4j_chained_temporary_container_call():
+    spark = get_spark_i_know_what_i_am_doing()
+
+    assert spark._jvm.java.util.Collections.emptyList().size() == 0
+
+
+def test_py4j_weak_container_is_replaced_with_strong_reference():
+    class WeakJavaMember:
+        def __init__(self, name, container, target_id, gateway_client):
+            self.container = weakref.ref(container)
+
+    assert _apply_py4j_strong_ref_workaround_if_needed(WeakJavaMember)
+
+    container = _Container()
+    container_ref = weakref.ref(container)
+    member = WeakJavaMember('get', container, 'o1', None)
+    del container
+    gc.collect()
+
+    assert container_ref() is member.container
+
+
+def test_py4j_workaround_is_idempotent():
+    class WeakJavaMember:
+        def __init__(self, name, container, target_id, gateway_client):
+            self.container = weakref.ref(container)
+
+    assert _apply_py4j_strong_ref_workaround_if_needed(WeakJavaMember)
+    patched_init = WeakJavaMember.__init__
+
+    assert not _apply_py4j_strong_ref_workaround_if_needed(WeakJavaMember)
+    assert WeakJavaMember.__init__ is patched_init
+
+
+def test_py4j_upstream_strong_container_is_unchanged():
+    class StrongJavaMember:
+        def __init__(self, name, container, target_id, gateway_client):
+            self.container = container
+
+    original_init = StrongJavaMember.__init__
+
+    assert not _apply_py4j_strong_ref_workaround_if_needed(StrongJavaMember)
+    assert StrongJavaMember.__init__ is original_init

--- a/integration_tests/src/main/python/py4j_workaround_test.py
+++ b/integration_tests/src/main/python/py4j_workaround_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import logging
 import weakref
 
 from spark_init_internal import (
@@ -25,10 +26,14 @@ class _Container:
     pass
 
 
-def test_py4j_chained_temporary_container_call():
+def test_py4j_chained_scala_map_get():
     spark = get_spark_i_know_what_i_am_doing()
+    scala_map = spark.conf._jconf.getAll()
+    keys = scala_map.keys().iterator()
 
-    assert spark._jvm.java.util.Collections.emptyList().size() == 0
+    assert keys.hasNext()
+    key = keys.next()
+    assert scala_map.get(key).get() == scala_map.apply(key)
 
 
 def test_py4j_weak_container_is_replaced_with_strong_reference():
@@ -68,3 +73,16 @@ def test_py4j_upstream_strong_container_is_unchanged():
 
     assert not _apply_py4j_strong_ref_workaround_if_needed(StrongJavaMember)
     assert StrongJavaMember.__init__ is original_init
+
+
+def test_py4j_probe_failure_skips_workaround(caplog):
+    class FailingJavaMember:
+        def __init__(self, name, container, target_id, gateway_client):
+            raise RuntimeError('probe failed')
+
+    original_init = FailingJavaMember.__init__
+    with caplog.at_level(logging.ERROR):
+        assert not _apply_py4j_strong_ref_workaround_if_needed(FailingJavaMember)
+
+    assert FailingJavaMember.__init__ is original_init
+    assert 'continuing without the temporary integration-test workaround' in caplog.text

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import os
 import pytest
 import re
 import stat
 import traceback
+import weakref
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -54,6 +56,52 @@ spark_jars_env = {
 # Initialized in pytest_sessionstart; declared here so pytest_sessionfinish
 # does not raise NameError if session startup fails before assignment.
 _spark = None
+
+_PY4J_STRONG_REF_WORKAROUND_MARKER = '_spark_rapids_strong_ref_workaround'
+
+
+def _java_member_uses_weak_container(java_member_class):
+    class _ProbeContainer:
+        pass
+
+    class _ProbeGatewayProperty:
+        pool = None
+
+    class _ProbeGatewayClient:
+        gateway_property = _ProbeGatewayProperty()
+        converters = ()
+
+    container = _ProbeContainer()
+    member = java_member_class(
+        '_spark_rapids_container_lifetime_probe', container, 'o0', _ProbeGatewayClient())
+    return isinstance(member.container, weakref.ReferenceType)
+
+
+def _apply_py4j_strong_ref_workaround_if_needed(java_member_class=None):
+    """Restore upstream JavaMember container lifetime semantics when needed."""
+    if java_member_class is None:
+        from py4j.java_gateway import JavaMember
+        java_member_class = JavaMember
+
+    original_init = java_member_class.__init__
+    if getattr(original_init, _PY4J_STRONG_REF_WORKAROUND_MARKER, False):
+        return False
+    if not _java_member_uses_weak_container(java_member_class):
+        return False
+
+    @functools.wraps(original_init)
+    def strong_ref_init(self, name, container, target_id, gateway_client):
+        original_init(self, name, container, target_id, gateway_client)
+        if isinstance(self.container, weakref.ReferenceType):
+            self.container = container
+
+    setattr(strong_ref_init, _PY4J_STRONG_REF_WORKAROUND_MARKER, True)
+    java_member_class.__init__ = strong_ref_init
+    logging.warning(
+        "Detected weak Py4J JavaMember container references; applying the temporary "
+        "strong-reference workaround for https://github.com/NVIDIA/cudf-spark/issues/15805")
+    return True
+
 
 def findspark_init():
     import findspark
@@ -119,6 +167,10 @@ def pytest_sessionstart(session):
 
     import pyspark
     from py4j.java_gateway import java_import
+
+    # Dataproc 2.2.86 can delete temporary JVM targets before chained Py4J calls complete.
+    # Keep this before SparkSession creation. The behavior probe makes it a no-op for upstream Py4J.
+    _apply_py4j_strong_ref_workaround_if_needed()
 
     # Force the RapidsPlugin to be enabled, so it blows up if the classpath is not set properly
     # DO NOT SET ANY OTHER CONFIGS HERE!!!

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -78,7 +78,7 @@ def _java_member_uses_weak_container(java_member_class):
 
 
 def _apply_py4j_strong_ref_workaround_if_needed(java_member_class=None):
-    """Restore upstream JavaMember container lifetime semantics when needed."""
+    """Restore upstream JavaMember container lifetime semantics in this IT process."""
     if java_member_class is None:
         from py4j.java_gateway import JavaMember
         java_member_class = JavaMember
@@ -86,7 +86,14 @@ def _apply_py4j_strong_ref_workaround_if_needed(java_member_class=None):
     original_init = java_member_class.__init__
     if getattr(original_init, _PY4J_STRONG_REF_WORKAROUND_MARKER, False):
         return False
-    if not _java_member_uses_weak_container(java_member_class):
+    try:
+        uses_weak_container = _java_member_uses_weak_container(java_member_class)
+    except Exception:
+        logging.exception(
+            "Could not probe Py4J JavaMember container lifetime; continuing without the "
+            "temporary integration-test workaround")
+        return False
+    if not uses_weak_container:
         return False
 
     @functools.wraps(original_init)
@@ -99,7 +106,8 @@ def _apply_py4j_strong_ref_workaround_if_needed(java_member_class=None):
     java_member_class.__init__ = strong_ref_init
     logging.warning(
         "Detected weak Py4J JavaMember container references; applying the temporary "
-        "strong-reference workaround for https://github.com/NVIDIA/cudf-spark/issues/15805")
+        "integration-test strong-reference workaround for the missing-target failures in "
+        "https://github.com/NVIDIA/cudf-spark/issues/15805")
     return True
 
 
@@ -170,7 +178,12 @@ def pytest_sessionstart(session):
 
     # Dataproc 2.2.86 can delete temporary JVM targets before chained Py4J calls complete.
     # Keep this before SparkSession creation. The behavior probe makes it a no-op for upstream Py4J.
-    _apply_py4j_strong_ref_workaround_if_needed()
+    try:
+        _apply_py4j_strong_ref_workaround_if_needed()
+    except Exception:
+        logging.exception(
+            "Could not initialize the temporary Py4J integration-test workaround; "
+            "continuing without it")
 
     # Force the RapidsPlugin to be enabled, so it blows up if the classpath is not set properly
     # DO NOT SET ANY OTHER CONFIGS HERE!!!


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — current nightly baseline artifacts were not applied; all JVM production modules are N/A for this Python-only integration-test harness change.**

Refs #15805.

### Description

Dataproc 2.2.86 changes Py4J's `JavaMember.container` from an upstream strong reference to a weak reference. A temporary `JavaObject` can therefore be finalized, and its JVM target deleted, before a chained call such as `scala_map.get(key).get()` reaches `JavaMember.__call__`.

This process-local workaround follows the runtime patch recommended by the Google Cloud Dataproc support team in Customer Care case `74970097` (P2): restore the upstream strong-reference behavior while their internal investigation continues. The support case link is intentionally omitted; please contact me offline if the exact link is needed.

The change applies only to the cudf-spark integration-test process before `SparkSession` creation; it is not a Dataproc/Py4J platform fix and does not change the cudf-spark product JAR. It probes the installed `JavaMember` behavior with an inert container and installs the wrapper only when the container is actually stored as a weak reference. The wrapper is idempotent, and probe or initialization failures are logged without aborting the pytest worker. Standard upstream Py4J remains unmodified.

Scope: this covers the Py4J missing-target failure family described in #15805. It does not address the separate ORC boolean-encoding signal reported on the same issue.

The regression tests cover the actual `scala_map.get(key).get()` call shape used by the test harness, strong-reference retention after garbage collection, idempotent installation, the upstream no-op path, and fail-open behavior when the probe cannot run. This is a driver-side Py4J lifetime path rather than a Spark query: CPU and GPU session helpers share the same SparkSession and gateway and only toggle RAPIDS SQL configuration, so the focused test intentionally exercises the failing chained call directly instead of introducing an unrelated query or execution-plan assertion.

Review focus: whether behavior-based detection is the right temporary boundary while Dataproc owns the permanent platform fix.

Validation completed locally:

- `python3 -m py_compile` for both changed Python files.
- Standalone helper regression tests: `4 passed, 1 deselected in 0.04s`.
- Spark 3.5.3, Python 3.12.3, Py4J 0.10.9.7, four xdist workers, upstream Py4J: `5 passed in 25.74s`.
- The same Spark/Python/xdist run with the Dataproc weak-container behavior injected into a temporary Py4J copy: `5 passed in 22.97s`.
- `git diff --check`.

AI assistance: The change and PR description were prepared with Codex assistance.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
