### PR TITLE
Add Delta column-mapping predicate coverage with deletion vectors [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 import pytest
 from pyspark.sql import Row
 from asserts import assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_collect, \
@@ -940,6 +942,74 @@ def test_delta_read_column_mapping(spark_tmp_path, reader_confs, mapping, enable
     with_cpu_session(create_delta, conf=confs)
     assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.read.format("delta").load(data_path),
                                          conf=confs)
+
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(is_databricks_runtime(), reason="OSS Delta column-mapping scan path")
+@pytest.mark.skipif(not gpu_supports_delta_dv_scan(),
+                    reason="GPU Delta deletion vector scan support is required")
+def test_delta_column_mapping_predicate_pushdown_with_deletion_vector(spark_tmp_path):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    cpu_path = data_path + "/CPU"
+    gpu_path = data_path + "/GPU"
+    conf = {
+        "spark.databricks.delta.properties.defaults.columnMapping.mode": "name",
+        "spark.databricks.delta.properties.defaults.minReaderVersion": "2",
+        "spark.databricks.delta.properties.defaults.minWriterVersion": "5",
+        "spark.databricks.delta.properties.defaults.enableDeletionVectors": "true",
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.sql.parquet.fieldId.read.enabled": "true",
+        "spark.rapids.sql.format.parquet.reader.type": "PERFILE",
+    }
+
+    def setup_table(spark, path):
+        spark.createDataFrame(
+            [(0, None), (1, "one"), (2, None), (3, "three"), (4, "four")],
+            ["id", "payload"]) \
+            .write.format("delta").mode("overwrite").save(path)
+        deleted = spark.sql(
+            f"DELETE FROM delta.`{path}` WHERE id = 4").collect()[0][0]
+        assert deleted == 1
+
+    with_cpu_session(lambda spark: setup_table(spark, cpu_path), conf=conf)
+    with_cpu_session(lambda spark: setup_table(spark, gpu_path), conf=conf)
+
+    def assert_column_mapping_and_dv(spark, path):
+        schema_strings = spark.read.text(path + "/_delta_log/*.json") \
+            .selectExpr("get_json_object(value, '$.metaData.schemaString') AS schema") \
+            .where("schema IS NOT NULL") \
+            .collect()
+        assert len(schema_strings) == 1
+        fields = json.loads(schema_strings[0][0])["fields"]
+        physical_names = {
+            field["name"]: field["metadata"]["delta.columnMapping.physicalName"]
+            for field in fields
+        }
+        assert set(physical_names) == {"id", "payload"}
+        assert all(logical_name != physical_name
+                   for logical_name, physical_name in physical_names.items())
+        dv_adds = spark.read.json(path + "/_delta_log/*.json") \
+            .where("add.deletionVector IS NOT NULL").count()
+        assert dv_adds > 0, f"Expected a deletion-vector AddFile in {path}"
+
+    with_cpu_session(
+        lambda spark: assert_column_mapping_and_dv(spark, cpu_path), conf=conf)
+    with_cpu_session(
+        lambda spark: assert_column_mapping_and_dv(spark, gpu_path), conf=conf)
+
+    def filtered_read(spark):
+        path = gpu_path if spark.conf.get("spark.rapids.sql.enabled") == "true" else cpu_path
+        return spark.read.format("delta").load(path) \
+            .where("id IN (1, 2, 3) AND payload IS NOT NULL") \
+            .select("id", "payload")
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        filtered_read,
+        exist_classes="GpuFileSourceScanExec",
+        conf=conf,
+        require_non_empty=True)
 
 
 @allow_non_gpu(*delta_meta_allow)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -993,11 +993,43 @@ def test_delta_column_mapping_predicate_pushdown_with_deletion_vector(spark_tmp_
         dv_adds = spark.read.json(path + "/_delta_log/*.json") \
             .where("add.deletionVector IS NOT NULL").count()
         assert dv_adds > 0, f"Expected a deletion-vector AddFile in {path}"
+        return physical_names
 
     with_cpu_session(
         lambda spark: assert_column_mapping_and_dv(spark, cpu_path), conf=conf)
-    with_cpu_session(
+    gpu_physical_names = with_cpu_session(
         lambda spark: assert_column_mapping_and_dv(spark, gpu_path), conf=conf)
+
+    def assert_filter_translation(spark):
+        jvm = spark._jvm
+        quoting_utils = jvm.org.apache.spark.sql.catalyst.util.QuotingUtils
+        java_name_map = jvm.java.util.HashMap()
+        for logical_name, physical_name in gpu_physical_names.items():
+            java_name_map.put(
+                quoting_utils.quoteIfNeeded(logical_name),
+                quoting_utils.quoteIfNeeded(physical_name))
+        physical_name_map = jvm.org.apache.spark.api.python.PythonUtils \
+            .toScalaMap(java_name_map)
+
+        in_values = spark.sparkContext._gateway.new_array(jvm.java.lang.Object, 4)
+        for index, value in enumerate([1, 2, 3, 4]):
+            in_values[index] = value
+        logical_filters = [
+            jvm.org.apache.spark.sql.sources.In("id", in_values),
+            jvm.org.apache.spark.sql.sources.IsNotNull("payload")]
+        translator = jvm.com.nvidia.spark.rapids.delta.common.RapidsDeletionVectors
+        translated_filters = [
+            translator.translateFilterForColumnMapping(filter_, physical_name_map)
+            for filter_ in logical_filters]
+        assert all(filter_.isDefined() for filter_ in translated_filters)
+        translated_attributes = [
+            filter_.get().attribute() for filter_ in translated_filters]
+        expected_attributes = [
+            quoting_utils.quoteIfNeeded(gpu_physical_names["id"]),
+            quoting_utils.quoteIfNeeded(gpu_physical_names["payload"])]
+        assert translated_attributes == expected_attributes
+
+    with_gpu_session(assert_filter_translation, conf=conf)
 
     def filtered_read(spark):
         path = gpu_path if spark.conf.get("spark.rapids.sql.enabled") == "true" else cpu_path

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -1002,14 +1002,33 @@ def test_delta_column_mapping_predicate_pushdown_with_deletion_vector(spark_tmp_
     def filtered_read(spark):
         path = gpu_path if spark.conf.get("spark.rapids.sql.enabled") == "true" else cpu_path
         return spark.read.format("delta").load(path) \
-            .where("id IN (1, 2, 3) AND payload IS NOT NULL") \
+            .where("id IN (1, 2, 3, 4) AND payload IS NOT NULL") \
             .select("id", "payload")
+
+    # id=4 satisfies both predicates in the Parquet file but is removed by the
+    # deletion vector. Pin the CPU oracle so CPU/GPU equality cannot pass if both
+    # readers accidentally return the deleted row.
+    expected = [Row(id=1, payload="one"), Row(id=3, payload="three")]
+    cpu_rows = with_cpu_session(
+        lambda spark: filtered_read(spark).orderBy("id").collect(), conf=conf)
+    assert cpu_rows == expected
+
+    def assert_gpu_pushdown(plan):
+        from conftest import spark_jvm
+
+        callback = spark_jvm().org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+        explain_str = str(callback.extractExecutedPlan(plan))
+        compact_plan = explain_str.replace(" ", "")
+        assert "PushedFilters:" in explain_str, explain_str
+        assert "IsNotNull(payload)" in compact_plan, explain_str
+        assert "In(id,[1,2,3,4])" in compact_plan, explain_str
 
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         filtered_read,
         exist_classes="GpuFileSourceScanExec",
         conf=conf,
-        require_non_empty=True)
+        require_non_empty=True,
+        gpu_plan_assertion=assert_gpu_pushdown)
 
 
 @allow_non_gpu(*delta_meta_allow)


### PR DESCRIPTION
**JaCoCo production line coverage: +15 lines** (`delta-lake +15`; `sql-plugin N/A` because nightly b8 contains no compatible sql-plugin classfiles; Scala 2.13, shim 401, Spark 4.0.1, Delta 4.0.0 OSS, anchor `2f158658d8235688496390401328983c299a7f4d`)

Fixes #15913.

### Description

Delta scans combining name-based column mapping, deletion vectors, and predicate pushdown did not have direct GPU correctness coverage. This adds `test_delta_column_mapping_predicate_pushdown_with_deletion_vector`.

The test:

- Creates isolated CPU and GPU Delta tables using name-based column mapping.
- Deletes `id=4` to persist a deletion vector, then includes that deleted row in the read predicate.
- Requires the exact CPU and GPU result to contain only the surviving rows with ids 1 and 3, so the assertion detects failure to apply the deletion vector.
- Verifies transaction-log metadata contains physical column names and a deletion-vector `AddFile`.
- Directly calls `translateFilterForColumnMapping` with the generated table physical-name map and asserts that `In` and `IsNotNull` are translated to those physical column names.
- Requires the finalized GPU plan to contain `GpuFileSourceScanExec` and pushed `IsNotNull(payload)` and `In(id,[1,2,3,4])` filters.

The setup writes the Delta tables directly because Delta 4.0.1 rejects the external-metadata `CREATE TABLE` path before reaching the scan under test.

Validation of the review update on current head `46cad01dd`:

- Python syntax: `python3 -m py_compile integration_tests/src/main/python/delta_lake_test.py` passed.
- Focused CPU/GPU test with Delta 4.1.0 on Spark 4.1.1: `1 passed, 263 deselected`.
- Focused CPU/GPU test with Delta 4.2.0 on Spark 4.1.1: `1 passed, 263 deselected`.

Earlier validation on `bbd8482af` (the production code and classfiles are unchanged by the review update):

- Spark 4.0.1 / Scala 2.13 Maven build: all 19 modules succeeded; `BUILD SUCCESS`.
- Focused CPU/GPU test with Delta 4.0.1: `1 passed`.
- Focused CPU/GPU test with Delta 4.0.0: `1 passed`.
- Spark 4.1.1 / Scala 2.13 Maven package (`-DskipTests`): all 19 modules succeeded; `BUILD SUCCESS`.
- Focused CPU/GPU test with Delta 4.1.0 on Spark 4.1.1: `1 passed, 32006 deselected`.
- Focused CPU/GPU test with Delta 4.2.0 on Spark 4.1.1: `1 passed, 32006 deselected`.
- Exact-anchor focused JaCoCo replay: `1 passed`; its merged report matches the previously validated final report after excluding only the report-group name.
- Delta JaCoCo lines: `3830/5178` → `3845/5178` (`+15`).
- Delta JaCoCo branches: `1328/5134` → `1343/5134` (`+15`).
- No class-ID mismatch, coverage regression, or denominator change was accepted.

Broader validation on the prior head before the review-strengthening commits:

- Delta column-mapping selection: `14 passed`.
- Full `delta_lake_test.py`: `253 passed, 11 skipped`.

The full Delta file was not rerun after the focused review updates. The Databricks matrix was not run locally, and the new test is explicitly skipped on Databricks because it covers the OSS Delta scan path.

AI assistance: Codex assisted with the test change and PR description.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
