### PR TITLE
[BUG] Unshim Spark 5 RapidsShuffleManagerBase for spark-shell[reduced-it]

### DIFF
--- a/dist/unshimmed-from-each-spark3xx.txt
+++ b/dist/unshimmed-from-each-spark3xx.txt
@@ -1,5 +1,5 @@
 com/nvidia/spark/rapids/*/RapidsShuffleManager.class
-org/apache/spark/shuffle/RapidsShuffleManagerBase.class
+org/apache/spark/shuffle/RapidsBlockingShuffleManagerBase.class
 com/nvidia/spark/rapids/AvroProvider.class
 com/nvidia/spark/rapids/HiveProvider.class
 com/nvidia/spark/rapids/iceberg/IcebergProvider.class

--- a/dist/unshimmed-from-each-spark3xx.txt
+++ b/dist/unshimmed-from-each-spark3xx.txt
@@ -1,4 +1,5 @@
 com/nvidia/spark/rapids/*/RapidsShuffleManager.class
+org/apache/spark/shuffle/RapidsShuffleManagerBase.class
 com/nvidia/spark/rapids/AvroProvider.class
 com/nvidia/spark/rapids/HiveProvider.class
 com/nvidia/spark/rapids/iceberg/IcebergProvider.class

--- a/sql-plugin/src/main/spark500/java/com/nvidia/spark/rapids/spark500/RapidsShuffleManager.java
+++ b/sql-plugin/src/main/spark500/java/com/nvidia/spark/rapids/spark500/RapidsShuffleManager.java
@@ -21,10 +21,10 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.spark500;
 
 import org.apache.spark.SparkConf;
-import org.apache.spark.shuffle.RapidsShuffleManagerBase;
+import org.apache.spark.shuffle.RapidsBlockingShuffleManagerBase;
 
 /** A shuffle manager optimized for the RAPIDS Plugin for Apache Spark. */
