### PR TITLE
Fix Spark master GpuBatchScanExec compile after replanWithRuntimeFilters API change[reduced-it]

### DIFF
--- a/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -94,7 +94,7 @@ case class GpuBatchScanExec(
   @transient override lazy val inputPartitions: Seq[InputPartition] =
     ArraySeq.unsafeWrapArray(batch.planInputPartitions())
 
-  @transient protected lazy val filteredPartitions: Seq[Option[InputPartition]] =
+  @transient lazy val filteredPartitions: Seq[Option[InputPartition]] =
     PushDownUtils.replanWithRuntimeFilters(
       scan,
       runtimeFilters,

--- a/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -78,12 +78,18 @@ case class GpuBatchScanExec(
     case other: GpuBatchScanExec =>
       this.batch != null && this.batch == other.batch &&
         this.runtimeFilters == other.runtimeFilters &&
-        this.keyGroupedPartitioning == other.keyGroupedPartitioning
+        this.prunedKeyGroupedPartitioning == other.prunedKeyGroupedPartitioning
     case _ =>
       false
   }
 
-  override def hashCode(): Int = Objects.hashCode(batch, runtimeFilters, keyGroupedPartitioning)
+  override def hashCode(): Int =
+    Objects.hashCode(batch, runtimeFilters, prunedKeyGroupedPartitioning)
+
+  // Keep in sync with Spark BatchScanExec: dangling keys after column pruning are planner
+  // metadata and must not affect equals, hashCode, or canonicalize.
+  @transient lazy val prunedKeyGroupedPartitioning: Option[Seq[Expression]] =
+    keyGroupedPartitioning.map(_.filter(_.references.subsetOf(outputSet)))
 
   @transient override lazy val inputPartitions: Seq[InputPartition] =
     ArraySeq.unsafeWrapArray(batch.planInputPartitions())
@@ -122,7 +128,9 @@ case class GpuBatchScanExec(
       runtimeFilters = QueryPlan.normalizePredicates(
         runtimeFilters.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral)),
         output),
-      keyGroupedPartitioning = keyGroupedPartitioning.map(QueryPlan.normalizePredicates(_, output)))
+      // SPARK-58120: normalizeExpressions preserves key order; normalizePredicates can reorder.
+      keyGroupedPartitioning = prunedKeyGroupedPartitioning.map(
+        _.map(QueryPlan.normalizeExpressions(_, output))))
   }
 
   override def simpleString(maxFields: Int): String = {

--- a/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -94,7 +94,9 @@ case class GpuBatchScanExec(
       runtimeFilters,
       table,
       output,
-      outputPartitioning,
+      // Full-width keys as the source reported them. outputPartitioning may project
+      // pruned key columns away and is a Partitioning, not Option[KeyedPartitioning].
+      reportedKeyedPartitioning,
       inputPartitions)
 
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()

--- a/tests/src/test/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecCanonicalizeSuite.scala
+++ b/tests/src/test/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecCanonicalizeSuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "500"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids.{GpuScan, SparkQueryCompareTestSuite}
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+
+class GpuBatchScanExecCanonicalizeSuite extends SparkQueryCompareTestSuite with MockitoSugar {
+  private object EmptyBatch extends Batch {
+    override def planInputPartitions(): Array[InputPartition] = Array.empty
+    override def createReaderFactory(): PartitionReaderFactory = null
+  }
+
+  private val scan = new GpuScan {
+    override def readSchema(): StructType = new StructType()
+    override def toBatch: Batch = EmptyBatch
+    override def withInputFile(): GpuScan = this
+    override def description(): String = "canonicalize-test-scan"
+  }
+
+  private val id = AttributeReference("id", IntegerType)()
+  private val data = AttributeReference("data", StringType)()
+  private val extra = AttributeReference("extra", IntegerType)()
+
+  private def exec(keys: Option[Seq[AttributeReference]]): GpuBatchScanExec = {
+    GpuBatchScanExec(
+      output = Seq(id, data),
+      scan = scan,
+      table = mock[Table],
+      keyGroupedPartitioning = keys)
+  }
+
+  test("equals and hashCode ignore partition keys pruned out of output") {
+    withCpuSparkSession { _ =>
+      val withDangling = exec(Some(Seq(id, extra)))
+      val pruned = exec(Some(Seq(id)))
+      assert(withDangling.prunedKeyGroupedPartitioning == pruned.prunedKeyGroupedPartitioning)
+      assert(withDangling == pruned)
+      assert(withDangling.hashCode() == pruned.hashCode())
+    }
+  }
+
+  test("doCanonicalize drops dangling keys and preserves remaining key order") {
+    withCpuSparkSession { _ =>
+      val plan = exec(Some(Seq(id, data, extra)))
+      val canonical = plan.doCanonicalize()
+      val keys = canonical.keyGroupedPartitioning.get
+      assert(keys.map(_.dataType) == Seq(IntegerType, StringType))
+    }
+  }
+}

--- a/tests/src/test/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecCanonicalizeSuite.scala
+++ b/tests/src/test/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecCanonicalizeSuite.scala
@@ -19,13 +19,23 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
+import java.util.Collections
+
 import com.nvidia.spark.rapids.{GpuScan, SparkQueryCompareTestSuite}
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.connector.catalog.Table
-import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal}
+import org.apache.spark.sql.catalyst.plans.physical.KeyedPartitioning
+import org.apache.spark.sql.connector.catalog.{Column, Table, TableCapability}
+import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference}
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.read.{Batch, HasPartitionKey, InputPartition,
+    PartitionReaderFactory, SupportsRuntimeV2Filtering}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+import org.mockito.Mockito.when
 
 class GpuBatchScanExecCanonicalizeSuite extends SparkQueryCompareTestSuite with MockitoSugar {
   private object EmptyBatch extends Batch {
@@ -43,6 +53,9 @@ class GpuBatchScanExecCanonicalizeSuite extends SparkQueryCompareTestSuite with 
   private val id = AttributeReference("id", IntegerType)()
   private val data = AttributeReference("data", StringType)()
   private val extra = AttributeReference("extra", IntegerType)()
+  private val storeId = AttributeReference("store_id", IntegerType)()
+  private val deptId = AttributeReference("dept_id", IntegerType)()
+  private val payload = AttributeReference("data", IntegerType)()
 
   private def exec(keys: Option[Seq[AttributeReference]]): GpuBatchScanExec = {
     GpuBatchScanExec(
@@ -59,6 +72,29 @@ class GpuBatchScanExecCanonicalizeSuite extends SparkQueryCompareTestSuite with 
       assert(withDangling.prunedKeyGroupedPartitioning == pruned.prunedKeyGroupedPartitioning)
       assert(withDangling == pruned)
       assert(withDangling.hashCode() == pruned.hashCode())
+      // sameResult goes through SparkPlan.canonicalized, the AQE reuse / reuse-exchange path.
+      assert(withDangling.sameResult(pruned))
+    }
+  }
+
+  test("sameResult holds for equivalent scans that differ only by ExprId") {
+    withCpuSparkSession { _ =>
+      val idB = AttributeReference("id", IntegerType)()
+      val extraB = AttributeReference("extra", IntegerType)()
+      val dataB = AttributeReference("data", StringType)()
+      val left = GpuBatchScanExec(
+        output = Seq(id, data),
+        scan = scan,
+        table = mock[Table],
+        keyGroupedPartitioning = Some(Seq(id, extra)))
+      val right = GpuBatchScanExec(
+        output = Seq(idB, dataB),
+        scan = scan,
+        table = mock[Table],
+        keyGroupedPartitioning = Some(Seq(idB, extraB)))
+      assert(left.sameResult(right),
+        "Canonicalized GPU scans with different ExprIds should still sameResult")
+      assert(left.doCanonicalize().sameResult(right.doCanonicalize()))
     }
   }
 
@@ -68,6 +104,91 @@ class GpuBatchScanExecCanonicalizeSuite extends SparkQueryCompareTestSuite with 
       val canonical = plan.doCanonicalize()
       val keys = canonical.keyGroupedPartitioning.get
       assert(keys.map(_.dataType) == Seq(IntegerType, StringType))
+    }
+  }
+
+  // SPARK-59248: join/filter key is a non-leading subset of the partition keys, and the leading
+  // key has been pruned from scan output. replanWithRuntimeFilters must still see the full-width
+  // reported keys; pruned or empty keys misalign HasPartitionKey rows.
+  test("runtime-filter replan uses full-width keys after pruning a leading partition key") {
+    val v2Conf = new SparkConf().set(SQLConf.V2_BUCKETING_ENABLED.key, "true")
+    withCpuSparkSession({ _ =>
+      val keyedScan = new KeyedRuntimeFilterGpuScan
+      val table = mock[Table]
+      when(table.name()).thenReturn("prune_lead_t")
+      when(table.columns()).thenReturn(Array(
+        Column.create("store_id", IntegerType),
+        Column.create("dept_id", IntegerType),
+        Column.create("data", IntegerType)))
+      when(table.partitioning()).thenReturn(Array(
+        Expressions.identity("store_id"),
+        Expressions.identity("dept_id")))
+      when(table.capabilities()).thenReturn(Collections.emptySet[TableCapability]())
+
+      val plan = GpuBatchScanExec(
+        // Leading store_id is absent from output, matching SPARK-59248 column pruning.
+        output = Seq(deptId, payload),
+        scan = keyedScan,
+        runtimeFilters = Seq(EqualTo(deptId, Literal(10))),
+        table = table,
+        keyGroupedPartitioning = Some(Seq(storeId, deptId)))
+
+      assert(plan.keyGroupedPartitioning.get.map(_.asInstanceOf[AttributeReference].name) ==
+        Seq("store_id", "dept_id"))
+      assert(!plan.output.exists(_.name == "store_id"))
+      plan.outputPartitioning match {
+        case k: KeyedPartitioning =>
+          assert(k.expressions.size == 1,
+            s"Planner view should drop the pruned leading key, found ${k.expressions}")
+        case other =>
+          fail(s"Expected a projected KeyedPartitioning, found $other")
+      }
+
+      val filtered = plan.filteredPartitions
+      assert(filtered.exists(_.isDefined),
+        "Expected at least one remaining keyed partition after the runtime filter")
+      assert(filtered.exists(_.isEmpty),
+        "Expected filtered-out keys to keep their original slots as None")
+      val keptKeys = filtered.flatten.map(_.asInstanceOf[HasPartitionKey].partitionKey())
+      assert(keptKeys.forall(_.getInt(1) == 10),
+        s"Runtime filter should keep only dept_id=10 keys, found $keptKeys")
+      assert(keptKeys.forall(row => row.numFields == 2),
+        "HasPartitionKey rows stay full-width even after the leading output column is pruned")
+    }, v2Conf)
+  }
+
+  private class KeyedInputPartition(key: InternalRow)
+      extends InputPartition with HasPartitionKey {
+    override def partitionKey(): InternalRow = key
+  }
+
+  private class KeyedRuntimeFilterGpuScan extends GpuScan with SupportsRuntimeV2Filtering {
+    private var parts: Array[InputPartition] = Array(
+      new KeyedInputPartition(InternalRow(1, 10)),
+      new KeyedInputPartition(InternalRow(1, 20)),
+      new KeyedInputPartition(InternalRow(2, 5)),
+      new KeyedInputPartition(InternalRow(2, 10)))
+
+    override def readSchema(): StructType =
+      new StructType()
+        .add("dept_id", IntegerType)
+        .add("data", IntegerType)
+
+    override def toBatch: Batch = new Batch {
+      override def planInputPartitions(): Array[InputPartition] = parts
+      override def createReaderFactory(): PartitionReaderFactory = null
+    }
+
+    override def withInputFile(): GpuScan = this
+    override def description(): String = "keyed-runtime-filter-scan"
+
+    override def filterAttributes(): Array[NamedReference] =
+      Array(Expressions.column("dept_id"))
+
+    override def filter(predicates: Array[Predicate]): Unit = {
+      parts = parts.filter { p =>
+        p.asInstanceOf[HasPartitionKey].partitionKey().getInt(1) == 10
+      }
     }
   }
 }

