### PR TITLE
[DOC] apply rename follow-ups on main [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ If you want to create a jar with multiple versions we have the following options
 
 1. Build for all Apache Spark versions and CDH with no SNAPSHOT versions of Spark, only released. Use `-PnoSnapshots`.
 2. Build for all Apache Spark versions and CDH including SNAPSHOT versions of Spark we have supported for. Use `-Psnapshots`.
-3. Build for all Apache Spark versions, CDH and Databricks with no SNAPSHOT versions of Spark, only released. Use `-PnoSnaphsotsWithDatabricks`.
+3. Build for all Apache Spark versions, CDH and Databricks with no SNAPSHOT versions of Spark, only released. Use `-PnoSnapshotsWithDatabricks`.
 4. Build for all Apache Spark versions, CDH and Databricks including SNAPSHOT versions of Spark we have supported for. Use `-PsnapshotsWithDatabricks`
 5. Build for an arbitrary combination of comma-separated build versions using `-Dincluded_buildvers=<CSV list of build versions>`.
    E.g., `-Dincluded_buildvers=330,331`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NVIDIA cuDF plugin for Apache Spark
-NOTE: For the latest stable [README.md](https://github.com/nvidia/cudf-spark/blob/main/README.md) ensure you are on the main branch.
+NOTE: For the latest stable [README.md](https://github.com/NVIDIA/cudf-spark/blob/main/README.md) ensure you are on the main branch.
 
 The NVIDIA cuDF plugin for [Apache Spark](https://spark.apache.org) provides a plugin library that
-leverages GPUs to accelerate processing via the [cuDF](https://github.com/rapidsai/cudf) (CUDA
+leverages GPUs to accelerate processing via the [cuDF](https://github.com/NVIDIA/cudf) (CUDA
 DataFrame) libraries.
 
 Documentation on the current release can be found [here](https://nvidia.github.io/cudf-spark/).
@@ -12,7 +12,7 @@ To get started and try the plugin out use the [getting started guide](https://do
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/cudf-spark)
 
 Note: The NVIDIA cuDF plugin for Apache Spark was formerly known as the RAPIDS Accelerator for
-Apache Spark.  The RAPIDS name will be sunset over time.  Github links from `spark-rapids` will
+Apache Spark.  The RAPIDS name will be sunset over time.  GitHub links from `spark-rapids` will
 redirect to `cudf-spark`.  Artifact names will remain the same for now.
 
 ## Compatibility
@@ -62,8 +62,8 @@ access to any of the memory that RMM is holding.
 
 ## Qualification and Profiling tools
 
-The Qualification and Profiling tools have been moved to
-[nvidia/spark-rapids-tools](https://github.com/NVIDIA/spark-rapids-tools) repo.
+The Qualification and Profiling tools are available in the
+[NVIDIA/cudf-spark-tools](https://github.com/NVIDIA/cudf-spark-tools) repository.
 
 Please refer to [Qualification tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/qualification/overview.html)
 and [Profiling tool documentation](https://docs.nvidia.com/spark-rapids/user-guide/latest/profiling/overview.html)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,8 +20,8 @@ remote_theme: pmarsceill/just-the-docs
 aux_links:
   "NVIDIA cuDF plugin for Apache Spark User Guide":
     - "//docs.nvidia.com/spark-rapids/user-guide/latest/index.html"
-  "NVIDIA cuDF plugin for Apache Spark on Github":
-    - "//github.com/nvidia/cudf-spark"
+  "NVIDIA cuDF plugin for Apache Spark on GitHub":
+    - "//github.com/NVIDIA/cudf-spark"
 
 plugins:
   - jekyll-optional-front-matter # GitHub Pages


### PR DESCRIPTION
Contributes to #15107.

### Description

Backports the applicable review follow-ups from #15874 to `main` so the source documentation remains consistent with the `gh-pages` copies.

Changes include:
- Use canonical `NVIDIA` capitalization in GitHub repository URLs and spell `GitHub` consistently.
- Describe the Qualification and Profiling tools by their current location in `NVIDIA/cudf-spark-tools`.
- Correct `-PnoSnaphsotsWithDatabricks` to `-PnoSnapshotsWithDatabricks` in the contributor build instructions.

The `gh-pages`-specific absolute links for source-only files are intentionally excluded because relative links are valid in the `main` repository tree.

Validation:
- `git diff --check`
- IDE lints on all modified files
- Verified the three canonical GitHub links return HTTP 200
- Audited the modified files for the stale URLs, wording, and Maven profile typo

`[skip ci]` because this changes documentation and static site metadata only.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required