### PR TITLE
Exercise the ORC empty-child STRUCT guard [databricks]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -17,10 +17,9 @@
 package com.nvidia.spark.rapids
 
 import java.io.{File, FileNotFoundException}
-import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.hive.ql.exec.vector.{BytesColumnVector, StructColumnVector}
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector
 import org.apache.orc.{OrcFile, TypeDescription}
 
 import org.apache.spark.SparkConf
@@ -54,8 +53,7 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
     assert(base.mkdirs())
     val schema = TypeDescription.createStruct().addField("name",
       TypeDescription.createStruct()
-        .addField("empty", TypeDescription.createStruct())
-        .addField("first", TypeDescription.createString()))
+        .addField("empty", TypeDescription.createStruct()))
     val writer = OrcFile.createWriter(new Path(base.getCanonicalPath, "part-00000.orc"),
       OrcFile.writerOptions(spark.sparkContext.hadoopConfiguration).setSchema(schema))
     try {
@@ -64,7 +62,6 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
       val nameVector = batch.cols(0).asInstanceOf[StructColumnVector]
       nameVector.noNulls = false
       nameVector.isNull(1) = true
-      nameVector.fields(1).asInstanceOf[BytesColumnVector].setVal(0, "Janet".getBytes(UTF_8))
       writer.addRowBatch(batch)
     } finally {
       writer.close()
@@ -75,7 +72,8 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
     file => spark => spark.read.schema(StructType(Seq(
       StructField("name", StructType(Seq(StructField("missing", StringType)))))))
       .orc(file.getCanonicalPath),
-    writeNestedEmptyStructOrc) { frame => frame }
+    writeNestedEmptyStructOrc,
+    existClasses = "GpuFileSourceScanExec") { frame => frame }
 
   testSparkResultsAreEqual("schema-can-prune dis-order read schema",
     frameFromOrcWithSchema("schema-can-prune.orc", StructType(Seq(


### PR DESCRIPTION
**JaCoCo production line coverage: +0 lines** (complete applicable measured scope: `sql-plugin +0`; shim 350, vs nightly b19 at `d2f4fe24`)

Fixes #15292.

### Description

This is a test-only coverage correction; it does not change production behavior or fix a new CPU/GPU result difference. The existing ORC schema-evolution test was intended to exercise the empty-child STRUCT guard added by #15210, but its fixture also contained a string sibling. ORC selected that sibling and never reached the guard, so removing the guard would still leave the test passing. This PR narrows the fixture so the test actually follows the empty-child path and explicitly verifies that the scan runs on the GPU.

#### What changed

- Make `empty:struct<>` the only physical child of the nested `name` STRUCT while preserving one valid and one null parent row.
- Keep the requested schema looking for a missing string child, which drives the schema-evolution path under test.
- Require `GpuFileSourceScanExec` so CPU fallback cannot satisfy the regression test.

The production fix from [NVIDIA/cudf#23289](https://github.com/NVIDIA/cudf/pull/23289) is merged as `c9d44df0745660735436715bffa5b10e679bcf5d`. Both the nightly-anchor JNI artifact and the current cudf-spark-jni cuDF pin contain that commit.

AI assistance: The change and PR description were prepared with Codex assistance.

#### Validation

- Spark 3.3 `OrcScanSuite`: `Tests: succeeded 15, failed 0, canceled 0, ignored 1, pending 0`; `BUILD SUCCESS`.
- Spark 3.5 nightly-anchor `OrcScanSuite`: `Tests: succeeded 14, failed 0, canceled 0, ignored 1, pending 0`; `BUILD SUCCESS`.
- At the exact shim-350 nightly anchor, the retain guard changed from one covered branch (`mb=1, cb=1`) to both branches covered (`mb=0, cb=2`), and its empty-child clone arm became covered. The published aggregate already covered the relevant production lines, so the measured net line contribution is `+0`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
