### PR TITLE
Fix 0-col case in concatenateBatchesWithRetry + canUsePartialSortAgg fix [databricks]

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -518,6 +518,32 @@ def assert_gpu_fallback_write_sql(write_func,
         jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.endCapture()
 
 
+def collect_plan_nodes(plan):
+    """Flatten a JVM SparkPlan into a list of nodes, parents before children.
+
+    Intended for the gpu_plan_assertion callback of
+    assert_cpu_and_gpu_are_equal_collect_with_capture. This does not descend into
+    AdaptiveSparkPlanExec or QueryStageExec, so a caller that needs the whole tree should
+    disable AQE.
+    """
+    nodes = [plan]
+    children = plan.children().iterator()
+    while children.hasNext():
+        nodes.extend(collect_plan_nodes(children.next()))
+    return nodes
+
+def plan_metric(node, name):
+    """Value of a named metric on a JVM plan node, or None if the node has no such metric.
+
+    Many GPU metrics are only registered at certain values of spark.rapids.sql.metrics.level
+    (numOutputBatches on a non-aggregate exec is DEBUG), so a None here usually means the
+    metrics level is too low rather than that the operator did no work.
+    """
+    metrics = node.metrics()
+    if not metrics.contains(name):
+        return None
+    return metrics.apply(name).value()
+
 def assert_cpu_and_gpu_are_equal_collect_with_capture(func,
         exist_classes='',
         non_exist_classes='',

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -534,6 +534,245 @@ def test_hash_reduction_sum_count_action(data_gen):
         conf = {'spark.sql.ansi.enabled': False}
     )
 
+def _zero_column_reduction_aggs(plan):
+    """GpuHashAggregate(keys=[], functions=[], output=[]) nodes -- the shape that produces
+    zero-column batches."""
+    return [node for node in collect_plan_nodes(plan)
+            if node.getClass().getSimpleName() == "GpuHashAggregateExec"
+            and node.groupingExpressions().isEmpty()
+            and node.output().isEmpty()]
+
+def _child_batch_counts(plan):
+    """For each zero-column reduction aggregate, how many batches its child handed it."""
+    counts = []
+    for agg in _zero_column_reduction_aggs(plan):
+        child = agg.children().apply(0)
+        batches = plan_metric(child, "numOutputBatches")
+        assert batches is not None, \
+            "Expected a numOutputBatches metric on {}; is the metrics level high enough?:\n{}".format(
+                child.getClass().getSimpleName(), plan)
+        counts.append((child.getClass().getSimpleName(), batches))
+    return counts
+
+def _dedup_aggs(plan):
+    """GpuHashAggregate nodes with grouping keys but no aggregate functions.
+
+    aggregateExpressions is empty here, so the aggModes set is empty and `forall` on it is
+    vacuously true -- the shape that canUsePartialSortAgg's `aggModes.nonEmpty` guard exists
+    to reject.
+    """
+    return [node for node in collect_plan_nodes(plan)
+            if node.getClass().getSimpleName() == "GpuHashAggregateExec"
+            and not node.groupingExpressions().isEmpty()
+            and node.aggregateExpressions().isEmpty()]
+
+def _assert_dedup_not_single_pass(expect_forced=False):
+    """Plan assertion: the query still builds the empty-aggModes dedup shape, and that shape
+    was kept off the single pass partial sort path.
+
+    allowSinglePassAgg is the plan-level output of canUsePartialSortAgg, so this pins the
+    guard directly. Removing the `aggModes.nonEmpty` check flips it to True and the query
+    returns duplicate rows.
+    """
+    def do_assert(plan):
+        aggs = _dedup_aggs(plan)
+        assert aggs, \
+            "Expected an aggregate with grouping keys and no aggregate functions in:\n{}".format(plan)
+        for agg in aggs:
+            assert not agg.allowSinglePassAgg(), \
+                "Expected allowSinglePassAgg=False on the dedup aggregate:\n{}".format(plan)
+            if expect_forced:
+                # the force conf is set, so this also pins that the guard beats the conf
+                assert agg.forceSinglePassAgg(), \
+                    "Expected forceSinglePassAgg=True from the test conf:\n{}".format(plan)
+    return do_assert
+
+def _assert_zero_column_agg_batches(expect_multiple):
+    """Plan assertion: the query really did build a zero-column reduction aggregate, and it
+    consumed 2+ batches when the configuration was meant to force that.
+
+    Without this an unrelated change to batching could quietly turn one of these regression
+    tests into a single-batch query, which takes the `size == 1` early return in
+    concatenateBatchesWithRetry and therefore exercises nothing.
+    """
+    def do_assert(plan):
+        counts = _child_batch_counts(plan)
+        assert counts, "Expected a zero-column reduction aggregate in:\n{}".format(plan)
+        if expect_multiple:
+            assert any(n >= 2 for (_, n) in counts), \
+                "Expected a zero-column aggregate to consume 2+ batches, got {}:\n{}".format(
+                    counts, plan)
+    return do_assert
+
+# numOutputBatches on a non-aggregate exec is a DEBUG-level metric (GpuExec's
+# outputBatchesLevel), and collect_plan_nodes does not descend into AdaptiveSparkPlanExec,
+# so both settings are needed for the plan assertions above to see the whole tree.
+_plan_metric_conf = {'spark.rapids.sql.metrics.level': 'DEBUG',
+                     'spark.sql.adaptive.enabled': False}
+
+@pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
+@pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
+def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_size_bytes):
+    # Regression test: a reduction (keyless) aggregate whose only function gets pruned to
+    # zero columns by count()-driven column pruning must not crash when the aggregate's own
+    # cross-batch merge has to concatenate 2+ zero-column batches. See
+    # GpuAggregateIterator.concatenateBatchesWithRetry / GpuColumnVector.from.
+    #
+    # The bug needs 2+ batches reaching the partial aggregate, which is what
+    # override_batch_size_bytes=1 forces: it drives the row-to-columnar transition down to
+    # roughly one row per batch, so these 100 rows arrive as ~100 batches. At the default
+    # 1 GiB the same query is a single batch and hits the `size == 1` early return, which is
+    # why the older test_hash_reduction_sum_count_action never caught this.
+    # disable ANSI mode to avoid overflow errors on longs_with_nulls
+    conf = {'spark.sql.ansi.enabled': False}
+    conf.update(_plan_metric_conf)
+    if override_batch_size_bytes is not None:
+        conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
+    # groupBy().count() rather than count(): it prunes the sum the same way, but keeps the
+    # pruned plan on the DataFrame we hand back, so the plan assertion can see it.
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')).groupBy().count(),
+        conf = conf,
+        gpu_plan_assertion = _assert_zero_column_agg_batches(
+            override_batch_size_bytes is not None))
+
+@pytest.mark.parametrize('override_batch_size_bytes', [None, 1024], ids=idfn)
+def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
+    # Regression test for the shape seen in TPC-DS q97 run under a benchmark harness that
+    # only consumes the row count: a join feeds a keyless aggregate whose aggregate
+    # functions are all pruned away by count()-driven column pruning, leaving
+    # GpuHashAggregate(keys=[], functions=[], output=[]) directly above the join.
+    #
+    # The bug needs 2+ batches to reach one such aggregate. Rather than assume the
+    # configuration produces that, the plan assertion below reads the numOutputBatches
+    # metric off the aggregate's child, which is exactly the number of batches the
+    # aggregate consumed, and requires 2+ for the small-batch case. Without that check a
+    # future change to batching could silently reduce this to a one-batch query, which
+    # takes the `size == 1` early return in concatenateBatchesWithRetry and tests nothing.
+    #
+    # batchSizeBytes is 1024 rather than 1: a 1-byte target puts roughly one row in every
+    # batch for the whole join too, which makes the test take minutes.
+    #
+    # AQE is disabled so that the executed plan handed to the assertion is the whole tree;
+    # collect_plan_nodes does not descend into AdaptiveSparkPlanExec/QueryStageExec.
+    #
+    # numOutputBatches on non-aggregate execs is a DEBUG-level metric (GpuExec's
+    # outputBatchesLevel), so the metrics level has to be raised for the assertion to see it.
+    conf = {'spark.sql.ansi.enabled': False,
+            'spark.sql.autoBroadcastJoinThreshold': '-1',
+            'spark.sql.adaptive.enabled': False,
+            'spark.rapids.sql.metrics.level': 'DEBUG'}
+    if override_batch_size_bytes is not None:
+        conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
+
+    def do_it(spark):
+        a = spark.range(0, 2000, 1, 4).selectExpr("id as k", "id as v1")
+        b = spark.range(0, 2000, 2, 4).selectExpr("id as k", "id as v2")
+        # groupBy().count() rather than count(): it prunes the sums the same way, but keeps
+        # the pruned plan on the DataFrame we hand back, so the plan assertion can see it.
+        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2")).groupBy().count()
+
+    def assert_batches(plan):
+        counts = _child_batch_counts(plan)
+        assert counts, "Expected a zero-column reduction aggregate in:\n{}".format(plan)
+        if override_batch_size_bytes is not None:
+            assert any(n >= 2 for (_, n) in counts), \
+                "Expected a zero-column aggregate to consume 2+ batches, got {}:\n{}".format(
+                    counts, plan)
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it, conf = conf, gpu_plan_assertion = assert_batches)
+
+@pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
+def test_distinct_zero_columns(override_batch_size_bytes):
+    # Regression test for the `aggModes.nonEmpty` guard on canUsePartialSortAgg
+    # (GpuAggregateExec.scala). Catalyst plans this as
+    #   HashAggregate(keys=[0#x], functions=[], output=[])
+    # -- a zero-column distinct() gets a literal 0 as its grouping key, so
+    # groupingExpressions is non-empty while aggregateExpressions is empty. `forall` is
+    # vacuously true on the resulting empty aggModes set, so the aggregate is misreported as
+    # a Partial one and takes the single pass partial sort path, which emits
+    # non-fully-aggregated output for a terminal dedup that has no final agg to merge it.
+    # The GPU then returns 1000 rows where the CPU returns 1.
+    #
+    # This checks wrong results, not the zero-column crash: verified to still pass with the
+    # concatenateBatchesWithRetry `dataTypes.nonEmpty` guard removed.
+    conf = dict(_plan_metric_conf)
+    if override_batch_size_bytes is not None:
+        conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.range(0, 1000, 1, 1).select().distinct(),
+        conf = conf,
+        gpu_plan_assertion = _assert_dedup_not_single_pass()
+    )
+
+@pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
+@pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
+def test_hash_grpby_literal_sum_count_action(data_gen, override_batch_size_bytes):
+    # Coverage for a groupBy on a literal/constant key. Catalyst does NOT constant-fold the
+    # key away: the plan keeps groupingExpressions=[1] and, once count() prunes sum('b'),
+    # aggregateExpressions=[] -- the same empty-aggModes dedup shape as
+    # test_distinct_zero_columns rather than a keyless reduction.
+    #
+    # This does not reproduce either aggregate bug on its own: verified to pass with the
+    # concatenateBatchesWithRetry `dataTypes.nonEmpty` guard removed and with the
+    # canUsePartialSortAgg `aggModes.nonEmpty` guard removed. Unlike
+    # test_hash_grpby_skewed_single_key_batch_size it does not set the force conf, and at
+    # this size the firstBatchHeuristic does not pick the single pass path on its own. The
+    # plan assertion pins the shape so that a change in folding or in the heuristic shows up
+    # here rather than silently making the test vacuous.
+    # disable ANSI mode to avoid overflow errors on longs_with_nulls
+    conf = {'spark.sql.ansi.enabled': False}
+    conf.update(_plan_metric_conf)
+    if override_batch_size_bytes is not None:
+        conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: gen_df(spark, data_gen, length=100).groupby(f.lit(1)).agg(
+            f.sum('b')).groupBy().count(),
+        conf = conf,
+        gpu_plan_assertion = _assert_dedup_not_single_pass()
+    )
+
+
+@pytest.mark.parametrize('override_batch_size_bytes', [None, 1024], ids=idfn)
+def test_hash_grpby_skewed_single_key_batch_size(override_batch_size_bytes):
+    # Regression test for the `aggModes.nonEmpty` guard on canUsePartialSortAgg, reached
+    # through a grouped aggregate rather than a distinct(). assert_gpu_and_cpu_row_counts_equal
+    # runs count(), which prunes sum('id') away and leaves
+    #   HashAggregate(keys=[key], functions=[], output=[key])
+    # i.e. a dedup on a single key with an empty aggModes set. Verified: this fails (GPU 5
+    # rows vs CPU 1) with the aggModes.nonEmpty guard removed and passes with it, and is
+    # unaffected by the concatenateBatchesWithRetry `dataTypes.nonEmpty` guard.
+    #
+    # The mechanism that turns the mis-selected path into duplicate rows is below.
+    # DynamicGpuPartialAggregateIterator.singlePassSortedAgg
+    # (GpuAggregateExec.scala) sorts the input on the grouping key and runs a
+    # per-batch partial aggregation with no cross-batch merge, assuming a group's rows
+    # never span two output batches. GpuOutOfCoreSortIterator's merge-sort (GpuSortExec.scala,
+    # mergeSortEnoughToOutput) finalizes rows into separate output batches as soon as global
+    # ordering is provably safe (an upperBound cutoff against the next pending batch's first
+    # row), independent of whether more rows sharing that same key are still pending. Once a
+    # single key's total row volume approaches/exceeds the target batch size, that key's rows
+    # get split across multiple output batches and each fragment is aggregated separately,
+    # producing duplicate output rows for what should be one group.
+    #
+    # For real (non-degenerate) skewed data the normal heuristic (firstBatchHeuristic) avoids
+    # this path -- a low cardinality/numRows ratio drives estimatedGrowthAfterAgg below 1.0, so
+    # it correctly falls back to fullHashAggWithMerge instead of singlePassSortedAgg. We use the
+    # internal, test-only spark.rapids.sql.agg.forceSinglePassPartialSort conf to force the
+    # buggy path directly and isolate the defect in singlePassSortedAgg itself from the
+    # heuristic that normally protects against it.
+    conf = {'spark.rapids.sql.agg.forceSinglePassPartialSort': True}
+    conf.update(_plan_metric_conf)
+    if override_batch_size_bytes is not None:
+        conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.range(0, 200000).withColumn('key', f.lit(1)).groupby('key').agg(
+            f.sum('id')).groupBy().count(),
+        conf = conf,
+        gpu_plan_assertion = _assert_dedup_not_single_pass(expect_forced=True)
+    )
+
 # Make sure that we can do computation in the group by columns
 @ignore_order
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -554,33 +554,35 @@ def _child_batch_counts(plan):
         counts.append((child.getClass().getSimpleName(), batches))
     return counts
 
