### PR TITLE
[dependency-check]: isolate warmup dependencies to avoid maven central 429 [skip ci]

### DIFF
--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -26,6 +26,7 @@
 #   SERVER_ID:      The repository id for this deployment.
 #   SERVER_URL:     The url where to deploy artifacts.
 #   M2_CACHE:       Maven local repo
+#   WARMUP_REPO:    Maven local repo populated through the internal settings
 ###
 
 set -ex
@@ -34,34 +35,68 @@ ARTIFACT_FILE=${1:-"/tmp/artifacts-list"}
 SERVER_ID=${SERVER_ID:-"local"}
 SERVER_URL=${SERVER_URL:-"file:/tmp/local-release-repo"}
 M2_CACHE=${M2_CACHE:-"/tmp/m2-cache"}
+WARMUP_REPO=${WARMUP_REPO:-"${M2_CACHE}-warmup"}
 DEST_PATH=${DEST_PATH:-"/tmp/test-get-dest"}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MVN_SETTINGS=${MVN_SETTINGS:-"$SCRIPT_DIR/settings.xml"}
 MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 
+# This flow addresses two related problems:
+# 1. Plain-Maven dependency checks can fail with HTTP 429 while downloading from Maven Central.
+#    The original fix used the internal settings to warm up dependencies directly in $M2_CACHE.
+# 2. That simple warmup is not sufficient because Maven records the source repository of each
+#    cached artifact. The warmup records internal repository IDs, but plain Maven later requests
+#    the same dependencies from Central. Maven then ignores the cached entries from the different
+#    source repository and downloads from Central again, which reintroduces the HTTP 429 failure.
+#
+# More issue details: https://github.com/NVIDIA/cudf-spark/issues/15747
+#
+# Current fix is to keep the internally downloaded dependencies in a separate warmup repository and expose that
+# cache as a file-based remote repository during validation.
+#
+# Repository roles:
+# - remote_maven_repo: contains the artifacts under test at SERVER_URL.
+# - warmup_maven_repo: exposes external dependencies fetched through internal Artifactory as a
+#   file-based remote repository.
+# - validation_maven_repos: combines the repository under test and the warmup repository for the
+#   final plain-Maven dependency checks.
 remote_maven_repo=$SERVER_ID::default::$SERVER_URL
+warmup_maven_repo=warmup-cache::default::file://$WARMUP_REPO
+validation_maven_repos=$remote_maven_repo,$warmup_maven_repo
 
-# Warm up $M2_CACHE by downloading the Maven Dependency Plugin using -s $MVN_SETTINGS to fix
-# intermittent mvn failures caused by timeouts or HTTP 429 errors while downloading Maven plugins
-# from Maven Central. See https://github.com/NVIDIA/spark-rapids/pull/14727.
-# 
+# Step 1: Initialize $M2_CACHE by downloading the Maven Dependency Plugin through the internal
+# settings.
+# The final plain-Maven command cannot use warmup_maven_repo until this plugin has been loaded.
+$MVN -B dependency:get \
+    -Dmaven.repo.local="$M2_CACHE" \
+    -Dartifact=org.apache.maven.plugins:maven-dependency-plugin:2.8
+
+# Step 2: Resolve the artifact POM and its parent/dependency graph transitively through the original
+# settings, downloading external dependencies from internal Artifactory into $WARMUP_REPO.
 # All entries in $ARTIFACT_FILE share this POM, so resolving it transitively also caches common
 # dependencies through the internal Maven repository before validation runs with plain Maven.
 IFS=: read -r group_id artifact_id version _ < "$ARTIFACT_FILE"
 pom_artifact="$group_id:$artifact_id:$version:pom"
 $MVN -B dependency:get \
     -DremoteRepositories="$remote_maven_repo" \
-    -Dmaven.repo.local="$M2_CACHE" \
+    -Dmaven.repo.local="$WARMUP_REPO" \
     -Dartifact="$pom_artifact"
 
+# Step 3: Remove NVIDIA artifacts downloaded during warmup. This keeps external dependencies
+# available without allowing artifacts under test to resolve from the internal repository.
+rm -rf "$WARMUP_REPO/com/nvidia"
+
+# Step 4: Run the actual dependency checks with plain Maven against two remote repositories: the
+# repository under test and the file-based warmup repository. Do not use $MVN_SETTINGS here,
+# because temporary or test NVIDIA artifacts from internal Artifactory must not satisfy validation.
 while read -r line; do
     artifact=$line # artifact=groupId:artifactId:version:[[packaging]:classifier]
     # Clean up $M2_CACHE to avoid side-effect of previous dependency:get
     rm -rf $M2_CACHE/com/nvidia
     # Dependency checks should run without -s $MVN_SETTINGS, because we do not want to download temporary or test JARs from the internal Maven repository.
     # These internal JARs will not be released, and we only want to check dependency issues for release JARs. Using -s $MVN_SETTINGS may interfere with the check.
-    mvn -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
+    mvn -B dependency:get -DremoteRepositories=$validation_maven_repos -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
 done < $ARTIFACT_FILE
 
 ls -l $DEST_PATH


### PR DESCRIPTION


Fixes https://github.com/NVIDIA/cudf-spark/issues/15747

### Description
Plain-Maven dependency checks can retry Maven Central and fail with HTTP 429 even after a warmup. Maven records the source repository for cached artifacts, so dependencies fetched through internal Artifactory may not satisfy later requests associated with Central.
This change isolates Artifactory-fetched transitive dependencies in a separate warmup repository and exposes that cache as a file-based validation remote. The actual checks still run without the internal Maven settings, and NVIDIA artifacts are removed from the warmup cache so only artifacts from the repository under test can satisfy validation.


### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
