### PR TITLE
Support explicit Iceberg audit runtime paths [reduced-it]

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -51,7 +51,9 @@ manifest. Fix failures by making the caller root-safe through
 `root-safe-module-classes.txt` or, for exceptional per-class placement, the applicable
 `unshimmed-*.txt` input above.
 
-Single-shim builds against a non-Maven runtime can add its absolute local jar path with
-`-Drapids.iceberg.audit.runtime.path=...`. This path also supplies the required audit
-runtime when a real Iceberg integration module has no Maven Iceberg runtime dependency.
-Missing or otherwise ambiguous runtime inputs fail the build.
+Single-shim builds where every real Iceberg integration module uses the same non-Maven
+runtime can add its absolute local jar path with
+`-Drapids.iceberg.audit.runtime.path=...`. This replaces Maven-coordinate discovery for
+the selected aggregator: every real Iceberg integration module must declare zero Maven
+Iceberg runtime dependencies, and the supplied path is used to audit all of them. Missing,
+empty, or otherwise ambiguous runtime inputs fail the build.

--- a/dist/README.md
+++ b/dist/README.md
@@ -50,3 +50,8 @@ with `build/iceberg_runtime.py`, resolves the runtime jars, and writes the gener
 manifest. Fix failures by making the caller root-safe through
 `root-safe-module-classes.txt` or, for exceptional per-class placement, the applicable
 `unshimmed-*.txt` input above.
+
+Single-shim builds against a non-Maven runtime can add its absolute local jar path with
+`-Drapids.iceberg.audit.runtime.path=...`. This path also supplies the required audit
+runtime when a real Iceberg integration module has no Maven Iceberg runtime dependency.
+Missing or otherwise ambiguous runtime inputs fail the build.

--- a/dist/build/iceberg_runtime.py
+++ b/dist/build/iceberg_runtime.py
@@ -87,8 +87,8 @@ def coordinates(zip_handle, buildver, scala_version, property_lookup):
                     group_id,
                     resolve_maven_properties(artifact_id, overrides, property_lookup),
                     resolve_maven_properties(version, overrides, property_lookup)))
-        if (len(runtime_dependencies) != 1 and
-                not (len(runtime_dependencies) == 0 and system_path is not None)):
+        if ((system_path is None and len(runtime_dependencies) != 1) or
+                (system_path is not None and len(runtime_dependencies) != 0)):
             raise RuntimeError("Iceberg module %s has %d runtime dependencies" %
                                (module_artifact_id, len(runtime_dependencies)))
         result.update(runtime_dependencies)

--- a/dist/build/iceberg_runtime.py
+++ b/dist/build/iceberg_runtime.py
@@ -18,6 +18,15 @@ import xml.etree.ElementTree as ET
 
 MAVEN_NS = "http://maven.apache.org/POM/4.0.0"
 MAVEN_PROPERTY_RE = re.compile(r"\$\{([^}]+)\}")
+SYSTEM_RUNTIME_PROPERTY = "rapids.iceberg.audit.runtime.path"
+
+
+def system_runtime_path(property_lookup):
+    value = property_lookup(SYSTEM_RUNTIME_PROPERTY)
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
 
 
 def resolve_maven_properties(value, overrides, property_lookup):
@@ -49,6 +58,7 @@ def coordinates(zip_handle, buildver, scala_version, property_lookup):
     namespace = {"m": MAVEN_NS}
     real_modules = []
     stub_modules = []
+    system_path = system_runtime_path(property_lookup)
     for entry in zip_handle.namelist():
         if not entry.startswith(prefix) or not entry.endswith("/pom.xml"):
             continue
@@ -77,7 +87,8 @@ def coordinates(zip_handle, buildver, scala_version, property_lookup):
                     group_id,
                     resolve_maven_properties(artifact_id, overrides, property_lookup),
                     resolve_maven_properties(version, overrides, property_lookup)))