-def _dedup_aggs(plan):
-    """GpuHashAggregate nodes with grouping keys but no aggregate functions.
+def _aggs_with_no_agg_functions(plan):
+    """GpuHashAggregate nodes that have grouping keys but an empty aggregateExpressions.
 
-    aggregateExpressions is empty here, so the aggModes set is empty and `forall` on it is
-    vacuously true -- the shape that canUsePartialSortAgg's `aggModes.nonEmpty` guard exists
-    to reject.
+    A GROUP BY with no aggregate functions is a distinct on the keys. aggModes is derived
+    from aggregateExpressions, so it is empty here, and `forall` on an empty set is
+    vacuously true -- this is the shape canUsePartialSortAgg's `aggModes.nonEmpty` guard
+    exists to reject.
     """
     return [node for node in collect_plan_nodes(plan)
             if node.getClass().getSimpleName() == "GpuHashAggregateExec"
             and not node.groupingExpressions().isEmpty()
             and node.aggregateExpressions().isEmpty()]
 
-def _assert_dedup_not_single_pass(expect_forced=False):
-    """Plan assertion: the query still builds the empty-aggModes dedup shape, and that shape
-    was kept off the single pass partial sort path.
+def _assert_no_agg_functions_not_single_pass(expect_forced=False):
+    """Plan assertion: the query still builds an aggregate with no aggregate functions, and
+    that aggregate was kept off the single pass partial sort path.
 
     allowSinglePassAgg is the plan-level output of canUsePartialSortAgg, so this pins the
     guard directly. Removing the `aggModes.nonEmpty` check flips it to True and the query
     returns duplicate rows.
     """
     def do_assert(plan):