--- a/tests/src/test/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecCanonicalizeSuite.scala
+++ b/tests/src/test/spark500/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecCanonicalizeSuite.scala
@@ -22,6 +22,7 @@ package com.nvidia.spark.rapids.shims
 import java.util.Collections
 
 import com.nvidia.spark.rapids.{GpuScan, SparkQueryCompareTestSuite}
+import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.SparkConf
@@ -35,7 +36,6 @@ import org.apache.spark.sql.connector.read.{Batch, HasPartitionKey, InputPartiti
     PartitionReaderFactory, SupportsRuntimeV2Filtering}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
-import org.mockito.Mockito.when
 
 class GpuBatchScanExecCanonicalizeSuite extends SparkQueryCompareTestSuite with MockitoSugar {
   private object EmptyBatch extends Batch {


### PR DESCRIPTION
Fixes #15930.

### Description

Spark master nightly builds fail in `sql-plugin` while compiling the Spark 5.0 shim: `GpuBatchScanExec` still passes `outputPartitioning` (`Partitioning`) into `PushDownUtils.replanWithRuntimeFilters`, which now takes `Option[KeyedPartitioning]`. Released Spark versions are unaffected. After this change, Spark 5 / master snapshot compilation succeeds again. No new configuration.

The helper must use the full-width keys the source reported, not the planner view. `outputPartitioning` may project away pruned key columns and is the wrong type. GPU `GpuBatchScanExec` now passes `reportedKeyedPartitioning` from `DataSourceV2ScanExecBase`, matching Spark's `BatchScanExec`.

The same Spark 5 `BatchScanExec` also treats pruned-out partition keys as planner metadata: `equals`, `hashCode`, and `doCanonicalize` use `prunedKeyGroupedPartitioning`, and canonicalize uses `normalizeExpressions` so multi-key order is preserved (SPARK-58120). Those were ported as well so GPU AQE reuse / `sameResult` does not diverge from CPU, and so a canonicalized keyed scan cannot reorder Integer/String keys.

Compile and the Spark 5 suite were checked with `mvn -f scala2.13/pom.xml -Dbuildver=500 -Dcuda.version=cuda13 -pl sql-plugin,tests -am package -DwildcardSuites=com.nvidia.spark.rapids.shims.GpuBatchScanExecCanonicalizeSuite` (BUILD SUCCESS, 4 tests). `GpuBatchScanExecCanonicalizeSuite` covers dangling-key equality, `sameResult` across different `ExprId`s, SPARK-58120 key order, and SPARK-59248-style runtime-filter replanning after a pruned leading key (`filteredPartitions` on a keyed `GpuScan`). Spark 5 unit tests use the Iceberg stub, so that last case is a `GpuScan` with `HasPartitionKey` partitions rather than an Iceberg query. Existing Spark 4 Iceberg SPJ / DSv2 scan tests still cover the Iceberg runtime-filter path.

This change was drafted with AI assistance. A human reviewed the diff and this description before updating the PR.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

Driver-side plan identity and a compile-time argument swap when building scan partitions. No per-row or executor GPU work is added. `reportedKeyedPartitioning` is already the lazy value `outputPartitioning` is derived from in Spark's `DataSourceV2ScanExecBase`.