-        if len(runtime_dependencies) != 1:
+        if (len(runtime_dependencies) != 1 and
+                not (len(runtime_dependencies) == 0 and system_path is not None)):
             raise RuntimeError("Iceberg module %s has %d runtime dependencies" %
                                (module_artifact_id, len(runtime_dependencies)))
         result.update(runtime_dependencies)

--- a/dist/build/iceberg_runtime.py
+++ b/dist/build/iceberg_runtime.py
@@ -26,7 +26,9 @@ def system_runtime_path(property_lookup):
     if value is None:
         return None
     value = str(value).strip()
-    return value or None
+    if not value:
+        raise RuntimeError("%s must not be empty" % SYSTEM_RUNTIME_PROPERTY)
+    return value
 
 
 def resolve_maven_properties(value, overrides, property_lookup):

--- a/dist/build/package-parallel-worlds.py
+++ b/dist/build/package-parallel-worlds.py
@@ -167,6 +167,15 @@ def ensure_external_artifact(group_id, artifact_id, version):
     return artifact_path
 
 
+def ensure_system_artifact(path):
+    if not os.path.isabs(path):
+        raise Exception("system Iceberg runtime path is not absolute: %s" % path)
+    resolved_path = os.path.realpath(path)
+    if not os.path.isfile(resolved_path):
+        raise Exception("system Iceberg runtime is missing: %s" % resolved_path)
+    return resolved_path
+
+
 def root_safe_module_class_members(classifier):
     members = set()
     for module in root_safe_modules:
@@ -196,6 +205,10 @@ maven_repository = project.getProperty('maven.local.repository')
 dist_dir = os.sep.join([source_basedir, 'dist'])
 iceberg_runtime = {}
 execfile(os.path.join(dist_dir, 'build', 'iceberg_runtime.py'), iceberg_runtime)
+system_iceberg_runtime = iceberg_runtime["system_runtime_path"](project.getProperty)
+if system_iceberg_runtime and len(buildver_list) != 1:
+    raise Exception("%s is supported only for single-shim builds" %
+                    iceberg_runtime["SYSTEM_RUNTIME_PROPERTY"])
 runtime_manifest = os.path.join(project_build_dir, 'iceberg-audit-runtimes.txt')
 with open(os.sep.join([dist_dir, 'unshimmed-common-from-single-shim.txt']), 'r') as f:
     from_single_shim = f.read().splitlines()
@@ -218,6 +231,9 @@ for bv in buildver_list:
                     ensure_external_artifact(group_id, artifact_id, version)
                     for group_id, artifact_id, version in coordinates
                 ]
+                if system_iceberg_runtime:
+                    iceberg_audit_runtimes[bv].append(
+                        ensure_system_artifact(system_iceberg_runtime))
             if project.getProperty('should.build.conventional.jar'):
                 zip_handle.extractall(path=top_dist_jar_dir)
             else:

--- a/dist/scripts/tests/test_check_iceberg_package_private_access.py
+++ b/dist/scripts/tests/test_check_iceberg_package_private_access.py
@@ -497,6 +497,23 @@ class IcebergPackagePrivateAccessTest(unittest.TestCase):
             finally:
                 archive.close()
 
+    def test_aggregator_rejects_system_and_maven_runtimes(self):
+        with temporary_directory() as root:
+            aggregator = os.path.join(root, "aggregator.jar")
+            real_module = "rapids-4-spark-iceberg-1-11-x_2.13"
+            write_aggregator(aggregator, [(real_module, RUNTIME_DEPENDENCY)])
+            properties = dict(ICEBERG_411_PROPERTIES)
+            properties[RUNTIME_DISCOVERY.SYSTEM_RUNTIME_PROPERTY] = \
+                "/usr/share/aws/iceberg/lib/iceberg-spark-runtime.jar"
+            archive = zipfile.ZipFile(aggregator, "r")
+            try:
+                with self.assertRaises(RuntimeError) as raised:
+                    RUNTIME_DISCOVERY.coordinates(
+                        archive, "413", "2.13", lambda name: properties.get(name))
+                self.assertIn("1 runtime dependencies", str(raised.exception))
+            finally:
+                archive.close()
+
     def test_real_module_requires_declared_spark_line_artifact_suffix(self):
         with temporary_directory() as root:
             aggregator = os.path.join(root, "aggregator.jar")

