### PR TITLE
[BUG] Mock ParquetTableWriter in CachedBatchWriterSuite [reduced-it]

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -49,6 +49,13 @@ def get_orc_timestamp_gen(nullable=True):
 
 orc_timestamp_gen = get_orc_timestamp_gen()
 
+# The range get_orc_timestamp_gen covered before it was bounded to 1901. Kept so the
+# dropped coverage stays visible and is easy to restore: once the Local Mean Time
+# conversion defect is fixed, delete this generator and the skipped test that uses it,
+# and move get_orc_timestamp_gen back to 1590.
+def get_orc_pre_standard_time_timestamp_gen(nullable=True):
+    return TimestampGen(start=datetime(1590, 1, 1, tzinfo=timezone.utc), nullable=nullable)
+
 # test with original orc file reader, the multi-file parallel reader for cloud
 __original_orc_file_reader_conf = {'spark.rapids.sql.format.orc.reader.type': 'PERFILE'}
 __multithreaded_orc_file_reader_conf = {'spark.rapids.sql.format.orc.reader.type': 'MULTITHREADED',
@@ -205,6 +212,27 @@ def test_orc_fallback(spark_tmp_path, read_func, disable_conf):
 @tz_sensitive_test
 def test_read_round_trip(spark_tmp_path, orc_gens, read_func, reader_confs, v1_enabled_list):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(orc_gens)]
+    data_path = spark_tmp_path + '/ORC_DATA'
+    with_cpu_session(
+            lambda spark : gen_df(spark, gen_list).write.orc(data_path))
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    assert_gpu_and_cpu_are_equal_collect(
+            read_func(data_path),
+            conf=all_confs)
+
+# Covers the pre-1901 timestamps that get_orc_timestamp_gen no longer generates.
+# Expected to fail today: GPU and CPU disagree on Local Mean Time offsets, which apply
+# to a time zone before it adopted standard time. Remove the skip once that is fixed.
+@pytest.mark.skip(reason="https://github.com/NVIDIA/cudf-spark/issues/15895")
+@pytest.mark.order(2)
+@pytest.mark.parametrize('read_func', [read_orc_df, read_orc_sql])
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+@pytest.mark.parametrize('v1_enabled_list', ['', 'orc'])
+@tz_sensitive_test
+def test_read_round_trip_pre_standard_time_timestamps(spark_tmp_path, read_func, reader_confs,
+                                                      v1_enabled_list):
+    gen_list = [('_c0', get_orc_pre_standard_time_timestamp_gen()),
+                ('_c1', ArrayGen(get_orc_pre_standard_time_timestamp_gen()))]
     data_path = spark_tmp_path + '/ORC_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.orc(data_path))

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -33,11 +33,19 @@ def read_orc_df(data_path):
 def read_orc_sql(data_path):
     return lambda spark : spark.sql('select * from orc.`{}`'.format(data_path))
 
-# Using timestamps from 1590 to work around a cudf ORC bug
-# https://github.com/NVIDIA/spark-rapids/issues/131.
-# Once the bug is fixed we should remove this and use timestamp_gen.
+# Timestamps are limited to 1901 and later for two separate reasons:
+#  * a cudf ORC bug, https://github.com/NVIDIA/spark-rapids/issues/131, which is why this
+#    helper starts at a fixed date at all instead of using timestamp_gen;
+#  * GPU and CPU disagree on Local Mean Time offsets, which apply to a zone before it
+#    adopted standard time. Premerge runs the tz_sensitive_test cases under
+#    America/New_York (LMT until 1883-11-18) and Asia/Shanghai (LMT until 1901), so
+#    starting at 1901-01-01 keeps generated timestamps clear of both windows.
+#    Note this bound does not eliminate the problem for nightly runs, which rotate
+#    through every time zone; a few kept LMT offsets far later, Africa/Monrovia until
+#    1972 being the latest. The real fix is the underlying LMT conversion defect.
+# Once both are fixed we should remove this and use timestamp_gen.
 def get_orc_timestamp_gen(nullable=True):
-    return TimestampGen(start=datetime(1590, 1, 1, tzinfo=timezone.utc), nullable=nullable)
+    return TimestampGen(start=datetime(1901, 1, 1, tzinfo=timezone.utc), nullable=nullable)
 
 orc_timestamp_gen = get_orc_timestamp_gen()
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.collection.mutable
 
-import ai.rapids.cudf.{ColumnVector, CompressionType, DType, Rmm, Table, TableWriter}
+import ai.rapids.cudf.{ColumnVector, CompressionType, DType, ParquetTableWriter, Rmm, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableFromBatchColumns
 import com.nvidia.spark.rapids.parquet.{ParquetCachedBatchSerializer, ParquetOutputFileFormat}
@@ -355,7 +355,7 @@ class CachedBatchWriterSuite extends SparkQueryCompareTestSuite {
      gpuCols: Array[org.apache.spark.sql.vectorized.ColumnVector], splitAt: Int*): Unit = {
     // mock static method for Table
     val theTableMock = mockStatic(classOf[Table], (_: InvocationOnMock) => {
-      val ret = mock(classOf[TableWriter])
+      val ret = mock(classOf[ParquetTableWriter])
       doAnswer( invocation =>
         checkSize(invocation.getArgument(0, classOf[Table]))
       ).when(ret).write(isA(classOf[Table]))


### PR DESCRIPTION
Fixes #15888 
Contributes to #15895

cuDF NVIDIA/cudf#23912 narrowed the static `Table.writeParquetChunked` overloads from `TableWriter` to the new `public final ParquetTableWriter`. Production code absorbed this fine, but the blanket `mockStatic(classOf[Table], ...)` default answer in `testCompressColBatch` always returns a `TableWriter` mock, and Mockito validates the returned value against the invoked method's declared return type. Both large-batch tests fail with `WrongTypeOfReturnValue`, which fails the whole `rapids-4-spark-tests` module and blocks premerge for every PR in the repo.

### Another intermittent failure is addressed here:

GPU and CPU disagree on Local Mean Time offsets, which apply to a time zone
before it adopted standard time. When the data generator happens to produce a
timestamp inside one of those windows, ORC round-trip tests fail with a value
mismatch equal to the zone's LMT-to-standard-time offset difference.

Observed with DATAGEN_SEED=1788463960 under TZ=America/New_York: a generated
value at 1883-11-18 15:48 produced a 238 second GPU/CPU delta, exactly the
America/New_York LMT (UTC-04:56:02) versus EST (UTC-05:00:00) difference. It
failed 62 parameterizations of orc_test.py::test_read_round_trip and
test_read_round_trip_for_multithreaded_combining, all from that single value.

Raise get_orc_timestamp_gen's lower bound from 1590 to 1901, which clears the
LMT windows of both time zones premerge exercises (America/New_York, 1883;
Asia/Shanghai, 1901). This follows the existing precedent of bounding this
generator for a known cuDF ORC bug rather than disabling the tests, and keeps
all pre-epoch coverage from 1901 onward.

This does not fix the underlying defect tracked by #15895, and does not cover
nightly runs, which rotate through every time zone; some retained LMT offsets
much later, Africa/Monrovia until 1972 being the latest.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
