### PR TITLE
[SkipRecovery] Restore empty partitioned Parquet write tests [reduced-it] [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -752,28 +752,36 @@ def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path, aqe_en
         ))
 
 
-@pytest.mark.skipif(True, reason="currently not support write emtpy data: https://github.com/NVIDIA/spark-rapids/issues/6453")
+def _assert_write_empty_partitioned_data(spark_tmp_path, max_concurrent_writers):
+    schema = StructType(
+        [StructField("c1", StringType()), StructField("c2", IntegerType()), StructField("c3", IntegerType())])
+    data = []  # empty data
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+
+    def read_empty_data(spark, path):
+        # Empty partitioned output has no data files from which either writer can infer a schema.
+        with pytest.raises(pyspark.sql.utils.AnalysisException, match="Unable to infer schema for Parquet"):
+            spark.read.parquet(path)
+        result = spark.read.schema(schema).parquet(path)
+        assert result.schema == schema
+        return result
+
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        lambda spark, path: spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+            .write.mode("overwrite").partitionBy('c1', 'c2').parquet(path),
+        read_empty_data,
+        data_path,
+        conf={"spark.sql.maxConcurrentOutputFileWriters": max_concurrent_writers})
+
+
+@validate_execs_in_gpu_plan("GpuDataWritingCommandExec")
 def test_write_empty_data_concurrent_writer(spark_tmp_path):
-    schema = StructType(
-        [StructField("c1", StringType()), StructField("c2", IntegerType()), StructField("c3", IntegerType())])
-    data = []  # empty data
-    data_path = spark_tmp_path + '/PARQUET_DATA'
-    with_gpu_session(lambda spark: spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
-                     .write.mode("overwrite").partitionBy('c1', 'c2').parquet(data_path),
-                     # concurrent writer
-                     {"spark.sql.maxConcurrentOutputFileWriters": 10})
-    with_cpu_session(lambda spark: spark.read.parquet(data_path).collect())
+    _assert_write_empty_partitioned_data(spark_tmp_path, 10)
 
 
-@pytest.mark.skipif(True, reason="currently not support write emtpy data: https://github.com/NVIDIA/spark-rapids/issues/6453")
+@validate_execs_in_gpu_plan("GpuDataWritingCommandExec")
 def test_write_empty_data_single_writer(spark_tmp_path):
-    schema = StructType(
-        [StructField("c1", StringType()), StructField("c2", IntegerType()), StructField("c3", IntegerType())])
-    data = []  # empty data
-    data_path = spark_tmp_path + '/PARQUET_DATA'
-    with_gpu_session(lambda spark: spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
-                     .write.mode("overwrite").partitionBy('c1', 'c2').parquet(data_path))
-    with_cpu_session(lambda spark: spark.read.parquet(data_path).collect())
+    _assert_write_empty_partitioned_data(spark_tmp_path, 0)
 
 
 PartitionWriteMode = Enum('PartitionWriteMode', ['Static', 'Dynamic'])


### PR DESCRIPTION
**JaCoCo production line coverage: not fully measurable locally — no compatible nightly/runtime bytecode tuple** (all five report groups N/A; details below).

Contributes to #6453.

### Description

This test-only change restores two skipped checks for empty partitioned Parquet writes. Their original readback expected Spark to infer a schema from output with no data files, which also fails on CPU. The restored tests verify the shared CPU/GPU behavior: schema inference fails, while reading with the declared schema returns no rows. Production behavior is unchanged; these two cases showed no CPU/GPU divergence.

Both the single-writer and concurrent-writer cases compare CPU/GPU outputs and require `GpuDataWritingCommandExec`. Existing test names are retained. This recovers the two exclusions linked to #6453 without claiming to resolve that issue's broader file-format scope.

AI assistance: The change and PR description were prepared with Codex assistance.

#### Validation

- Apache Spark 3.5.0, Scala 2.12, Python 3.10.18, RTX 5880 Ada: focused empty-output tests **53 passed, 335 deselected**; full `parquet_write_test.py`: **387 passed, 1 skipped** (385.75 seconds).
- Exact-main shim-350 integration-test build: **BUILD SUCCESS**. The original two tests, with only their skips removed, reached the GPU writer and failed at schema inference. CPU probes on Spark 3.3.0 and 3.5.0 produced the same error for writer settings 0 and 10.
- Three independent local source reviewers reported no actionable findings. Databricks was not run locally.

<details>
<summary>Commands, CI selection, and coverage provenance</summary>

Built from `b50f7744723118d5bd63b419fc280a8e52d1a447`:

```bash
mvn package -DskipTests -pl integration_tests -am -Dbuildver=350 \
  -Dmaven.repo.local=./.mvn-repo \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm

# SPARK_HOME and both PYSPARK interpreters set to Spark 3.5.0 / Python 3.10.
# local[2], TEST_PARALLEL=0, TEST_TYPE=developer, DATAGEN_SEED=0, TZ=UTC;
# spark.rapids.memory.gpu alloc/maxAlloc/minAllocFraction = 0.3/0.3/0.
TESTS=parquet_write_test.py \
TEST='test_write_empty_data or test_write_empty_parquet_round_trip' \
  integration_tests/run_pyspark_from_build.sh --capture=tee-sys
TESTS=parquet_write_test.py TEST='' \
  integration_tests/run_pyspark_from_build.sh --capture=tee-sys
```

`[reduced-it]` retains both recovered cases: neither test has a parametrization decorator, and each collected one node. The full enclosing file was run without reduced selection. Scala unit tests retain the parallel default. `[databricks]` requests coverage for these shared tests.

JaCoCo execution data was collected for the current runtime. The refreshed nightly is Scala 2.12 / shim 350 / 26.10.0-SNAPSHOT b21 at `7ad4b98727db387b84a5030c34463733da45cf5f`. No compatible complete baseline/runtime/classfile tuple was available: the older local runtime candidate has class-ID mismatches in `sql-plugin` and `iceberg`, while the current runtime contains newer production bytecode. All five report groups (`sql-plugin`, `iceberg`, `shuffle-plugin`, `udf-compiler`, and `delta-lake`) are N/A for marginal contribution; none is reported as measured zero. The shim-350 Delta group is a stub, not real Delta Lake coverage.

</details>

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
