### PR TITLE
Enable Iceberg V3 REST catalog tests [reduced-it]

### DIFF
--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -35,10 +35,8 @@ iceberg_unsupported_mark = pytest.mark.skipif(
 runtime_iceberg_version = os.environ.get("EXPECTED_ICEBERG_VERSION")
 supports_iceberg_v3 = (
     runtime_iceberg_version is not None and
-    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 9) and
-    not is_iceberg_rest_catalog())
-ICEBERG_V3_UNSUPPORTED_REASON = (
-    "Iceberg v3 requires Iceberg 1.9.0 or later and a catalog backend with v3 support")
+    tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 9))
+ICEBERG_V3_UNSUPPORTED_REASON = "Iceberg v3 requires Iceberg 1.9.0 or later"
 supports_iceberg_row_lineage_inheritance = (
     runtime_iceberg_version is not None and
     tuple(int(part) for part in runtime_iceberg_version.split(".")[:2]) >= (1, 10))


### PR DESCRIPTION
Fixes #15657.

### Description

Enable Iceberg V3 fallback tests when the integration tests use a REST catalog.

This restores REST coverage for V3 table creation and the intended RAPIDS read and write fallback paths now that the test catalog accepts format version 3.

The shared Iceberg V3 capability check now depends only on Iceberg 1.9.0 or later instead of excluding every REST catalog run. The existing `test_iceberg_v3_read_fallback` parameter cases cover the newly enabled path.

Validation:

- Spark 3.5.8, Scala 2.13, Iceberg 1.10.1, and Lakekeeper 0.13.1 REST catalog: all 22 V3 row-lineage and deletion-vector cases passed; no `Invalid format version 3` error occurred.
- Spark 3.5.6, Scala 2.13, Iceberg 1.9.2, and Lakekeeper 0.13.1 REST catalog: `24 passed, 5 skipped, 1 xpassed`; all 12 REST-applicable V3 fallback parameter cases completed (`11 passed, 1 xpassed`).
- The same REST run completed all 12 selected V1 view cases and the selected V2 insert case. Lakekeeper audit output confirmed successful V1, V2, and V3 table creation.
- Java 17 Scala 2.13 build: `mvn -f scala2.13/pom.xml clean package -Dbuildver=358 -DskipTests -Drat.skip=true`.
- `python -m py_compile integration_tests/src/main/python/iceberg/__init__.py`.
- `git diff --check`.

This is a test-only change and does not affect production runtime performance.

AI assistance: Codex helped implement and validate this change.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
