### PR TITLE
[AutoSparkUT] Spark 3.3 data sources: recover 52 ignored tests [databricks]

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsOrcSchemaPruningSuite.scala
@@ -24,7 +24,6 @@ import com.nvidia.spark.rapids.shims.GpuBatchScanExec
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.orc.{OrcV1SchemaPruningSuite, OrcV2SchemaPruningSuite}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
@@ -38,11 +37,10 @@ class RapidsOrcV1SchemaPruningSuite
   override protected def checkScan(
       df: DataFrame,
       expectedSchemaCatalogStrings: String*): Unit = {
+    df.collect()
     checkScanSchema(df, expectedSchemaCatalogStrings: _*) {
-      case scan: FileSourceScanExec => scan.requiredSchema
       case scan: GpuFileSourceScanExec => scan.requiredSchema
     }
-    df.collect()
   }
 }
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -191,7 +191,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-37371: UnionExec should support columnar if all children support columnar", ADJUST_UT("CPU test uses CPU-specific node checks (InMemoryTableScanExec, UnionExec); GPU version implemented as testRapids() in RapidsDataFrameSetOperationsSuite"))
   enableSuite[RapidsDataFrameRangeSuite]
   enableSuite[RapidsFileBasedDataSourceSuite]
-    .exclude("Enabling/disabling ignoreMissingFiles using orc", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15100"))
     .exclude("SPARK-25237 compute correct input metrics in FileScanRDD", ADJUST_UT("Replaced by testRapids version that checks GpuFileSourceScanExec file metrics and populated Spark input metrics."))
     .exclude("Option recursiveFileLookup: disable partition inferring", ADJUST_UT("Replaced by testRapids version that uses testFile() to expand Spark test resources from the tests jar before reading with binaryFile."))
     .exclude("SPARK-22790,SPARK-27668: spark.sql.sources.compressionFactor takes effect", ADJUST_UT("Replaced by testRapids version that checks file-compression statistics with GpuBroadcastHashJoinExec and GpuShuffledSymmetricHashJoinExec."))
@@ -254,9 +253,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("Propagate Hadoop configs from orc options to underlying file system",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/11602. " +
         "Recovery trigger: GPU ORC writes propagate data-source options; P1."))
-    .exclude("Write Spark version into ORC file metadata",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15468. " +
-        "Recovery trigger: GPU ORC files include Spark version metadata; P1."))
     .exclude("SPARK-31284: compatibility with Spark 2.4 in reading timestamps",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15471. " +
         "Recovery trigger: GPU ORC legacy timestamp reads match Spark CPU; P0."))
@@ -275,9 +271,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("Propagate Hadoop configs from orc options to underlying file system",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/11602. " +
         "Recovery trigger: GPU ORC writes propagate data-source options; P1."))
-    .exclude("Write Spark version into ORC file metadata",
-      KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15468. " +
-        "Recovery trigger: GPU ORC files include Spark version metadata; P1."))
     .exclude("SPARK-31284: compatibility with Spark 2.4 in reading timestamps",
       KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15471. " +
         "Recovery trigger: GPU ORC legacy timestamp reads match Spark CPU; P0."))
@@ -381,7 +374,6 @@ class RapidsTestSettings extends BackendTestSettings {
         "guidance; P1."))
   enableSuite[RapidsFileSourceStrategySuite]
     .exclude("partitioned table - after scan filters", ADJUST_UT("Replaced by testRapids version that checks GpuFilterExec residual filters."))