-        aggs = _dedup_aggs(plan)
+        aggs = _aggs_with_no_agg_functions(plan)
         assert aggs, \
             "Expected an aggregate with grouping keys and no aggregate functions in:\n{}".format(plan)
         for agg in aggs:
             assert not agg.allowSinglePassAgg(), \
-                "Expected allowSinglePassAgg=False on the dedup aggregate:\n{}".format(plan)
+                "Expected allowSinglePassAgg=False on the aggregate with no aggregate " \
+                "functions:\n{}".format(plan)
             if expect_forced:
                 # the force conf is set, so this also pins that the guard beats the conf
                 assert agg.forceSinglePassAgg(), \
@@ -692,7 +694,7 @@ def test_distinct_zero_columns(override_batch_size_bytes):
     # groupingExpressions is non-empty while aggregateExpressions is empty. `forall` is
     # vacuously true on the resulting empty aggModes set, so the aggregate is misreported as
     # a Partial one and takes the single pass partial sort path, which emits
-    # non-fully-aggregated output for a terminal dedup that has no final agg to merge it.
+    # non-fully-aggregated output, which here has no final agg downstream to merge it.
     # The GPU then returns 1000 rows where the CPU returns 1.
     #
     # This checks wrong results, not the zero-column crash: verified to still pass with the
@@ -703,7 +705,7 @@ def test_distinct_zero_columns(override_batch_size_bytes):
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: spark.range(0, 1000, 1, 1).select().distinct(),
         conf = conf,
-        gpu_plan_assertion = _assert_dedup_not_single_pass()
+        gpu_plan_assertion = _assert_no_agg_functions_not_single_pass()
     )
 
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
@@ -711,7 +713,7 @@ def test_distinct_zero_columns(override_batch_size_bytes):
 def test_hash_grpby_literal_sum_count_action(data_gen, override_batch_size_bytes):
     # Coverage for a groupBy on a literal/constant key. Catalyst does NOT constant-fold the
     # key away: the plan keeps groupingExpressions=[1] and, once count() prunes sum('b'),
-    # aggregateExpressions=[] -- the same empty-aggModes dedup shape as
+    # aggregateExpressions=[] -- the same no-aggregate-functions shape as
     # test_distinct_zero_columns rather than a keyless reduction.
     #
     # This does not reproduce either aggregate bug on its own: verified to pass with the
@@ -730,18 +732,19 @@ def test_hash_grpby_literal_sum_count_action(data_gen, override_batch_size_bytes
         lambda spark: gen_df(spark, data_gen, length=100).groupby(f.lit(1)).agg(
             f.sum('b')).groupBy().count(),
         conf = conf,
-        gpu_plan_assertion = _assert_dedup_not_single_pass()
+        gpu_plan_assertion = _assert_no_agg_functions_not_single_pass()
     )
 
 
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1024], ids=idfn)
 def test_hash_grpby_skewed_single_key_batch_size(override_batch_size_bytes):
     # Regression test for the `aggModes.nonEmpty` guard on canUsePartialSortAgg, reached
-    # through a grouped aggregate rather than a distinct(). assert_gpu_and_cpu_row_counts_equal
-    # runs count(), which prunes sum('id') away and leaves
+    # through a grouped aggregate rather than a distinct(). The count() prunes sum('id') away
+    # and leaves
     #   HashAggregate(keys=[key], functions=[], output=[key])
-    # i.e. a dedup on a single key with an empty aggModes set. Verified: this fails (GPU 5
-    # rows vs CPU 1) with the aggModes.nonEmpty guard removed and passes with it, and is
+    # i.e. a distinct on a single key: no aggregate functions remain, so aggModes is empty.
+    # Verified: this fails (GPU 5 rows vs CPU 1) with the aggModes.nonEmpty guard removed
+    # and passes with it, and is
     # unaffected by the concatenateBatchesWithRetry `dataTypes.nonEmpty` guard.
     #
     # The mechanism that turns the mis-selected path into duplicate rows is below.
@@ -770,7 +773,7 @@ def test_hash_grpby_skewed_single_key_batch_size(override_batch_size_bytes):
         lambda spark: spark.range(0, 200000).withColumn('key', f.lit(1)).groupby('key').agg(
             f.sum('id')).groupBy().count(),
         conf = conf,
-        gpu_plan_assertion = _assert_dedup_not_single_pass(expect_forced=True)
+        gpu_plan_assertion = _assert_no_agg_functions_not_single_pass(expect_forced=True)
     )
 
 # Make sure that we can do computation in the group by columns

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -575,7 +575,7 @@ def _assert_no_agg_functions_not_single_pass(expect_forced=False):
     guard directly. Removing the `aggModes.nonEmpty` check flips it to True and the query
     returns duplicate rows.
     """
-    def do_assert(plan):
+    def do_assert(cpu_plan, plan):
         aggs = _aggs_with_no_agg_functions(plan)
         assert aggs, \
             "Expected an aggregate with grouping keys and no aggregate functions in:\n{}".format(plan)
@@ -597,7 +597,7 @@ def _assert_zero_column_agg_batches(expect_multiple):
     tests into a single-batch query, which takes the `size == 1` early return in
     concatenateBatchesWithRetry and therefore exercises nothing.
     """
