### PR TITLE
[AutoSparkUT] Recover ORC legacy date read coverage [fast-ut] [databricks]

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -257,9 +257,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("Write Spark version into ORC file metadata",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15468. " +
         "Recovery trigger: GPU ORC files include Spark version metadata; P1."))
-    .exclude("SPARK-31238: compatibility with Spark 2.4 in reading dates",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15470. " +
-        "Recovery trigger: GPU ORC legacy date rebasing matches Spark CPU; P0."))
     .exclude("SPARK-31284: compatibility with Spark 2.4 in reading timestamps",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15471. " +
         "Recovery trigger: GPU ORC legacy timestamp reads match Spark CPU; P0."))
@@ -281,9 +278,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("Write Spark version into ORC file metadata",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15468. " +
         "Recovery trigger: GPU ORC files include Spark version metadata; P1."))
-    .exclude("SPARK-31238: compatibility with Spark 2.4 in reading dates",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15470. " +
-        "Recovery trigger: GPU ORC legacy date rebasing matches Spark CPU; P0."))
     .exclude("SPARK-31284: compatibility with Spark 2.4 in reading timestamps",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15471. " +
         "Recovery trigger: GPU ORC legacy timestamp reads match Spark CPU; P0."))


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — the available 26.10 nightly tuple is Scala 2.12/shim 350 (`d2f4fe24`, b19), while `RapidsOrcSourceV1Suite` and `RapidsOrcSourceV2Suite` are shim-330-only and execute 0 tests under shim 350; measured modules: none; N/A: `sql-plugin` (no compatible shim-330 nightly baseline).**

Contributes to #15470.

### Description

#15470 tracked a GPU/CPU correctness mismatch when reading a Spark 2.4 legacy ORC DATE: GPU returned `1200-01-08` while Spark CPU returned `1200-01-01`. PR #15496 fixed the production ORC calendar-rebasing path, but the inherited Spark test remained excluded from both migrated Spark 3.3 suites.

This change removes the two stale exclusions from `RapidsOrcSourceV1Suite` and `RapidsOrcSourceV2Suite`. The original Spark test semantics and expected value are unchanged:

- RAPIDS test: `SPARK-31238: compatibility with Spark 2.4 in reading dates`
- Spark source: [`OrcSourceSuite.scala` lines 488-494](https://github.com/apache/spark/blob/f74867bddfbcdd4d08076db36851e88b15e66556/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala#L488-L494)

Focused GPU validation after rebasing onto current `main` (`e313d91fdbc22039c360ef69da662df0c5b26f05`):

```text
Tests: succeeded 54, failed 0, canceled 0, ignored 14, pending 0
BUILD SUCCESS
```

Both recovered V1/V2 cases completed successfully. No production code or expected values were changed.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
