### PR TITLE
[AutoSparkUT] Fix map_zip_with lambda result nullability [fast-ut] [databricks]

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-from py4j.protocol import Py4JJavaError
 
 from asserts import *
 from conftest import is_not_utc
@@ -45,11 +44,6 @@ maps_with_struct_key = [
     MapGen(StructGen([['child0', IntegerGen()],
                       ['child1', IntegerGen()]], nullable=False),
            IntegerGen())]
-
-
-# Keep the xfail limited to issue #15783 so plan-validation failures still propagate.
-class _MapZipWithDecimalKnownIssue(Exception):
-    pass
 
 
 supported_key_map_gens = \
@@ -922,10 +916,6 @@ def test_map_zip_with_decimal_non_identity(data_gen):
     MapGen(DecimalGen(20, 2, nullable=False),
            DecimalGen(20, 2, nullable=False), nullable=False),
 ], ids=idfn)
-@pytest.mark.xfail(
-    reason='https://github.com/NVIDIA/cudf-spark/issues/15783',
-    raises=_MapZipWithDecimalKnownIssue,
-    strict=True)
 @validate_execs_in_gpu_plan('GpuProjectExec')
 @allow_non_gpu(*non_utc_allow)
 def test_map_zip_with_decimal_identity(data_gen):
@@ -935,25 +925,7 @@ def test_map_zip_with_decimal_identity(data_gen):
             'map_zip_with(a, b, (key, value1, value2) -> value1) as ident1',
             'map_zip_with(a, b, (key, value1, value2) -> value2) as ident2')
 
-    try:
-        assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
-    except AssertionError as error:
-        message = str(error)
-        is_known_decimal_failure = (
-            'CPU (null) values are different at ' in message
-            and ("'ident1'" in message or "'ident2'" in message))
-        if is_known_decimal_failure:
-            raise _MapZipWithDecimalKnownIssue() from error
-        raise
-    except Py4JJavaError as error:
-        message = str(error)
-        is_known_decimal_failure = (
-            'java.lang.AssertionError:' in message
-            and 'value at ' in message
-            and ' is null' in message)
-        if is_known_decimal_failure:
-            raise _MapZipWithDecimalKnownIssue() from error
-        raise
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(False, min_val=-5, max_val=5), ArrayGen(int_gen, max_length=5), min_length=7)], ids=idfn)
 @allow_non_gpu(*non_utc_allow)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -1071,14 +1071,13 @@ case class GpuMapZipWith(
     boundIntermediate: Seq[GpuExpression] = Seq.empty)
     extends GpuMapTwoArgumentHigherOrderFunction {
 
-  @transient lazy val MapType(keyType1, valueType1, valueContainsNull1) = argument1.dataType
-  @transient lazy val MapType(keyType2, valueType2, valueContainsNull2) = argument2.dataType
+  @transient lazy val MapType(keyType1, _, _) = argument1.dataType
+  @transient lazy val MapType(keyType2, _, _) = argument2.dataType
 
   @transient lazy val keyType =
     TypeCoercion.findCommonTypeDifferentOnlyInNullFlags(keyType1, keyType2).get
 
-  override def dataType: DataType = MapType(keyType, function.dataType, 
-    valueContainsNull1 || valueContainsNull2)
+  override def dataType: DataType = MapType(keyType, function.dataType, function.nullable)
 
   override def prettyName: String = "map_zip_with"
 


### PR DESCRIPTION
**JaCoCo production line coverage: +3 lines** (`sql-plugin +3`; shim 350, fix-line intersection from the seed-0 regression)

Fixes #15783.
Contributes to #15896.

### Description

`GpuMapZipWith` derived the result map's `valueContainsNull` flag from the two input maps. Spark derives it from `function.nullable`: when the input maps have different key sets, either lambda value argument can be null even if both input map value types are declared non-null. The old GPU schema could therefore declare a nullable lambda result as non-null and produce wrong results.

This change makes the GPU result type follow the lambda's nullability contract and removes the strict xfail from the Decimal identity regression. The focused regressions also require `GpuProjectExec`, so their successful GPU/CPU comparison proves that the repaired expression executed on GPU.

Performance impact: none expected. This only changes Catalyst output-type metadata during expression planning, replacing an input-map boolean calculation with the already-computed lambda `nullable` flag; it adds no row/batch runtime work, allocation, or GPU kernel.

AI assistance: The change and PR description were prepared with Codex assistance.

Local validation:

- Spark 3.5 integration-test build on upstream base `3580969fb1b47c9c58a04ff4f7daa2b8f56cccef`: 16/16 reactor modules succeeded.
- Focused Decimal identity regression, Spark 3.5, seed 0 with OOM injection: `2 passed`; both Decimal parameterizations were marked `INJECT_OOM`, and `GpuProjectExec` was validated.
- Full `map_test.py`, Spark 3.5, seed 0 without OOM injection: `710 passed, 5 skipped`.
- Scalastyle: 1,843 files processed, 0 errors, 0 warnings; resource-nesting lint unit tests: 20 passed.
- JaCoCo fix-line intersection: 3 of 3 added `sql-plugin` production lines covered.

The exact Dataproc Serverless 2.2 / Scala 2.13 rerun from #15896 is not part of this local validation.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
