### PR TITLE
[SkipRecovery] Match Hive decimal integer and exponent limits [databricks]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -241,11 +241,14 @@ then results in a number being returned when the CPU would have returned null.
 
 ### Hive Text File Decimal
 
-Hive has some limitations in what decimal values it can parse. The GPU kernels that we use
-to parse decimal values do not have the same limitations. This means that there are times
-when the CPU version would return a null for an input value, but the GPU version will
-return a value. This typically happens for numbers with large negative exponents where
-the GPU will return `0` and Hive will return `null`.
+Hive decimal parsing and GPU decimal parsing can differ for long fractional inputs.
+Hive rounds the mantissa to its internal precision before applying the exponent and
+the column's precision and scale, whereas the GPU converts directly to the target scale.
+For example, Hive reads `0.000000000000000000000000000000000000001E39` as `0`,
+while the GPU reads it as `1`. The GPU can also return `null` for zero mantissas with
+large positive exponents, such as `0e+99`, that Hive accepts as `0`. Both readers reject
+inputs with more than 38 integer digits (excluding leading zeros) or an exponent
+outside `[-99, 99]`.
 See https://github.com/NVIDIA/cudf-spark/issues/7246
 
 ## ORC

--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -175,12 +175,8 @@ non_utc_allow_for_test_basic_hive_text_read=['HiveTableScanExec', 'DataWritingCo
     ('hive-delim-text/extended-float-values', make_schema(IntegerType()),        {}),
     ('hive-delim-text/extended-float-values', make_schema(FloatType()),          {}),
     ('hive-delim-text/extended-float-values', make_schema(DoubleType()),         {}),
-    pytest.param('hive-delim-text/extended-float-values',   make_schema(DecimalType(10, 3)),   {},
-        marks=pytest.mark.xfail(reason="GPU supports more valid values than CPU. "
-            "https://github.com/NVIDIA/spark-rapids/issues/7246")),
-    pytest.param('hive-delim-text/extended-float-values',   make_schema(DecimalType(38, 10)),   {},
-        marks=pytest.mark.xfail(reason="GPU supports more valid values than CPU. "
-            "https://github.com/NVIDIA/spark-rapids/issues/7246")),
+    ('hive-delim-text/extended-float-values', make_schema(DecimalType(10, 3)), {}),
+    ('hive-delim-text/extended-float-values', make_schema(DecimalType(38, 10)), {}),
 
     # Custom datasets
     ('hive-delim-text/Acquisition_2007Q3', acq_schema, {}),
@@ -256,6 +252,42 @@ def create_hive_text_table(spark, column_gen, text_table_name, data_path, fields
     spark.sql("CREATE TABLE " + text_table_name + " STORED AS TEXTFILE " +
               "LOCATION '" + data_path + "' " +
               "AS SELECT " + fields + " FROM input_view")
+
+
+@pytest.mark.skipif(is_spark_cdh(), reason="Hive text reads are disabled on CDH")
+@pytest.mark.parametrize('max_rows', [1, 1000])
+@pytest.mark.parametrize('decimal_type', [
+    DecimalType(7, 3), DecimalType(10, 3), DecimalType(38, 10)], ids=idfn)
+@pytest.mark.parametrize('values', [
+    pytest.param([
+        '0', '00012.3400', '+00012.', '-.125', '0' * 100,
+        '1e-99', '1e-100', '1e-00099', '1e-00100', '1e00000',
+        '0e-99', '0e+100', '0e+00100',
+        '1' * 38 + 'e-37', '1' * 39 + 'e-38',
+        '0' * 50 + '1' * 38 + 'e-37', '0' * 50 + '1' * 39 + 'e-38',
+        '-1e-99', '-1e-100', '+1e-99', '+1e-100',
+        '-' + '1' * 38 + 'e-37', '-' + '1' * 39 + 'e-38',
+        r'\N', ' 1', '1 ', 'NaN', 'Infinity'], id='parser-limits'),
+    pytest.param(['0e+99', '0e+00099'], id='zero-positive-exponent',
+        marks=pytest.mark.xfail(reason="GPU rejects zero with a large positive exponent: "
+                               "https://github.com/NVIDIA/cudf-spark/issues/7246")),
+    pytest.param([
+        '0.000000000000000000000000000000000000001E39',
+        '1.00499999999999999999999999999999999995'], id='long-fraction',
+        marks=pytest.mark.xfail(reason="Hive rounds long fractions before applying the exponent "
+                               "and target scale: https://github.com/NVIDIA/cudf-spark/issues/7246"))
+])
+@allow_non_gpu(*non_utc_allow_for_test_basic_hive_text_read)
+def test_hive_text_decimal_parser(spark_tmp_path, spark_tmp_table_factory, decimal_type, values,
+                                 max_rows):
+    # Write the original strings, since creating decimals first would hide parser boundaries.
+    data_path = spark_tmp_path + '/decimal_text'
+    with_cpu_session(lambda spark: spark.createDataFrame(
+        [(value,) for value in values], 'value string').coalesce(1).write.text(data_path))
+    assert_gpu_and_cpu_are_equal_collect(
+        read_hive_text_sql(data_path, make_schema(decimal_type), spark_tmp_table_factory),
+        conf=copy_and_update(hive_text_enabled_conf,
+                             {'spark.rapids.sql.reader.batchSizeRows': max_rows}))
 
 
 def read_hive_text_table(spark, text_table_name, fields="my_field"):
@@ -587,12 +619,8 @@ TableWriteMode = Enum('TableWriteMode', ['CTAS', 'CreateThenWrite'])
     ('hive-delim-text/extended-float-values', make_schema(IntegerType()),        {}),
     ('hive-delim-text/extended-float-values', make_schema(FloatType()),          {}),
     ('hive-delim-text/extended-float-values', make_schema(DoubleType()),         {}),
-    pytest.param('hive-delim-text/extended-float-values',   make_schema(DecimalType(10, 3)),   {},
-                 marks=pytest.mark.xfail(reason="GPU supports more valid values than CPU. "
-                                                "https://github.com/NVIDIA/spark-rapids/issues/7246")),
-    pytest.param('hive-delim-text/extended-float-values',   make_schema(DecimalType(38, 10)),   {},
-                 marks=pytest.mark.xfail(reason="GPU supports more valid values than CPU. "
-                                                "https://github.com/NVIDIA/spark-rapids/issues/7246")),
+    ('hive-delim-text/extended-float-values', make_schema(DecimalType(10, 3)), {}),
+    ('hive-delim-text/extended-float-values', make_schema(DecimalType(38, 10)), {}),
 
     # Custom datasets
     ('hive-delim-text/Acquisition_2007Q3', acq_schema, {}),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -580,8 +580,45 @@ class GpuHiveDelimitedTextPartitionReader(conf: Configuration,
   override def castStringToInt(input: ColumnVector, intType: DType): ColumnVector =
     CastStrings.toInteger(input, false, false, intType)
 
-  override def castStringToDecimal(input: ColumnVector, dt: DecimalType): ColumnVector =
-    CastStrings.toDecimal(input, false, false, dt.precision, -dt.scale)
+  override def castStringToDecimal(input: ColumnVector, dt: DecimalType): ColumnVector = {
+    // All-null (including empty) batches need no Hive-specific input validation.
+    if (input.getNullCount == input.getRowCount) {
+      return CastStrings.toDecimal(input, false, false, dt.precision, -dt.scale)
+    }
+    // Hive rejects more than 38 integer digits (excluding leading zeros) before applying
+    // the exponent, and rejects exponents outside [-99, 99], even for a zero mantissa.
+    // These restrictions are specific to Hive, not the generic string-to-decimal cast.
+    // Split off the integer part instead of using a large bounded-repeat regex, whose
+    // per-row matching workspace would grow excessively for large input batches.
+    val integerLengths = withResource(Scalar.fromString("+-0")) { leadingChars =>
+      withResource(input.lstrip(leadingChars)) { stripped =>
+        val separator = new RegexProgram("[.eE]", CaptureGroups.NON_CAPTURE)
+        withResource(stripped.stringSplit(separator, 2)) { parts =>
+          parts.getColumn(0).getCharLengths()
+        }
+      }
+    }
+    val integerTooLong = withResource(integerLengths) { _ =>
+      withResource(Scalar.fromInt(38)) { maxIntegerDigits =>
+        integerLengths.greaterThan(maxIntegerDigits)
+      }
+    }
+    val unsupported = withResource(integerTooLong) { _ =>
+      val exponentRegex = new RegexProgram(raw"[eE][+-]?0*[1-9][0-9][0-9]",
+        CaptureGroups.NON_CAPTURE)
+      withResource(input.containsRe(exponentRegex)) { exponentTooLarge =>
+        integerTooLong.or(exponentTooLarge)
+      }
+    }
+    withResource(unsupported) { _ =>
+      withResource(CastStrings.toDecimal(input, false, false, dt.precision, -dt.scale)) {
+          converted =>
+        withResource(Scalar.fromNull(converted.getType)) { nullDecimal =>
+          unsupported.ifElse(nullDecimal, converted)
+        }
+      }
+    }
+  }
 
   /**
    * Override of [[com.nvidia.spark.rapids.GpuTextBasedPartitionReader.castStringToDate()]],


### PR DESCRIPTION
**JaCoCo production line coverage: +20 lines** (`sql-plugin +20`; shim 350, single-run covered added production lines)

Contributes to #7246.

### Description

This is a partial correctness fix for Hive text-file decimal reads. The GPU currently returns a number for some strings that Hive rejects as `null`, so the same query can produce different results with acceleration enabled. This change applies Hive's integer-digit and exponent limits to the GPU reader and re-enables the six existing decimal read/write cases. Generic SQL string-to-decimal casts are unchanged. Long-fraction rounding and zero mantissas with large positive exponents remain known differences under #7246; this PR does not close that issue.

- Reject more than 38 integer digits, excluding leading zeros, and exponents outside `[-99, 99]`, matching Hive before target precision/scale conversion.
- Add raw-string boundary coverage across decimal32/64/128 and one-row/multi-row batches. Writing strings directly preserves the parser inputs; constructing decimal values first would hide these boundaries.
- Keep the two residual families explicitly marked and update the compatibility documentation.

The filter is confined to the Hive reader. It splits out the integer part and uses a compact exponent regex; a bounded-repeat regex prototype required excessive per-row workspace. All-null batches use the existing cast directly. GPU resources remain scoped within the existing retry path.

AI assistance: The change and PR description were prepared with Codex assistance.

#### Validation

The original six cases failed with `--runxfail` before the fix (CPU `null` versus GPU numeric values). After the fix, the six recovered cases plus six parser-limit combinations passed unmasked: **12 passed, 155 deselected**, seed `1`.

Full `hive_delimited_text_test.py`, seed `72462026`, UTC, Python 3.10.18, RTX 5880 Ada, 512 MiB GPU pool:

| Runtime | Result |
| --- | --- |
| Apache Spark 3.3.0 | 155 passed, 12 xfailed; 111.97 s |
| Apache Spark 3.5.0 | 155 passed, 12 xfailed; 123.99 s |

The 12 expected failures are the two documented residual input groups × three decimal widths × two batch sizes. The passing cases retain CPU/GPU equality checks and GPU-plan enforcement; Hive scanning is not CPU-allowlisted in UTC. Databricks was not run locally; the title requests its CI matrix without reduced parameter selection.

Both Maven builds reported `BUILD SUCCESS`. Scalastyle and the resource-nesting gate also passed. Independent local source review found no remaining actionable findings after fixing the all-null-batch regression.

<details>
<summary>Build, coverage, and performance evidence</summary>

Build command, run separately for `buildver=330` and `350`:

```bash
mvn package -pl dist,integration_tests -am -Dbuildver=350 -DskipTests \
  -Dmaven.repo.local=./.mvn-repo \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm
```

With version-matched `SPARK_HOME` and Python 3.10 selected for both PySpark interpreters:

```bash
TZ=UTC TEST_PARALLEL=1 DATAGEN_SEED=72462026 \
  PYSP_TEST_spark_rapids_memory_gpu_allocSize=512m \
  TESTS=hive_delimited_text_test.py \
  bash integration_tests/run_pyspark_from_build.sh -v
```

JaCoCo used the Spark 3.5 full-file run and exact runtime-JAR classfiles, with no class-ID mismatch warnings. Intersecting executed lines with added JVM production lines measured **20 covered lines in `sql-plugin`**, the only affected JVM production module. This is a fix-line measurement, not a marginal delta against nightly coverage; other JVM modules have no added production lines in this patch.

The added filter has a measurable cost. A synchronized GPU conversion microbenchmark used 1,000,000 strings, `decimal(38,10)`, five warmups, and nine alternating-order rounds of ten casts per implementation in a 512 MiB pool:

| Input mix | Existing cast | Cast with Hive filter |
| --- | --- | --- |
| Ordinary decimals and nulls | 0.132 ms | 0.992 ms (7.515×) |
| Leading-zero/exponent boundaries | 0.519 ms | 1.822 ms (3.514×) |

These timings measure decimal conversion only, not end-to-end Hive throughput. The filter adds about 0.86–1.30 ms per million rows for these two input mixes; no end-to-end performance claim is made.

</details>

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