--- a/dist/scripts/tests/test_check_iceberg_package_private_access.py
+++ b/dist/scripts/tests/test_check_iceberg_package_private_access.py
@@ -480,6 +480,23 @@ class IcebergPackagePrivateAccessTest(unittest.TestCase):
             finally:
                 archive.close()
 
+    def test_aggregator_system_runtime_is_explicit(self):
+        with temporary_directory() as root:
+            aggregator = os.path.join(root, "aggregator.jar")
+            real_module = "rapids-4-spark-iceberg-1-10-x_2.13"
+            write_aggregator(aggregator, [(real_module, "")])
+            properties = {
+                RUNTIME_DISCOVERY.SYSTEM_RUNTIME_PROPERTY:
+                    "/usr/share/aws/iceberg/lib/iceberg-spark-runtime.jar",
+                "spark40x.iceberg.artifact.suffix": "4.0",
+            }
+            archive = zipfile.ZipFile(aggregator, "r")
+            try:
+                self.assertEqual([], RUNTIME_DISCOVERY.coordinates(
+                    archive, "402", "2.13", lambda name: properties.get(name)))
+            finally:
+                archive.close()
+
     def test_real_module_requires_declared_spark_line_artifact_suffix(self):
         with temporary_directory() as root:
             aggregator = os.path.join(root, "aggregator.jar")

--- a/dist/scripts/tests/test_check_iceberg_package_private_access.py
+++ b/dist/scripts/tests/test_check_iceberg_package_private_access.py
@@ -497,6 +497,11 @@ class IcebergPackagePrivateAccessTest(unittest.TestCase):
             finally:
                 archive.close()
 
+    def test_empty_system_runtime_is_rejected(self):
+        with self.assertRaises(RuntimeError) as raised:
+            RUNTIME_DISCOVERY.system_runtime_path(lambda name: "")
+        self.assertIn(RUNTIME_DISCOVERY.SYSTEM_RUNTIME_PROPERTY, str(raised.exception))
+
     def test_aggregator_rejects_system_and_maven_runtimes(self):
         with temporary_directory() as root:
             aggregator = os.path.join(root, "aggregator.jar")


### PR DESCRIPTION
No associated issue.

### Description

Builds for proprietary distributions can intentionally compile against the Iceberg runtime supplied by the distribution image instead of declaring an OSS Iceberg runtime dependency. The package-private-access audit previously required every real Iceberg integration module to expose exactly one Maven runtime dependency, so these builds failed during packaging even though the required runtime was present on the image classpath.

This change lets a single-shim build provide an explicit absolute Iceberg runtime JAR through `rapids.iceberg.audit.runtime.path`. The distribution packager resolves and validates the path, records it in the build-version-qualified audit manifest, and audits against that runtime. The property replaces Maven-coordinate discovery for the selected aggregator, so every real Iceberg integration module must declare zero Maven runtimes. Empty paths, multi-shim use, and simultaneous Maven and system runtimes are rejected, while existing Maven-coordinate discovery remains unchanged for normal builds.

This affects packaging validation only and has no production runtime-performance impact.

AI assistance: OpenAI Codex assisted with implementation, validation, and review.

Validation:

- 44 focused Jython/Javassist package-private-access tests passed, including explicit-runtime discovery and rejection of empty paths and simultaneous Maven and system runtimes.
- A clean OSS plugin build for a proprietary distribution and follow-up incremental builds passed using the image-provided Iceberg runtime, with no OSS Iceberg runtime download.
- The package audit checked 20 caller classes against the single image-provided runtime world.
- Clean bounded multi-shim distribution builds passed for Scala 2.12 (`334`, `344`, `359`) and Scala 2.13 (`359`, `404`, `413`, `420`).
- Final JAR layout checks found no missing, duplicated, shadowed, or incorrectly promoted classes in either Scala assembly.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
