### PR TITLE
Fix Spark master GpuGroupPartitionsExec compile after KeyReducer API change[databricks][reduced-it]

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>${cudf-spark-private.artifactId}</artifactId>
             <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -930,7 +930,6 @@
                 <buildver>500</buildver>
                 <spark.version>${spark500.version}</spark.version>
                 <spark.test.version>${spark500.version}</spark.test.version>
-                <!-- Master private jars are a separate artifactId, still classified spark500. -->
                 <cudf-spark-private.artifactId>cudf-spark-private_${scala.binary.version}-spark-master</cudf-spark-private.artifactId>
                 <parquet.hadoop.version>1.15.2</parquet.hadoop.version>
                 <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -930,6 +930,8 @@
                 <buildver>500</buildver>
                 <spark.version>${spark500.version}</spark.version>
                 <spark.test.version>${spark500.version}</spark.test.version>
+                <!-- Master private jars are a separate artifactId, still classified spark500. -->
+                <cudf-spark-private.artifactId>cudf-spark-private_${scala.binary.version}-spark-master</cudf-spark-private.artifactId>
                 <parquet.hadoop.version>1.15.2</parquet.hadoop.version>
                 <maven.compiler.source>17</maven.compiler.source>
                 <java.major.version>17</java.major.version>
@@ -1062,6 +1064,7 @@
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>26.10.0-SNAPSHOT</spark-rapids-jni.version>
         <cudf-spark-private.version>26.10.0-SNAPSHOT</cudf-spark-private.version>
+        <cudf-spark-private.artifactId>cudf-spark-private_${scala.binary.version}</cudf-spark-private.artifactId>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.21</scala.version>

--- a/scala2.13/aggregator/pom.xml
+++ b/scala2.13/aggregator/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>${cudf-spark-private.artifactId}</artifactId>
             <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -930,7 +930,6 @@
                 <buildver>500</buildver>
                 <spark.version>${spark500.version}</spark.version>
                 <spark.test.version>${spark500.version}</spark.test.version>
-                <!-- Master private jars are a separate artifactId, still classified spark500. -->
                 <cudf-spark-private.artifactId>cudf-spark-private_${scala.binary.version}-spark-master</cudf-spark-private.artifactId>
                 <parquet.hadoop.version>1.15.2</parquet.hadoop.version>
                 <maven.compiler.source>17</maven.compiler.source>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -930,6 +930,8 @@
                 <buildver>500</buildver>
                 <spark.version>${spark500.version}</spark.version>
                 <spark.test.version>${spark500.version}</spark.test.version>
+                <!-- Master private jars are a separate artifactId, still classified spark500. -->
+                <cudf-spark-private.artifactId>cudf-spark-private_${scala.binary.version}-spark-master</cudf-spark-private.artifactId>
                 <parquet.hadoop.version>1.15.2</parquet.hadoop.version>
                 <maven.compiler.source>17</maven.compiler.source>
                 <java.major.version>17</java.major.version>
@@ -1062,6 +1064,7 @@
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>26.10.0-SNAPSHOT</spark-rapids-jni.version>
         <cudf-spark-private.version>26.10.0-SNAPSHOT</cudf-spark-private.version>
+        <cudf-spark-private.artifactId>cudf-spark-private_${scala.binary.version}</cudf-spark-private.artifactId>
         <scala.binary.version>2.13</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.13.18</scala.version>

--- a/scala2.13/sql-plugin/pom.xml
+++ b/scala2.13/sql-plugin/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>${cudf-spark-private.artifactId}</artifactId>
             <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>cudf-spark-private_${scala.binary.version}</artifactId>
+            <artifactId>${cudf-spark-private.artifactId}</artifactId>
             <version>${cudf-spark-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsExec.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsExec.scala
@@ -100,8 +100,7 @@ object GpuGroupPartitionsExecInfo {
       groupPartitions.groupedPartitions.map(_._2),
       groupPartitions.joinKeyPositions,
       groupPartitions.expectedPartitionKeys.map(_.size),
-      groupPartitions.reducers.map(
-        _.map(_.map(_.displayName()).getOrElse("identity"))),
+      GpuGroupPartitionsShims.reducerNames(groupPartitions),
       groupPartitions.distributePartitions,
       groupPartitions.enableSortedMerge)
   }

--- a/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsShims.scala
+++ b/sql-plugin/src/main/spark420/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsShims.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "420"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
+
+object GpuGroupPartitionsShims {
+  // Spark 4.2.0 stores connector Reducer values. displayName is on Reducer.
+  def reducerNames(groupPartitions: GroupPartitionsExec): Option[Seq[String]] = {
+    groupPartitions.reducers.map(
+      _.map(_.map(_.displayName()).getOrElse("identity")))
+  }
+}

--- a/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsShims.scala
+++ b/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuGroupPartitionsShims.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "500"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.execution.datasources.v2.GroupPartitionsExec
+
+object GpuGroupPartitionsShims {
+  // SPARK-59045 wraps each Reducer in KeyReducer. displayName stays on the inner Reducer.
+  def reducerNames(groupPartitions: GroupPartitionsExec): Option[Seq[String]] = {
+    groupPartitions.reducers.map(
+      _.map(_.map(_.reducer.displayName()).getOrElse("identity")))
+  }
+}


### PR DESCRIPTION
Fixes #15909.

### Description

Spark master (5.0.0-SNAPSHOT) now wraps SPJ reducers in `KeyReducer` after [SPARK-59045](https://github.com/apache/spark/pull/58451). Shared `GpuGroupPartitionsExec` still called `displayName()` directly on that value, so the spark500 compile failed.

This change keeps the GPU grouping implementation shared for 420/500 and only shims the planner-only reducer display-name snapshot:
- Spark 4.2.0: `Reducer.displayName()`
- Spark 5.0.0-SNAPSHOT: `KeyReducer.reducer.displayName()`

It also resolves Spark master private jars from artifactId `cudf-spark-private_${scala.binary.version}-spark-master` while keeping classifier `spark500`, matching the published snapshot layout.

### Testing

- `scala2.13` `-Dbuildver=420` `sql-plugin` package
- `scala2.13` `-Dbuildver=500` `sql-plugin` package against Spark 5.0.0-SNAPSHOT
- Confirmed 500 compile classpath uses `cudf-spark-private_2.13-spark-master:jar:spark500`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`GroupPartitionsExecSuite` covers GPU grouping / plan summary paths)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required