-public final class RapidsShuffleManager extends RapidsShuffleManagerBase {
+public final class RapidsShuffleManager extends RapidsBlockingShuffleManagerBase {
   public RapidsShuffleManager(SparkConf conf, boolean isDriver) {
     super(conf, isDriver);
     initialize();

--- a/sql-plugin/src/main/spark500/java/org/apache/spark/shuffle/RapidsBlockingShuffleManagerBase.java
+++ b/sql-plugin/src/main/spark500/java/org/apache/spark/shuffle/RapidsBlockingShuffleManagerBase.java
@@ -27,9 +27,11 @@ import org.apache.spark.sql.rapids.ProxyRapidsShuffleInternalManagerBase;
  * Spark 5 requires custom shuffle managers to implement BlockingShuffleManager.
  * Keep that package-private Spark type in Spark's package so Scaladoc can resolve it.
  *
- * Spark instantiates {@code spark.shuffle.manager} before ShimLoader is active, so this
- * class must also be copied to the dist jar root via {@code unshimmed-from-each-spark3xx.txt}.
- * Leaving it only under {@code spark500/} causes NoClassDefFoundError when defining
+ * Spark resolves the class configured by {@code spark.shuffle.manager} through
+ * {@code Utils.classForName}, not through ShimLoader. The manager and every
+ * superclass needed to define it must therefore be visible from the dist jar root.
+ * Copy this class there via {@code unshimmed-from-each-spark3xx.txt}. Leaving it
+ * only under {@code spark500/} causes NoClassDefFoundError when defining
  * {@code com.nvidia.spark.rapids.spark500.RapidsShuffleManager}.
  */
 public abstract class RapidsBlockingShuffleManagerBase

--- a/sql-plugin/src/main/spark500/java/org/apache/spark/shuffle/RapidsBlockingShuffleManagerBase.java
+++ b/sql-plugin/src/main/spark500/java/org/apache/spark/shuffle/RapidsBlockingShuffleManagerBase.java
@@ -32,9 +32,9 @@ import org.apache.spark.sql.rapids.ProxyRapidsShuffleInternalManagerBase;
  * Leaving it only under {@code spark500/} causes NoClassDefFoundError when defining
  * {@code com.nvidia.spark.rapids.spark500.RapidsShuffleManager}.
  */
-public abstract class RapidsShuffleManagerBase extends ProxyRapidsShuffleInternalManagerBase
-    implements BlockingShuffleManager {
-  protected RapidsShuffleManagerBase(SparkConf conf, boolean isDriver) {
+public abstract class RapidsBlockingShuffleManagerBase
+    extends ProxyRapidsShuffleInternalManagerBase implements BlockingShuffleManager {
+  protected RapidsBlockingShuffleManagerBase(SparkConf conf, boolean isDriver) {
     super(conf, isDriver);
   }
 }

--- a/sql-plugin/src/main/spark500/java/org/apache/spark/shuffle/RapidsShuffleManagerBase.java
+++ b/sql-plugin/src/main/spark500/java/org/apache/spark/shuffle/RapidsShuffleManagerBase.java
@@ -26,6 +26,11 @@ import org.apache.spark.sql.rapids.ProxyRapidsShuffleInternalManagerBase;
 /**
  * Spark 5 requires custom shuffle managers to implement BlockingShuffleManager.
  * Keep that package-private Spark type in Spark's package so Scaladoc can resolve it.
+ *
+ * Spark instantiates {@code spark.shuffle.manager} before ShimLoader is active, so this
+ * class must also be copied to the dist jar root via {@code unshimmed-from-each-spark3xx.txt}.
+ * Leaving it only under {@code spark500/} causes NoClassDefFoundError when defining
+ * {@code com.nvidia.spark.rapids.spark500.RapidsShuffleManager}.
  */
 public abstract class RapidsShuffleManagerBase extends ProxyRapidsShuffleInternalManagerBase
     implements BlockingShuffleManager {


### PR DESCRIPTION
Fixes #15910.

### Description

Spark master integration tests (`spark500`, Scala 2.13) pass the pytest sample suite, then fail the `spark-shell` smoke test in `jenkins/spark-tests.sh`. Spark creates `spark.shuffle.manager=com.nvidia.spark.rapids.spark500.RapidsShuffleManager` with `Utils.classForName`, not through plugin `ShimLoader`. The versioned manager class is already copied to the dist jar root, but its Spark 5 parent `org.apache.spark.shuffle.RapidsBlockingShuffleManagerBase` was left only under the `spark500/` parallel world. Spark's classloader then throws `NoClassDefFoundError` for that parent, SparkContext never comes up, and the smoke test cannot match `Array([4950])`.

There is no user-facing configuration or API change. Operators that already set the RAPIDS shuffle manager on Spark 5.0 continue to use the same class name; `spark-shell` and other paths that load the manager through Spark itself now find both the manager and its `BlockingShuffleManager` bridge.

The fix adds `RapidsBlockingShuffleManagerBase.class` to `dist/unshimmed-from-each-spark3xx.txt` so packaging copies it next to `RapidsShuffleManager` at the jar root. The Spark 5-only bridge is named to make the `BlockingShuffleManager` requirement explicit. Other Spark 3.x/4.x shims are unchanged: they subclass `ProxyRapidsShuffleInternalManagerBase`, which is already root-visible.

This change was drafted with AI assistance. Please review the full diff and this description before merge.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`jenkins/spark-tests.sh` spark-shell smoke test with `SPARK_SHELL_SMOKE_TEST=1` and `PYSP_TEST_spark_shuffle_manager=com.nvidia.spark.rapids.spark500.RapidsShuffleManager`)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
      Dist-jar layout only: the same Spark 5 shuffle manager bytecode is loaded from the conventional jar root instead of remaining shim-hidden. No GPU operator, shuffle algorithm, or allocation path is changed.