### PR TITLE
Update dependencies for renamed cudf-spark-private artifacts

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -86,7 +86,7 @@ jobs:
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
 
           # get private artifact version
-          privateVer=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-private.version -DforceStdout)
+          privateVer=$(mvn help:evaluate -q -pl dist -Dexpression=cudf-spark-private.version -DforceStdout)
           # do not add empty snapshot versions or when private version is released one (does not include snapshot shims)
           if [[ ${#SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]} -gt 0 && $privateVer == *"-SNAPSHOT" ]]; then
             svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
@@ -204,7 +204,7 @@ jobs:
           svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
           # get private artifact version
-          privateVer=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-private.version -DforceStdout)
+          privateVer=$(mvn help:evaluate -q -pl dist -Dexpression=cudf-spark-private.version -DforceStdout)
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot)
 
           echo "scala213Versions=$svJsonStr" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check/get-deps-sha1.sh
+++ b/.github/workflows/mvn-verify-check/get-deps-sha1.sh
@@ -22,7 +22,7 @@ project_jni="spark-rapids-jni"
 project_private="cudf-spark-private_${scala_ver}"
 
 jni_ver=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-jni.version -DforceStdout)
-private_ver=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-private.version -DforceStdout)
+private_ver=$(mvn help:evaluate -q -pl dist -Dexpression=cudf-spark-private.version -DforceStdout)
 
 get_latest_snapshot_version() {
   local project_URL="$1"

--- a/.github/workflows/mvn-verify-check/get-deps-sha1.sh
+++ b/.github/workflows/mvn-verify-check/get-deps-sha1.sh
@@ -19,7 +19,7 @@ set -e
 scala_ver=${1:-"2.12"}
 base_URL="https://central.sonatype.com/repository/maven-snapshots/com/nvidia"
 project_jni="spark-rapids-jni"
-project_private="rapids-4-spark-private_${scala_ver}"
+project_private="cudf-spark-private_${scala_ver}"
 
 jni_ver=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-jni.version -DforceStdout)
 private_ver=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-private.version -DforceStdout)

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
-            <version>${spark-rapids-private.version}</version>
+            <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>
         <!--

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
             <version>${spark-rapids-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1061,7 +1061,7 @@
         <cuda.version>cuda12</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>26.10.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>26.10.0-SNAPSHOT</spark-rapids-private.version>
+        <cudf-spark-private.version>26.10.0-SNAPSHOT</cudf-spark-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.21</scala.version>

--- a/scala2.13/aggregator/pom.xml
+++ b/scala2.13/aggregator/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
-            <version>${spark-rapids-private.version}</version>
+            <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>
         <!--

--- a/scala2.13/aggregator/pom.xml
+++ b/scala2.13/aggregator/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
             <version>${spark-rapids-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1061,7 +1061,7 @@
         <cuda.version>cuda12</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>26.10.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>26.10.0-SNAPSHOT</spark-rapids-private.version>
+        <cudf-spark-private.version>26.10.0-SNAPSHOT</cudf-spark-private.version>
         <scala.binary.version>2.13</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.13.18</scala.version>

--- a/scala2.13/sql-plugin/pom.xml
+++ b/scala2.13/sql-plugin/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
-            <version>${spark-rapids-private.version}</version>
+            <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>
         <dependency>

--- a/scala2.13/sql-plugin/pom.xml
+++ b/scala2.13/sql-plugin/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
             <version>${spark-rapids-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
-            <version>${spark-rapids-private.version}</version>
+            <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>
         <dependency>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
             <version>${spark-rapids-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -84,7 +84,7 @@ object RapidsPluginUtils extends Logging {
   val CUDF_PROPS_FILENAME = "cudf-java-version-info.properties"
   val JNI_PROPS_FILENAME = "spark-rapids-jni-version-info.properties"
   val PLUGIN_PROPS_FILENAME = "rapids4spark-version-info.properties"
-  private val PRIVATE_PROPS_FILENAME = "rapids4spark-private-version-info.properties"
+  private val PRIVATE_PROPS_FILENAME = "cudf-spark-private-version-info.properties"
 
   private val SQL_PLUGIN_NAME = classOf[SQLExecPlugin].getName
   private val UDF_PLUGIN_NAME = "com.nvidia.spark.udf.Plugin"


### PR DESCRIPTION
Issue: part of https://github.com/NVIDIA/cudf-spark/issues/15882.


This change updates the Scala 2.12 and Scala 2.13 private-plugin Maven coordinates from `rapids-4-spark-private_*` to `cudf-spark-private_*`, renames the corresponding Maven version property,
updates CI dependency-cache lookup paths, and loads private build metadata from cudf-spark-private-version-info.properties. 

The dependency contents  and Spark execution paths are unchanged.

Performance testing is not required because this changes dependency coordinates and metadata resource naming only; no Spark execution or GPU processing path changes.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required