-    .exclude("[SPARK-16818] partition pruned file scans implement sameResult correctly", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15161"))
   enableSuite[RapidsFileScanSuite]
   enableSuite[RapidsPruneFileSourcePartitionsSuite]
   enableSuite[RapidsDataFrameWindowFunctionsSuite]
@@ -491,44 +483,8 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsOrcV2AggregatePushDownSuite]
     .exclude("nested column: Count(top level column) push down", KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15186"))
 
-  private val orcSchemaPruningModes = Seq(
-    "Spark vectorized reader - without partition data column",
-    "Spark vectorized reader - with partition data column",
-    "Non-vectorized reader - without partition data column",
-    "Non-vectorized reader - with partition data column")
-
-  private val orcComplexReaderFailureReason =
-    KNOWN_ISSUE("https://github.com/NVIDIA/cudf-spark/issues/15179")
-
-  private val orcV1ComplexReaderFailureCases = Seq(
-    "select a single complex field",
-    "select a single complex field and the partition column",
-    "partial schema intersection - select missing subfield",
-    "empty schema intersection",
-    "select one deep nested complex field after join",
-    "select one deep nested complex field after outer join")
-
-  private val orcV1SchemaPruning = enableSuite[RapidsOrcV1SchemaPruningSuite]
-  orcV1ComplexReaderFailureCases.foreach { testName =>
-    orcSchemaPruningModes.foreach { mode =>
-      orcV1SchemaPruning.exclude(s"$mode - $testName", orcComplexReaderFailureReason)
-    }
-  }
-
-  private val orcV2ComplexReaderFailureCases = Seq(
-    "select a single complex field",
-    "select a single complex field and the partition column",
-    "partial schema intersection - select missing subfield",
-    "empty schema intersection",
-    "select one deep nested complex field after join",
-    "select one deep nested complex field after outer join")
-
-  private val orcV2SchemaPruning = enableSuite[RapidsOrcV2SchemaPruningSuite]
-  orcV2ComplexReaderFailureCases.foreach { testName =>
-    orcSchemaPruningModes.foreach { mode =>
-      orcV2SchemaPruning.exclude(s"$mode - $testName", orcComplexReaderFailureReason)
-    }
-  }
+  enableSuite[RapidsOrcV1SchemaPruningSuite]
+  enableSuite[RapidsOrcV2SchemaPruningSuite]
   enableSuite[RapidsRandomSuite]
     .exclude("random", ADJUST_UT("Replaced by testRapids version that considers partitionIndex offset"))
     .exclude("SPARK-9127 codegen with long seed", ADJUST_UT("Replaced by testRapids version that considers partitionIndex offset"))


### PR DESCRIPTION
**JaCoCo production line coverage: +101 lines** (`sql-plugin +101`; shim330 exact local baseline A/B at `9f43ef50bde718f7dd65b48e08589bf3c6029437`; shim330 nightly report unavailable)

Refs #15100, #15161, #15179, and #15468.

### Description

The production fixes for four closed issues are already on `main`, but the corresponding inherited Spark 3.3 tests remained excluded. This change removes those stale exclusions and recovers 52 test instances without changing production code.

The V1 ORC schema-pruning helper now executes the DataFrame before inspecting its plan and accepts only `GpuFileSourceScanExec`. This inspects the final AQE plan instead of its pre-execution CPU plan and prevents the recovered V1 cases from passing through CPU fallback. The V2 helper was already GPU-only.

AI assistance: The change and PR description were prepared with Codex assistance and reviewed by the author before submission.

#### Scope and traceability

| Issue / merged fix | Recovered coverage | Spark 3.3 source |
| --- | ---: | --- |
| #15100 / #15103 | 1 instance in `RapidsFileBasedDataSourceSuite`: `Enabling/disabling ignoreMissingFiles using orc` | [`FileBasedDataSourceSuite.scala` L182-L234](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala#L182-L234) |
| #15161 / #15162 | 1 instance in `RapidsFileSourceStrategySuite`: `[SPARK-16818] partition pruned file scans implement sameResult correctly` | [`FileSourceStrategySuite.scala` L420-L441](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala#L420-L441) |
| #15179 / #15210 | 48 instances in `RapidsOrcV1SchemaPruningSuite` and `RapidsOrcV2SchemaPruningSuite`: 6 nested-pruning cases x 4 reader modes x 2 suites | [`SchemaPruningSuite.scala` L148-L224](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala#L148-L224), [L445-L486](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala#L445-L486), and [mode expansion L650-L672](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala#L650-L672) |
| #15468 / #15505 | 2 instances in `RapidsOrcSourceV1Suite` and `RapidsOrcSourceV2Suite`: `Write Spark version into ORC file metadata` | [`OrcSourceSuite.scala` L370-L385](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala#L370-L385) |

#### Validation

- Spark 3.3 CPU originals: `Tests: succeeded 491, failed 0, canceled 0, ignored 2, pending 0`; `All tests passed.`
- Baseline GPU run at the same base: `Tests: succeeded 429, failed 0, canceled 0, ignored 70, pending 0`; `BUILD SUCCESS`.
- Final six-suite GPU run: `Tests: succeeded 481, failed 0, canceled 0, ignored 18, pending 0`; `All tests passed.`; `BUILD SUCCESS`.
- Recovery delta: 52 additional executed test instances and 52 fewer ignored instances.
- Full V1 schema-pruning suite with post-execution GPU-only scan validation: `Tests: succeeded 174, failed 0, canceled 0, ignored 0, pending 0`; `BUILD SUCCESS`.
- NT local review gate: 6 independent reviewer passes, 0 findings.
- JaCoCo used identical shim330 production bytecode with no class-ID mismatch: `sql-plugin` 23,933/70,468 to 24,034/70,468 covered lines (+101). `shuffle-plugin`, `udf-compiler`, `iceberg`, and Delta 2.1/2.2/2.3 were also measured and each changed by 0 lines. The published nightly report is shim350-only, so this PR uses an exact local shim330 A/B anchored at the base SHA above.

#### Audited but not recovered

- #15472 remains excluded: both inherited V1 and V2 cases still fail with `ai.rapids.cudf.CudfException: Child columns must have the same number of rows as the Struct column`.
- #11416 and #14172 already have GPU-aware replacement coverage; their CPU-specific originals remain intentionally excluded.
- #15452 is a migration tracker rather than a product-fix closure, so its exclusions were not treated as fixed.
- All other closed issue references still present in `RapidsTestSettings.scala` are already categorized as `ADJUST_UT` or `WONT_FIX_ISSUE` with GPU-aware replacement coverage or CPU/implementation-specific contracts; they are not stale `KNOWN_ISSUE` exclusions.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