-    def do_assert(plan):
+    def do_assert(cpu_plan, plan):
         counts = _child_batch_counts(plan)
         assert counts, "Expected a zero-column reduction aggregate in:\n{}".format(plan)
         if expect_multiple:
@@ -674,7 +674,7 @@ def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
         # the pruned plan on the DataFrame we hand back, so the plan assertion can see it.
         return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2")).groupBy().count()
 
-    def assert_batches(plan):
+    def assert_batches(cpu_plan, plan):
         counts = _child_batch_counts(plan)
         assert counts, "Expected a zero-column reduction aggregate in:\n{}".format(plan)
         if override_batch_size_bytes is not None:

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -589,22 +589,27 @@ def _assert_no_agg_functions_not_single_pass(expect_forced=False):
                     "Expected forceSinglePassAgg=True from the test conf:\n{}".format(plan)
     return do_assert
 
-def _assert_zero_column_agg_batches(expect_multiple):
-    """Plan assertion: the query really did build a zero-column reduction aggregate, and it
-    consumed 2+ batches when the configuration was meant to force that.
+def _assert_zero_column_agg_batches(run_it, expect_multiple):
+    """Run `run_it` under plan capture, then check that a zero-column reduction aggregate ran
+    and, when `expect_multiple`, that it consumed 2+ batches.
 
