### PR TITLE
Fix mortgage test on EMR with Spark testing enabled

### DIFF
--- a/integration_tests/src/main/python/mortgage_test.py
+++ b/integration_tests/src/main/python/mortgage_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_iterator
+from conftest import is_emr_runtime
 from marks import approximate_float, incompat, ignore_order, allow_non_gpu, limit
+from spark_session import is_spark_testing_enabled
 
 @incompat
 @approximate_float
@@ -23,5 +25,11 @@ from marks import approximate_float, incompat, ignore_order, allow_non_gpu, limi
 @ignore_order
 @allow_non_gpu(any=True)
 def test_mortgage(mortgage):
+  conf = {}
+  # EMR's PullUpUnion rule rejects the exchange inserted below GpuTopN only when
+  # Spark's internal testing mode is enabled. See https://github.com/NVIDIA/cudf-spark/issues/14928.
+  if is_emr_runtime() and is_spark_testing_enabled():
+    conf['spark.sql.execution.pullUpUnion.enabled'] = 'false'
+
   assert_gpu_and_cpu_are_equal_iterator(
-          lambda spark : mortgage.do_test_query(spark))
+          lambda spark : mortgage.do_test_query(spark), conf=conf)


### PR DESCRIPTION
Fixes #14928.

### Description

The mortgage integration test fails on EMR *only* when Spark internal testing mode is enabled because the EMR PullUpUnion AQE rule rejects the exchange inserted below GpuTopN.

This change disables spark.sql.execution.pullUpUnion.enabled only for test_mortgage when both the runtime is EMR and Spark testing mode is active. Production-mode EMR runs, non-EMR runtimes, and all other tests retain their existing configuration and distribution defaults.

Validation:

- EMR 7.12, Spark 3.5.6-amzn-1, Scala 2.12, with spark.testing enabled: test_mortgage passed.
- EMR 8.0, Spark 4.0.2-amzn-0, Scala 2.13, with spark.testing enabled: test_mortgage passed.
- EMR 8.0 without spark.testing: test_mortgage passed without applying the override.
- Python compilation and git diff --check passed.

This is a test-only change and does not affect production runtime performance.

AI assistance: Codex helped reproduce, implement, validate, and prepare this change.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required