-    Without this an unrelated change to batching could quietly turn one of these regression
-    tests into a single-batch query, which takes the `size == 1` early return in
-    concatenateBatchesWithRetry and therefore exercises nothing.
+    A single-batch query takes the `size == 1` early return in concatenateBatchesWithRetry.
     """
-    def do_assert(cpu_plan, plan):
-        counts = _child_batch_counts(plan)
-        assert counts, "Expected a zero-column reduction aggregate in:\n{}".format(plan)
-        if expect_multiple:
-            assert any(n >= 2 for (_, n) in counts), \
-                "Expected a zero-column aggregate to consume 2+ batches, got {}:\n{}".format(
-                    counts, plan)
-    return do_assert
+    callback = spark_jvm().org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+    callback.startCapture()
+    try:
+        run_it()
+        plans = callback.getResultsWithTimeout(10000)
+    finally:
+        callback.endCapture()
+    counts = []
+    for plan in plans:
+        counts.extend(_child_batch_counts(callback.extractExecutedPlan(plan)))
+    assert counts, "Expected a zero-column reduction aggregate in the captured plans:\n{}".format(
+        "\n".join([str(plan) for plan in plans]))
+    if expect_multiple:
+        assert any(n >= 2 for (_, n) in counts), \
+            "Expected a zero-column aggregate to consume 2+ batches, got {}".format(counts)
 
 # numOutputBatches on a non-aggregate exec is a DEBUG-level metric (GpuExec's
 # outputBatchesLevel), and collect_plan_nodes does not descend into AdaptiveSparkPlanExec,
@@ -615,51 +620,34 @@ _plan_metric_conf = {'spark.rapids.sql.metrics.level': 'DEBUG',
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
 def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_size_bytes):
-    # Regression test: a reduction (keyless) aggregate whose only function gets pruned to
-    # zero columns by count()-driven column pruning must not crash when the aggregate's own
-    # cross-batch merge has to concatenate 2+ zero-column batches. See
+    # Regression test: count() prunes sum('b') away, leaving a keyless aggregate with zero
+    # columns. Its cross-batch merge must not crash on 2+ zero-column batches. See
     # GpuAggregateIterator.concatenateBatchesWithRetry / GpuColumnVector.from.
     #
-    # The bug needs 2+ batches reaching the partial aggregate, which is what
-    # override_batch_size_bytes=1 forces: it drives the row-to-columnar transition down to
-    # roughly one row per batch, so these 100 rows arrive as ~100 batches. At the default
-    # 1 GiB the same query is a single batch and hits the `size == 1` early return, which is
-    # why the older test_hash_reduction_sum_count_action never caught this.
+    # override_batch_size_bytes=1 puts roughly one row in each batch, so these 100 rows reach
+    # the partial aggregate as ~100 batches. At the default 1 GiB it is a single batch.
     # disable ANSI mode to avoid overflow errors on longs_with_nulls
     conf = {'spark.sql.ansi.enabled': False}
     conf.update(_plan_metric_conf)
     if override_batch_size_bytes is not None:
         conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
-    # groupBy().count() rather than count(): it prunes the sum the same way, but keeps the
-    # pruned plan on the DataFrame we hand back, so the plan assertion can see it.
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
-        lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')).groupBy().count(),
-        conf = conf,
-        gpu_plan_assertion = _assert_zero_column_agg_batches(
-            override_batch_size_bytes is not None))
+    _assert_zero_column_agg_batches(
+        lambda: assert_gpu_and_cpu_row_counts_equal(
+            lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')),
+            conf = conf),
+        override_batch_size_bytes is not None)
 
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1024], ids=idfn)
 def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
-    # Regression test for the shape seen in TPC-DS q97 run under a benchmark harness that
-    # only consumes the row count: a join feeds a keyless aggregate whose aggregate
-    # functions are all pruned away by count()-driven column pruning, leaving
-    # GpuHashAggregate(keys=[], functions=[], output=[]) directly above the join.
+    # Regression test for the TPC-DS q97 shape: count() prunes the sums away, leaving
+    # GpuHashAggregate(keys=[], functions=[], output=[]) directly above a join, with no
+    # shuffle in between to coalesce its zero-column batches.
     #
-    # The bug needs 2+ batches to reach one such aggregate. Rather than assume the
-    # configuration produces that, the plan assertion below reads the numOutputBatches
-    # metric off the aggregate's child, which is exactly the number of batches the
-    # aggregate consumed, and requires 2+ for the small-batch case. Without that check a
-    # future change to batching could silently reduce this to a one-batch query, which
-    # takes the `size == 1` early return in concatenateBatchesWithRetry and tests nothing.
+    # batchSizeBytes is 1024 rather than 1: a 1-byte target also puts one row in every batch
+    # of the join, which makes the test take minutes.
     #
-    # batchSizeBytes is 1024 rather than 1: a 1-byte target puts roughly one row in every
-    # batch for the whole join too, which makes the test take minutes.
-    #
-    # AQE is disabled so that the executed plan handed to the assertion is the whole tree;
-    # collect_plan_nodes does not descend into AdaptiveSparkPlanExec/QueryStageExec.
-    #
-    # numOutputBatches on non-aggregate execs is a DEBUG-level metric (GpuExec's
-    # outputBatchesLevel), so the metrics level has to be raised for the assertion to see it.
+    # AQE is off because collect_plan_nodes does not descend into QueryStageExec.
+    # numOutputBatches is DEBUG-level on non-aggregate execs (GpuExec's outputBatchesLevel).
     conf = {'spark.sql.ansi.enabled': False,
             'spark.sql.autoBroadcastJoinThreshold': '-1',
             'spark.sql.adaptive.enabled': False,
@@ -670,20 +658,11 @@ def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
     def do_it(spark):
         a = spark.range(0, 2000, 1, 4).selectExpr("id as k", "id as v1")
         b = spark.range(0, 2000, 2, 4).selectExpr("id as k", "id as v2")
-        # groupBy().count() rather than count(): it prunes the sums the same way, but keeps
-        # the pruned plan on the DataFrame we hand back, so the plan assertion can see it.
-        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2")).groupBy().count()
+        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2"))
 
-    def assert_batches(cpu_plan, plan):
-        counts = _child_batch_counts(plan)
-        assert counts, "Expected a zero-column reduction aggregate in:\n{}".format(plan)
-        if override_batch_size_bytes is not None:
-            assert any(n >= 2 for (_, n) in counts), \
-                "Expected a zero-column aggregate to consume 2+ batches, got {}:\n{}".format(
-                    counts, plan)
-
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
-        do_it, conf = conf, gpu_plan_assertion = assert_batches)
+    _assert_zero_column_agg_batches(
+        lambda: assert_gpu_and_cpu_row_counts_equal(do_it, conf = conf),
+        override_batch_size_bytes is not None)
 
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
 def test_distinct_zero_columns(override_batch_size_bytes):
@@ -691,14 +670,12 @@ def test_distinct_zero_columns(override_batch_size_bytes):
     # (GpuAggregateExec.scala). Catalyst plans this as
     #   HashAggregate(keys=[0#x], functions=[], output=[])
     # -- a zero-column distinct() gets a literal 0 as its grouping key, so
-    # groupingExpressions is non-empty while aggregateExpressions is empty. `forall` is
-    # vacuously true on the resulting empty aggModes set, so the aggregate is misreported as
-    # a Partial one and takes the single pass partial sort path, which emits
-    # non-fully-aggregated output, which here has no final agg downstream to merge it.
-    # The GPU then returns 1000 rows where the CPU returns 1.
+    # groupingExpressions is non-empty while aggregateExpressions is empty, making aggModes
+    # empty and `forall` on it vacuously true. Without the guard the aggregate takes the
+    # single pass partial sort path and emits non-fully-aggregated output with no final agg
+    # to merge it: the GPU returns 1000 rows where the CPU returns 1.
     #
-    # This checks wrong results, not the zero-column crash: verified to still pass with the
-    # concatenateBatchesWithRetry `dataTypes.nonEmpty` guard removed.
+    # This checks wrong results, not the zero-column crash.
     conf = dict(_plan_metric_conf)
     if override_batch_size_bytes is not None:
         conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
@@ -711,18 +688,12 @@ def test_distinct_zero_columns(override_batch_size_bytes):
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
 def test_hash_grpby_literal_sum_count_action(data_gen, override_batch_size_bytes):
-    # Coverage for a groupBy on a literal/constant key. Catalyst does NOT constant-fold the
-    # key away: the plan keeps groupingExpressions=[1] and, once count() prunes sum('b'),
-    # aggregateExpressions=[] -- the same no-aggregate-functions shape as
-    # test_distinct_zero_columns rather than a keyless reduction.
+    # Coverage for a groupBy on a literal key. Catalyst does not fold the key away: the plan
+    # keeps groupingExpressions=[1] and, once count() prunes sum('b'), aggregateExpressions=[]
+    # -- the same shape as test_distinct_zero_columns, not a keyless reduction.
     #
-    # This does not reproduce either aggregate bug on its own: verified to pass with the
-    # concatenateBatchesWithRetry `dataTypes.nonEmpty` guard removed and with the
-    # canUsePartialSortAgg `aggModes.nonEmpty` guard removed. Unlike
-    # test_hash_grpby_skewed_single_key_batch_size it does not set the force conf, and at
-    # this size the firstBatchHeuristic does not pick the single pass path on its own. The
-    # plan assertion pins the shape so that a change in folding or in the heuristic shows up
-    # here rather than silently making the test vacuous.
+    # This reproduces neither aggregate bug on its own: it does not set the force conf, and at
+    # this size firstBatchHeuristic does not pick the single pass path.
     # disable ANSI mode to avoid overflow errors on longs_with_nulls
     conf = {'spark.sql.ansi.enabled': False}
     conf.update(_plan_metric_conf)
@@ -739,32 +710,20 @@ def test_hash_grpby_literal_sum_count_action(data_gen, override_batch_size_bytes
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1024], ids=idfn)
 def test_hash_grpby_skewed_single_key_batch_size(override_batch_size_bytes):
     # Regression test for the `aggModes.nonEmpty` guard on canUsePartialSortAgg, reached
-    # through a grouped aggregate rather than a distinct(). The count() prunes sum('id') away
-    # and leaves
+    # through a grouped aggregate rather than a distinct(). count() prunes sum('id') away and
+    # leaves
     #   HashAggregate(keys=[key], functions=[], output=[key])
-    # i.e. a distinct on a single key: no aggregate functions remain, so aggModes is empty.
-    # Verified: this fails (GPU 5 rows vs CPU 1) with the aggModes.nonEmpty guard removed
-    # and passes with it, and is
-    # unaffected by the concatenateBatchesWithRetry `dataTypes.nonEmpty` guard.
+    # so aggModes is empty. Without the guard the GPU returns 5 rows where the CPU returns 1.
     #
-    # The mechanism that turns the mis-selected path into duplicate rows is below.
-    # DynamicGpuPartialAggregateIterator.singlePassSortedAgg
-    # (GpuAggregateExec.scala) sorts the input on the grouping key and runs a
-    # per-batch partial aggregation with no cross-batch merge, assuming a group's rows
-    # never span two output batches. GpuOutOfCoreSortIterator's merge-sort (GpuSortExec.scala,
-    # mergeSortEnoughToOutput) finalizes rows into separate output batches as soon as global
-    # ordering is provably safe (an upperBound cutoff against the next pending batch's first
-    # row), independent of whether more rows sharing that same key are still pending. Once a
-    # single key's total row volume approaches/exceeds the target batch size, that key's rows
-    # get split across multiple output batches and each fragment is aggregated separately,
-    # producing duplicate output rows for what should be one group.
+    # DynamicGpuPartialAggregateIterator.singlePassSortedAgg sorts on the grouping key and
+    # aggregates per batch with no cross-batch merge, assuming a group never spans two output
+    # batches. GpuOutOfCoreSortIterator.mergeSortEnoughToOutput (GpuSortExec.scala) finalizes
+    # rows into separate output batches as soon as global ordering is safe, regardless of
+    # whether more rows with the same key are pending, so once one key's rows exceed the
+    # target batch size each fragment is aggregated separately.
     #
-    # For real (non-degenerate) skewed data the normal heuristic (firstBatchHeuristic) avoids
-    # this path -- a low cardinality/numRows ratio drives estimatedGrowthAfterAgg below 1.0, so
-    # it correctly falls back to fullHashAggWithMerge instead of singlePassSortedAgg. We use the
-    # internal, test-only spark.rapids.sql.agg.forceSinglePassPartialSort conf to force the
-    # buggy path directly and isolate the defect in singlePassSortedAgg itself from the
-    # heuristic that normally protects against it.
+    # firstBatchHeuristic normally avoids that path for real skewed data, so the test-only
+    # spark.rapids.sql.agg.forceSinglePassPartialSort conf forces it directly.
     conf = {'spark.rapids.sql.agg.forceSinglePassPartialSort': True}
     conf.update(_plan_metric_conf)
     if override_batch_size_bytes is not None:

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -626,6 +626,10 @@ def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_siz
     #
     # override_batch_size_bytes=1 puts roughly one row in each batch, so these 100 rows reach
     # the partial aggregate as ~100 batches. At the default 1 GiB it is a single batch.
+    #
+    # The filter on a non-deterministic predicate is always true, but it stops the optimizer
+    # answering count() from the aggregate's known cardinality of one row. Databricks does
+    # that and replaces the aggregate under test with OneRowRelation.
     # disable ANSI mode to avoid overflow errors on longs_with_nulls
     conf = {'spark.sql.ansi.enabled': False}
     conf.update(_plan_metric_conf)
@@ -633,7 +637,8 @@ def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_siz
         conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
     _assert_zero_column_agg_batches(
         lambda: assert_gpu_and_cpu_row_counts_equal(
-            lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')),
+            lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')).filter(
+                f.rand() < 2),
             conf = conf),
         override_batch_size_bytes is not None)
 
@@ -648,6 +653,10 @@ def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
     #
     # AQE is off because collect_plan_nodes does not descend into QueryStageExec.
     # numOutputBatches is DEBUG-level on non-aggregate execs (GpuExec's outputBatchesLevel).
+    #
+    # The filter on a non-deterministic predicate is always true, but it stops the optimizer
+    # answering count() from the aggregate's known cardinality of one row. Databricks does
+    # that and replaces the aggregate under test with OneRowRelation.
     conf = {'spark.sql.ansi.enabled': False,
             'spark.sql.autoBroadcastJoinThreshold': '-1',
             'spark.sql.adaptive.enabled': False,
@@ -658,7 +667,7 @@ def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
     def do_it(spark):
         a = spark.range(0, 2000, 1, 4).selectExpr("id as k", "id as v1")
         b = spark.range(0, 2000, 2, 4).selectExpr("id as k", "id as v2")
-        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2"))
+        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2")).filter(f.rand() < 2)
 
     _assert_zero_column_agg_batches(
         lambda: assert_gpu_and_cpu_row_counts_equal(do_it, conf = conf),

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -617,6 +617,8 @@ def _assert_zero_column_agg_batches(run_it, expect_multiple):
 _plan_metric_conf = {'spark.rapids.sql.metrics.level': 'DEBUG',
                      'spark.sql.adaptive.enabled': False}
 
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="Databricks plans this query without the aggregate under test")
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
 def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_size_bytes):
@@ -627,9 +629,13 @@ def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_siz
     # override_batch_size_bytes=1 puts roughly one row in each batch, so these 100 rows reach
     # the partial aggregate as ~100 batches. At the default 1 GiB it is a single batch.
     #
-    # The filter on a non-deterministic predicate is always true, but it stops the optimizer
-    # answering count() from the aggregate's known cardinality of one row. Databricks does
-    # that and replaces the aggregate under test with OneRowRelation.
+    # Skipped on Databricks. A keyless aggregate always produces exactly one row, and
+    # Databricks uses that to answer count() without running it: both the CPU and GPU plans
+    # come back as
+    #   HashAggregate(keys=[], functions=[count(1)]) +- Scan OneRowRelation
+    # so the aggregate under test is not in the plan at all. Apache Spark 3.3, 3.5 and 4.0
+    # keep the aggregate. Adding an always-true filter above it does not help: Databricks
+    # simplifies the predicate away and then applies the same rewrite.
     # disable ANSI mode to avoid overflow errors on longs_with_nulls
     conf = {'spark.sql.ansi.enabled': False}
     conf.update(_plan_metric_conf)
@@ -637,11 +643,12 @@ def test_hash_reduction_sum_count_action_batch_size(data_gen, override_batch_siz
         conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
     _assert_zero_column_agg_batches(
         lambda: assert_gpu_and_cpu_row_counts_equal(
-            lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')).filter(
-                f.rand() < 2),
+            lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')),
             conf = conf),
         override_batch_size_bytes is not None)
 
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="Databricks plans this query without the aggregate under test")
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1024], ids=idfn)
 def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
     # Regression test for the TPC-DS q97 shape: count() prunes the sums away, leaving
@@ -654,9 +661,13 @@ def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
     # AQE is off because collect_plan_nodes does not descend into QueryStageExec.
     # numOutputBatches is DEBUG-level on non-aggregate execs (GpuExec's outputBatchesLevel).
     #
-    # The filter on a non-deterministic predicate is always true, but it stops the optimizer
-    # answering count() from the aggregate's known cardinality of one row. Databricks does
-    # that and replaces the aggregate under test with OneRowRelation.
+    # Skipped on Databricks. A keyless aggregate always produces exactly one row, and
+    # Databricks uses that to answer count() without running it: both the CPU and GPU plans
+    # come back as
+    #   HashAggregate(keys=[], functions=[count(1)]) +- Scan OneRowRelation
+    # so the aggregate under test is not in the plan at all. Apache Spark 3.3, 3.5 and 4.0
+    # keep the aggregate. Adding an always-true filter above it does not help: Databricks
+    # simplifies the predicate away and then applies the same rewrite.
     conf = {'spark.sql.ansi.enabled': False,
             'spark.sql.autoBroadcastJoinThreshold': '-1',
             'spark.sql.adaptive.enabled': False,
@@ -667,7 +678,7 @@ def test_hash_reduction_count_action_after_join(override_batch_size_bytes):
     def do_it(spark):
         a = spark.range(0, 2000, 1, 4).selectExpr("id as k", "id as v1")
         b = spark.range(0, 2000, 2, 4).selectExpr("id as k", "id as v2")
-        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2")).filter(f.rand() < 2)
+        return a.join(b, "k", "fullouter").agg(f.sum("v1"), f.sum("v2"))
 
     _assert_zero_column_agg_batches(
         lambda: assert_gpu_and_cpu_row_counts_equal(do_it, conf = conf),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.{CudfAggregate, GpuAggregateExpression}
 import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuShuffleMeta, TrampolineUtil}
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 object AggregateUtils extends Logging {
 
@@ -713,12 +713,28 @@ object GpuAggregateIterator extends Logging {
             val dataTypes = (0 until numCols).map {
               c => batchesToConcat.head.column(c).dataType
             }.toArray
-            withResource(batchesToConcat.safeMap(GpuColumnVector.from)) { tbl =>
-              withResource(cudf.Table.concatenate(tbl: _*)) { concatenated =>
-                val cb = GpuColumnVector.from(concatenated, dataTypes)
-                SpillableColumnarBatch(cb,
-                  SpillPriorities.ACTIVE_BATCHING_PRIORITY)
+            // A batch can legitimately have zero columns but a non-zero row count: an
+            // aggregate with no grouping keys whose aggregate functions were all pruned
+            // away (e.g. `df.agg(sum(x)).count()`, where only the row count is consumed)
+            // produces row-count-only batches. cuDF cannot build a Table from zero
+            // columns, so `GpuColumnVector.from` would throw here. Carry the row count
+            // forward instead. See NVIDIA/spark-rapids#8618 for the aggregate heuristics
+            // that surface this shape.
+            if (dataTypes.nonEmpty) {
+              withResource(batchesToConcat.safeMap(GpuColumnVector.from)) { tbl =>
+                withResource(cudf.Table.concatenate(tbl: _*)) { concatenated =>
+                  val cb = GpuColumnVector.from(concatenated, dataTypes)
+                  SpillableColumnarBatch(cb,
+                    SpillPriorities.ACTIVE_BATCHING_PRIORITY)
+                }
               }
+            } else {
+              // Row-count-only batches: nothing to concatenate on the GPU, so just sum
+              // the row counts and hand back an equivalent zero-column batch.
+              val totalRowCount = batchesToConcat.map(_.numRows()).sum
+              SpillableColumnarBatch(
+                new ColumnarBatch(Array[ColumnVector](), totalRowCount),
+                SpillPriorities.ACTIVE_BATCHING_PRIORITY)
             }
           }
         }
@@ -1308,7 +1324,14 @@ abstract class GpuBaseAggregateMeta[INPUT <: SparkPlan](
 
   override def convertToGpu(): GpuExec = {
     lazy val aggModes = agg.aggregateExpressions.map(_.mode).toSet
-    lazy val canUsePartialSortAgg = aggModes.forall { mode =>
+    // `aggModes` is empty when there are no aggregate functions at all (a dedup, e.g.
+    // `distinct()` / `GROUP BY` with no aggregates). `forall` is vacuously true on an
+    // empty set, so without the `nonEmpty` check this would report that the aggregate is
+    // a safe Partial one. It is not: single pass partial sort agg deliberately emits
+    // non-fully-aggregated output and relies on a downstream final agg to merge it, which
+    // a terminal dedup does not have -- yielding duplicate rows. This mirrors the
+    // `aggregateExpressions.nonEmpty` guard on `allowNonFullyAggregatedOutput` below.
+    lazy val canUsePartialSortAgg = aggModes.nonEmpty && aggModes.forall { mode =>
       mode == Partial || mode == PartialMerge
     } && agg.groupingExpressions.nonEmpty // Don't do this for a reduce...
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark/issues/15953

### Description

This PR fixes two bugs in hash aggregate where a 0-col aggregate (for example `.count()` or `.distinct().count()`) can cause either an exception during `Table` creation or it can create corrupted data due to lack of merging in a final aggregate. See https://github.com/NVIDIA/cudf-spark/issues/15953 and also see integration tests for more info.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required

I am going to trigger with [databricks] just for functional tests.

I ran NDS @ sf3k against the last nightly and there are no differences in that benchmark:

<details>
<summary>
I ran NDS @ sf3k against the last nightly and there are no differences in that benchmark
</summary>

query1: Previous (1389.0 ms) vs Current (1381.3333333333333 ms) Diff 7 E2E 1.01x
query2: Previous (1129.6666666666667 ms) vs Current (1122.0 ms) Diff 7 E2E 1.01x
query3: Previous (354.0 ms) vs Current (365.3333333333333 ms) Diff -11 E2E 0.97x
query4: Previous (4701.333333333333 ms) vs Current (3568.0 ms) Diff 1133 E2E 1.32x
query5: Previous (2259.6666666666665 ms) vs Current (2075.3333333333335 ms) Diff 184 E2E 1.09x
query6: Previous (1005.0 ms) vs Current (759.3333333333334 ms) Diff 245 E2E 1.32x
query7: Previous (2447.3333333333335 ms) vs Current (2553.3333333333335 ms) Diff -106 E2E 0.96x
query8: Previous (696.6666666666666 ms) vs Current (738.6666666666666 ms) Diff -42 E2E 0.94x
query9: Previous (1636.3333333333333 ms) vs Current (1598.3333333333333 ms) Diff 38 E2E 1.02x
query10: Previous (1164.0 ms) vs Current (1170.6666666666667 ms) Diff -6 E2E 0.99x
query11: Previous (2083.6666666666665 ms) vs Current (2247.3333333333335 ms) Diff -163 E2E 0.93x
query12: Previous (484.0 ms) vs Current (492.3333333333333 ms) Diff -8 E2E 0.98x
query13: Previous (923.3333333333334 ms) vs Current (903.6666666666666 ms) Diff 19 E2E 1.02x
query14_part1: Previous (4705.666666666667 ms) vs Current (4738.666666666667 ms) Diff -33 E2E 0.99x
query14_part2: Previous (4167.0 ms) vs Current (4102.666666666667 ms) Diff 64 E2E 1.02x
query15: Previous (1215.0 ms) vs Current (1028.0 ms) Diff 187 E2E 1.18x
query16: Previous (1338.0 ms) vs Current (1516.0 ms) Diff -178 E2E 0.88x
query17: Previous (1280.6666666666667 ms) vs Current (1362.3333333333333 ms) Diff -81 E2E 0.94x
query18: Previous (1586.3333333333333 ms) vs Current (1549.0 ms) Diff 37 E2E 1.02x
query19: Previous (941.6666666666666 ms) vs Current (973.6666666666666 ms) Diff -32 E2E 0.97x
query20: Previous (485.3333333333333 ms) vs Current (542.3333333333334 ms) Diff -57 E2E 0.89x
query21: Previous (474.6666666666667 ms) vs Current (484.0 ms) Diff -9 E2E 0.98x
query22: Previous (1064.6666666666667 ms) vs Current (1071.6666666666667 ms) Diff -7 E2E 0.99x
query23_part1: Previous (5049.333333333333 ms) vs Current (5017.333333333333 ms) Diff 32 E2E 1.01x
query23_part2: Previous (5506.666666666667 ms) vs Current (5519.0 ms) Diff -12 E2E 1.00x
query24_part1: Previous (5741.666666666667 ms) vs Current (5683.333333333333 ms) Diff 58 E2E 1.01x
query24_part2: Previous (6021.333333333333 ms) vs Current (5782.666666666667 ms) Diff 238 E2E 1.04x
query25: Previous (1385.3333333333333 ms) vs Current (1336.6666666666667 ms) Diff 48 E2E 1.04x
query26: Previous (640.3333333333334 ms) vs Current (629.3333333333334 ms) Diff 11 E2E 1.02x
query27: Previous (837.6666666666666 ms) vs Current (879.3333333333334 ms) Diff -41 E2E 0.95x
query28: Previous (3713.0 ms) vs Current (3864.0 ms) Diff -151 E2E 0.96x
query29: Previous (2602.3333333333335 ms) vs Current (2879.3333333333335 ms) Diff -277 E2E 0.90x
query30: Previous (1379.0 ms) vs Current (1380.0 ms) Diff -1 E2E 1.00x
query31: Previous (1369.0 ms) vs Current (1422.3333333333333 ms) Diff -53 E2E 0.96x
query32: Previous (1169.0 ms) vs Current (1000.0 ms) Diff 169 E2E 1.17x
query33: Previous (1022.3333333333334 ms) vs Current (949.6666666666666 ms) Diff 72 E2E 1.08x
query34: Previous (1697.0 ms) vs Current (1697.0 ms) Diff 0 E2E 1.00x
query35: Previous (1311.0 ms) vs Current (1278.6666666666667 ms) Diff 32 E2E 1.03x
query36: Previous (995.6666666666666 ms) vs Current (997.6666666666666 ms) Diff -2 E2E 1.00x
query37: Previous (614.6666666666666 ms) vs Current (658.3333333333334 ms) Diff -43 E2E 0.93x
query38: Previous (2300.0 ms) vs Current (1809.3333333333333 ms) Diff 490 E2E 1.27x
query39_part1: Previous (1613.6666666666667 ms) vs Current (1512.6666666666667 ms) Diff 101 E2E 1.07x
query39_part2: Previous (1018.6666666666666 ms) vs Current (1342.3333333333333 ms) Diff -323 E2E 0.76x
query40: Previous (962.6666666666666 ms) vs Current (1022.3333333333334 ms) Diff -59 E2E 0.94x
query41: Previous (252.0 ms) vs Current (263.0 ms) Diff -11 E2E 0.96x
query42: Previous (341.3333333333333 ms) vs Current (277.6666666666667 ms) Diff 63 E2E 1.23x
query43: Previous (697.3333333333334 ms) vs Current (636.6666666666666 ms) Diff 60 E2E 1.10x
query44: Previous (812.3333333333334 ms) vs Current (766.3333333333334 ms) Diff 46 E2E 1.06x
query45: Previous (987.0 ms) vs Current (977.3333333333334 ms) Diff 9 E2E 1.01x
query46: Previous (1085.6666666666667 ms) vs Current (1293.6666666666667 ms) Diff -208 E2E 0.84x
query47: Previous (1469.6666666666667 ms) vs Current (1504.6666666666667 ms) Diff -35 E2E 0.98x
query48: Previous (699.0 ms) vs Current (688.0 ms) Diff 11 E2E 1.02x
query49: Previous (1445.6666666666667 ms) vs Current (1404.3333333333333 ms) Diff 41 E2E 1.03x
query50: Previous (7287.0 ms) vs Current (6999.666666666667 ms) Diff 287 E2E 1.04x
query51: Previous (1503.0 ms) vs Current (1276.3333333333333 ms) Diff 226 E2E 1.18x
query52: Previous (417.3333333333333 ms) vs Current (390.6666666666667 ms) Diff 26 E2E 1.07x
query53: Previous (562.3333333333334 ms) vs Current (536.0 ms) Diff 26 E2E 1.05x
query54: Previous (1219.0 ms) vs Current (1132.3333333333333 ms) Diff 86 E2E 1.08x
query55: Previous (369.6666666666667 ms) vs Current (379.6666666666667 ms) Diff -10 E2E 0.97x
query56: Previous (752.3333333333334 ms) vs Current (708.3333333333334 ms) Diff 44 E2E 1.06x
query57: Previous (1151.3333333333333 ms) vs Current (1141.6666666666667 ms) Diff 9 E2E 1.01x
query58: Previous (743.0 ms) vs Current (682.0 ms) Diff 61 E2E 1.09x
query59: Previous (1706.3333333333333 ms) vs Current (1429.6666666666667 ms) Diff 276 E2E 1.19x
query60: Previous (995.6666666666666 ms) vs Current (985.6666666666666 ms) Diff 10 E2E 1.01x
query61: Previous (1055.0 ms) vs Current (959.6666666666666 ms) Diff 95 E2E 1.10x
query62: Previous (965.0 ms) vs Current (1000.3333333333334 ms) Diff -35 E2E 0.96x
query63: Previous (673.3333333333334 ms) vs Current (668.0 ms) Diff 5 E2E 1.01x
query64: Previous (8043.0 ms) vs Current (7818.0 ms) Diff 225 E2E 1.03x
query65: Previous (2630.3333333333335 ms) vs Current (2570.0 ms) Diff 60 E2E 1.02x
query66: Previous (2176.3333333333335 ms) vs Current (2355.0 ms) Diff -178 E2E 0.92x
query67: Previous (7798.333333333333 ms) vs Current (7935.0 ms) Diff -136 E2E 0.98x
query68: Previous (1387.3333333333333 ms) vs Current (1135.3333333333333 ms) Diff 252 E2E 1.22x
query69: Previous (1029.3333333333333 ms) vs Current (1001.3333333333334 ms) Diff 27 E2E 1.03x
query70: Previous (1367.3333333333333 ms) vs Current (1520.3333333333333 ms) Diff -153 E2E 0.90x
query71: Previous (2944.3333333333335 ms) vs Current (2832.0 ms) Diff 112 E2E 1.04x
query72: Previous (1950.3333333333333 ms) vs Current (1971.3333333333333 ms) Diff -21 E2E 0.99x
query73: Previous (920.0 ms) vs Current (826.3333333333334 ms) Diff 93 E2E 1.11x
query74: Previous (1607.6666666666667 ms) vs Current (1681.0 ms) Diff -73 E2E 0.96x
query75: Previous (5281.0 ms) vs Current (5309.0 ms) Diff -28 E2E 0.99x
query76: Previous (1570.0 ms) vs Current (1435.6666666666667 ms) Diff 134 E2E 1.09x
query77: Previous (839.6666666666666 ms) vs Current (842.3333333333334 ms) Diff -2 E2E 1.00x
query78: Previous (7456.0 ms) vs Current (7456.0 ms) Diff 0 E2E 1.00x
query79: Previous (678.0 ms) vs Current (659.3333333333334 ms) Diff 18 E2E 1.03x
query80: Previous (3596.3333333333335 ms) vs Current (3486.6666666666665 ms) Diff 109 E2E 1.03x
query81: Previous (1853.0 ms) vs Current (1704.0 ms) Diff 149 E2E 1.09x
query82: Previous (580.3333333333334 ms) vs Current (556.6666666666666 ms) Diff 23 E2E 1.04x
query83: Previous (622.0 ms) vs Current (706.3333333333334 ms) Diff -84 E2E 0.88x
query84: Previous (681.6666666666666 ms) vs Current (634.3333333333334 ms) Diff 47 E2E 1.07x
query85: Previous (1342.0 ms) vs Current (1248.0 ms) Diff 94 E2E 1.08x
query86: Previous (929.3333333333334 ms) vs Current (951.6666666666666 ms) Diff -22 E2E 0.98x
query87: Previous (1370.3333333333333 ms) vs Current (1357.0 ms) Diff 13 E2E 1.01x
query88: Previous (2924.0 ms) vs Current (2927.0 ms) Diff -3 E2E 1.00x
query89: Previous (933.0 ms) vs Current (887.6666666666666 ms) Diff 45 E2E 1.05x
query90: Previous (567.0 ms) vs Current (574.3333333333334 ms) Diff -7 E2E 0.99x
query91: Previous (966.0 ms) vs Current (911.6666666666666 ms) Diff 54 E2E 1.06x
query92: Previous (488.3333333333333 ms) vs Current (512.6666666666666 ms) Diff -24 E2E 0.95x
query93: Previous (9865.666666666666 ms) vs Current (10178.333333333334 ms) Diff -312 E2E 0.97x
query94: Previous (2256.6666666666665 ms) vs Current (2382.0 ms) Diff -125 E2E 0.95x
query95: Previous (2452.0 ms) vs Current (2315.3333333333335 ms) Diff 136 E2E 1.06x
query96: Previous (4354.333333333333 ms) vs Current (4371.666666666667 ms) Diff -17 E2E 1.00x
query97: Previous (1695.0 ms) vs Current (1653.3333333333333 ms) Diff 41 E2E 1.03x
query98: Previous (1208.3333333333333 ms) vs Current (1105.3333333333333 ms) Diff 103 E2E 1.09x
query99: Previous (1320.6666666666667 ms) vs Current (1405.3333333333333 ms) Diff -84 E2E 0.94x
benchmark: Previous (200000.0 ms) vs Current (196666.66666666666 ms) Diff 3333 E2E 1.02x

</details>