### PR TITLE
Budget parallel unit tests from available GPU memory [reduced-it]

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -97,9 +97,16 @@ mvn package -pl tests -am -Drapids.parallelUnitTests=true -DparallelForkCount=4
 
 - `-Dsuffixes` and `-Dtests` are not supported; the runner fails fast. Use
   `-DwildcardSuites`, which matches fully qualified suite-name prefixes.
+- Before starting workers, the runner detects free GPU memory and reserves 1 GiB for headroom.
+  It budgets 4 GiB per worker and uses the smallest of the resulting memory limit,
+  `parallelForkCount`, four workers, and the number of suite batches. For example, 9 GiB free
+  permits two workers and 17 GiB permits four. One worker still runs all selected suites
+  sequentially; less than 5 GiB free fails before any worker starts.
 - The GPU is shared. Each worker gets
-  `rapids.test.gpu.allocFraction * 0.8 / parallelForkCount`; with the defaults, four workers each
-  get 20% of the GPU memory pool instead of the 100% available to serial execution.
+  `rapids.test.gpu.allocFraction * 0.8 / workerCount`, using the actual worker count. The default
+  minimum pool fraction is also scaled by the startup free-to-total GPU memory ratio so memory
+  already occupied by other processes does not inflate the minimum. The 4 GiB budget controls
+  scheduling; suites that explicitly configure their own pools retain those settings.
 - Each suite has a watchdog controlled by `-DparallelSuiteTimeout`, which defaults to 1800 seconds.
   On timeout, the runner captures a `jstack`, kills the worker, and fails the run.
 - The `RapidsDynamicPartitionPruningV1SuiteAEOff` and

--- a/tests/README.md
+++ b/tests/README.md
@@ -95,6 +95,9 @@ explicitly:
 mvn package -pl tests -am -Drapids.parallelUnitTests=true -DparallelForkCount=4
 ```
 
+- Parallel unit tests currently support at most four concurrent worker JVMs. Setting
+  `parallelForkCount` higher than four does not increase concurrency. Further UT and IT
+  parallelism tuning is tracked in [#15344](https://github.com/NVIDIA/cudf-spark/issues/15344).
 - `-Dsuffixes` and `-Dtests` are not supported; the runner fails fast. Use
   `-DwildcardSuites`, which matches fully qualified suite-name prefixes.
 - Before starting workers, the runner detects free GPU memory and reserves 1 GiB for headroom.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer}
+import ai.rapids.cudf.{DeviceMemoryBuffer, Rmm}
 import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funsuite.AnyFunSuite
@@ -59,28 +59,38 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
 
   def toBytes: String => Long = ConfHelper.byteFromString(_, ByteUnit.BYTE)
 
-  test("RMM pool size") {
-    val freeGpuSize = Cuda.memGetInfo().free
-    val poolFraction = 0.1
-    val maxPoolFraction = 0.2
-    // we need to reduce the minAllocFraction for this test since the
-    // pool allocation here is less than the default minimum
-    val minPoolFraction = 0.01
-    val conf = new SparkConf()
-        .set(RapidsConf.RMM_POOL.key, "ARENA")
-        .set(RapidsConf.RMM_ALLOC_FRACTION.key, poolFraction.toString)
-        .set(RapidsConf.RMM_ALLOC_MIN_FRACTION.key, minPoolFraction.toString)
-        .set(RapidsConf.RMM_ALLOC_MAX_FRACTION.key, maxPoolFraction.toString)
-        .set(RapidsConf.RMM_ALLOC_RESERVE.key, "0")
-    TestUtils.withGpuSparkSession(conf) { _ =>
-      val poolSize = (freeGpuSize * poolFraction).toLong
-      val allocSize = poolSize * 3 / 4
-      assert(allocSize > 0)
-      // initial allocation should fit within pool size
-      withResource(DeviceMemoryBuffer.allocate(allocSize)) { _ =>
-        assertThrows[OutOfMemoryError] {
-          // this should exceed the specified pool size
-          DeviceMemoryBuffer.allocate(allocSize).close()
+  Seq(false, true).foreach { smallPool =>
+    val suffix = if (smallPool) " with startup allocations in a small pool" else ""
+    test(s"RMM pool size$suffix") {
+      val poolFraction = 0.1
+      val maxPoolFraction = 0.2
+      // we need to reduce the minAllocFraction for this test since the
+      // pool allocation here is less than the default minimum
+      val minPoolFraction = 0.01
+      val conf = new SparkConf()
+          .set(RapidsConf.RMM_POOL.key, "ARENA")
+          .set(RapidsConf.RMM_ALLOC_FRACTION.key, poolFraction.toString)
+          .set(RapidsConf.RMM_ALLOC_MIN_FRACTION.key, minPoolFraction.toString)
+          .set(RapidsConf.RMM_ALLOC_MAX_FRACTION.key, maxPoolFraction.toString)
+          .set(RapidsConf.RMM_ALLOC_RESERVE.key, "0")
+      if (smallPool) {
+        // Keep a deterministic regression case where startup allocations consume half the pool.
+        conf.set(RapidsConf.RMM_EXACT_ALLOC.key, "256m")
+            .set(RapidsConf.CHUNKED_PACK_BOUNCE_BUFFER_SIZE.key, "32m")
+            .set(RapidsConf.CHUNKED_PACK_BOUNCE_BUFFER_COUNT.key, "4")
+      }
+      TestUtils.withGpuSparkSession(conf) { _ =>
+        // Other workers can consume GPU memory before this session initializes its pool.
+        // Account for startup allocations, including the chunked-pack bounce buffers.
+        val availablePoolSize = GpuDeviceManager.getMemorySize - Rmm.getTotalBytesAllocated
+        val allocSize = availablePoolSize * 3 / 4
+        assert(allocSize > 0)
+        // initial allocation should fit within pool size
+        withResource(DeviceMemoryBuffer.allocate(allocSize)) { _ =>
+          assertThrows[OutOfMemoryError] {
+            // this should exceed the specified pool size
+            withResource(DeviceMemoryBuffer.allocate(allocSize)) { _ => () }
+          }
         }
       }
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunner.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunner.scala
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
+import ai.rapids.cudf.Cuda
 import com.nvidia.spark.rapids.spill.SpillFramework
 import org.apache.hadoop.fs.FileUtil
 
@@ -44,6 +45,9 @@ object ParallelUnitTestRunner {
 
   private val UNRESOLVED_PROPERTY = "${"
   private val PARALLEL_GPU_ALLOCATION_RATIO = 0.8
+  private val GPU_MEMORY_RESERVE = 1024L * 1024 * 1024
+  private val GPU_MEMORY_PER_WORKER = 4L * 1024 * 1024 * 1024
+  private val MAX_WORKER_COUNT = 4
   private val DPP_SUITES = Seq(
     "org.apache.spark.sql.rapids.suites.RapidsDynamicPartitionPruningV1SuiteAEOff",
     "org.apache.spark.sql.rapids.suites.RapidsDynamicPartitionPruningV1SuiteAEOn")
@@ -64,6 +68,13 @@ object ParallelUnitTestRunner {
       return
     }
 
+    run(args, () => {
+      val memoryInfo = Cuda.memGetInfo()
+      (memoryInfo.free, memoryInfo.total)
+    })
+  }
+
+  private[rapids] def run(args: Array[String], gpuMemoryInfo: () => (Long, Long)): Unit = {
     val config = args.map { arg =>
       val separator = arg.indexOf('=')
       require(separator > 0, s"Invalid argument: $arg")
@@ -116,14 +127,23 @@ object ParallelUnitTestRunner {
         .zipWithIndex
         .map { case (suite, index) => SuiteTask(index + 1, suite) }
     val suiteBatches = createSuiteBatches(suiteTasks)
-    val workerCount = effectiveWorkerCount(requestedForks, suiteBatches)
+    // Sample once, before any test workers start allocating on the shared GPU. The budget
+    // includes each worker's CUDA context and allocations outside its RMM pool.
+    val (freeGpuMemory, totalGpuMemory) = gpuMemoryInfo()
+    val workerCount = effectiveWorkerCount(requestedForks, suiteBatches, freeGpuMemory)
+    // minAllocFraction is relative to total device memory. Scale its test default to the
+    // memory actually available, especially when fewer workers share an already busy GPU.
+    val freeMemoryFraction = freeGpuMemory.toDouble / totalGpuMemory
     val (perForkAllocation, perForkMaxAllocation, perForkMinAllocation) =
       perWorkerGpuAllocations(
         workerCount,
         allocationFraction,
         maxAllocationFraction,
-        minAllocationFraction)
+        minAllocationFraction * freeMemoryFraction)
 
+    ConsoleOutput.writeLine(
+      s"GPU memory: ${freeGpuMemory / (1024 * 1024)} MiB free; " +
+        s"1024 MiB reserved, 4096 MiB budget per worker, at most $MAX_WORKER_COUNT workers")
     ConsoleOutput.writeLine(
       s"Running ${discovered.size} suites with at most $workerCount concurrent processes")
     suiteBatches.filter(_.tasks.size > 1).foreach { batch =>
@@ -776,8 +796,15 @@ object ParallelUnitTestRunner {
 
   private[rapids] def effectiveWorkerCount(
       requestedForks: Int,
-      suiteBatches: Seq[SuiteBatch]): Int = {
-    math.min(requestedForks, suiteBatches.size)
+      suiteBatches: Seq[SuiteBatch],
+      freeGpuMemory: Long): Int = {
+    val memoryLimit = math.max(0L, freeGpuMemory - GPU_MEMORY_RESERVE) /
+        GPU_MEMORY_PER_WORKER
+    require(memoryLimit > 0,
+      s"Insufficient free GPU memory for unit tests: $freeGpuMemory bytes; " +
+        "at least 5 GiB is required for one 4 GiB worker budget and 1 GiB reserve")
+    math.min(math.min(requestedForks, MAX_WORKER_COUNT),
+      math.min(suiteBatches.size.toLong, memoryLimit).toInt)
   }
 
   private[rapids] def perWorkerGpuAllocations(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunnerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParallelUnitTestRunnerSuite.scala
@@ -18,6 +18,8 @@ package com.nvidia.spark.rapids
 
 import java.io.{
   BufferedWriter, ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream, Writer}
+import java.lang.management.ManagementFactory
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
@@ -30,6 +32,11 @@ import org.apache.spark.sql.SparkSession
 
 class ParallelUnitTestRunnerSuite extends AnyFunSuite {
   private val fixtureSuiteName = classOf[ParallelUnitTestRunnerExpectedFailureFixtureSuite].getName
+  private val gib = 1024L * 1024 * 1024
+
+  private def runFixture(args: Array[String], freeGpuMemory: Long = 24L * gib): Unit = {
+    ParallelUnitTestRunner.run(args, () => (freeGpuMemory, 24L * gib))
+  }
 
   private def verifyExpectedChildJvmFailure(body: => Unit): Unit = {
     info("[parallel-unit-test-runner self-test] BEGIN expected child JVM failure")
@@ -118,7 +125,7 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     val batches = ParallelUnitTestRunner.createSuiteBatches(tasks)
 
     assert(batches.size === 1)
-    val workerCount = ParallelUnitTestRunner.effectiveWorkerCount(4, batches)
+    val workerCount = ParallelUnitTestRunner.effectiveWorkerCount(4, batches, 24L * gib)
     assert(workerCount === 1)
     val (allocation, maximum, minimum) =
       ParallelUnitTestRunner.perWorkerGpuAllocations(workerCount, 1.0, 1.0, 0.25)
@@ -134,6 +141,33 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     assert(math.abs(allocation - 0.2) < 1e-10)
     assert(math.abs(maximum - 0.2) < 1e-10)
     assert(minimum === 0.0625)
+  }
+
+  test("worker count budgets 4 GiB per worker with 1 GiB reserve and a maximum of four") {
+    val batches = (1 to 8).map { id =>
+      ParallelUnitTestRunner.SuiteBatch(Seq(
+        ParallelUnitTestRunner.SuiteTask(id, s"example.Suite$id")))
+    }
+    Seq(80L -> 4, 17L -> 4, 16L -> 3, 13L -> 3, 9L -> 2, 5L -> 1).foreach {
+      case (freeGiB, expectedWorkers) =>
+        assert(ParallelUnitTestRunner.effectiveWorkerCount(8, batches, freeGiB * gib) ===
+            expectedWorkers)
+    }
+    assert(ParallelUnitTestRunner.effectiveWorkerCount(2, batches, 80L * gib) === 2)
+    assert(ParallelUnitTestRunner.effectiveWorkerCount(4, batches.take(1), 80L * gib) === 1)
+  }
+
+  test("insufficient GPU memory fails before launching a test worker") {
+    val reportsDir = Files.createTempDirectory("parallel-unit-test-insufficient-memory")
+    try {
+      val error = intercept[IllegalArgumentException] {
+        runFixture(fixtureRunnerArgs(reportsDir, failFixture = false), 5L * gib - 1)
+      }
+      assert(error.getMessage.contains("Insufficient free GPU memory"))
+      assert(!Files.exists(reportsDir.resolve("wave-1")))
+    } finally {
+      FileUtil.fullyDelete(reportsDir.toFile)
+    }
   }
 
   test("suites are ordered by fully qualified name") {
@@ -185,7 +219,7 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
   test("main runs a successful suite in a child JVM and writes its JUnit report") {
     val reportsDir = Files.createTempDirectory("parallel-unit-test-success")
     try {
-      ParallelUnitTestRunner.main(fixtureRunnerArgs(reportsDir, failFixture = false))
+      runFixture(fixtureRunnerArgs(reportsDir, failFixture = false))
 
       assert(Files.isRegularFile(
         reportsDir.resolve("wave-1").resolve(s"TEST-$fixtureSuiteName.xml")))
@@ -197,10 +231,17 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
   test("main runs each configured Spark wave") {
     val reportsDir = Files.createTempDirectory("parallel-unit-test-waves")
     try {
-      ParallelUnitTestRunner.main(fixtureRunnerArgs(
-        reportsDir,
-        failFixture = false,
-        sparkConfs = "spark.sql.ansi.enabled=false;spark.sql.ansi.enabled=true"))
+      var memoryProbes = 0
+      ParallelUnitTestRunner.run(
+        fixtureRunnerArgs(
+          reportsDir,
+          failFixture = false,
+          sparkConfs = "spark.sql.ansi.enabled=false;spark.sql.ansi.enabled=true"),
+        () => {
+          memoryProbes += 1
+          (24L * gib, 24L * gib)
+        })
+      assert(memoryProbes === 1)
 
       Seq(1, 2).foreach { wave =>
         assert(Files.isRegularFile(
@@ -218,7 +259,7 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     try {
       val fixturePrefix =
         classOf[ParallelUnitTestRunnerConcurrentFixtureSuiteOne].getName.stripSuffix("One")
-      ParallelUnitTestRunner.main(fixtureRunnerArgs(
+      runFixture(fixtureRunnerArgs(
         reportsDir,
         failFixture = false,
         wildcardSuites = fixturePrefix,
@@ -236,11 +277,40 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     }
   }
 
+  test("limited GPU memory runs all selected suites in one persistent worker") {
+    val reportsDir = Files.createTempDirectory("parallel-unit-test-single-worker")
+    val barrierDir = reportsDir.resolve("barrier")
+    Files.createDirectories(barrierDir)
+    try {
+      val fixturePrefix =
+        classOf[ParallelUnitTestRunnerConcurrentFixtureSuiteOne].getName.stripSuffix("One")
+      runFixture(fixtureRunnerArgs(
+        reportsDir,
+        failFixture = false,
+        wildcardSuites = fixturePrefix,
+        extraJvmArgs = Seq(
+          s"-D${ParallelUnitTestRunnerConcurrentFixture.BARRIER_DIR_PROPERTY}=$barrierDir",
+          s"-D${ParallelUnitTestRunnerConcurrentFixture.SERIAL_PROPERTY}=true")),
+        freeGpuMemory = 5L * gib)
+
+      val firstWorker = Files.readAllBytes(barrierDir.resolve("one"))
+      val secondWorker = Files.readAllBytes(barrierDir.resolve("two"))
+      assert(firstWorker.nonEmpty)
+      assert(firstWorker.toSeq === secondWorker.toSeq)
+      Seq("One", "Two").foreach { suffix =>
+        assert(Files.isRegularFile(
+          reportsDir.resolve("wave-1").resolve(s"TEST-$fixturePrefix$suffix.xml")))
+      }
+    } finally {
+      FileUtil.fullyDelete(reportsDir.toFile)
+    }
+  }
+
   test("main propagates a child JVM suite failure") {
     val reportsDir = Files.createTempDirectory("parallel-unit-test-failure")
     try {
       verifyExpectedChildJvmFailure {
-        ParallelUnitTestRunner.main(fixtureRunnerArgs(reportsDir, failFixture = true))
+        runFixture(fixtureRunnerArgs(reportsDir, failFixture = true))
       }
 
       assert(Files.isRegularFile(
@@ -254,7 +324,7 @@ class ParallelUnitTestRunnerSuite extends AnyFunSuite {
     val reportsDir = Files.createTempDirectory("parallel-unit-test-forged-result")
     try {
       verifyExpectedChildJvmFailure {
-        ParallelUnitTestRunner.main(
+        runFixture(
           fixtureRunnerArgs(reportsDir, failFixture = true, spoofResult = true))
       }
     } finally {
@@ -481,17 +551,21 @@ class ParallelUnitTestRunnerExpectedFailureFixtureSuite extends AnyFunSuite {
 
 object ParallelUnitTestRunnerConcurrentFixture {
   val BARRIER_DIR_PROPERTY: String = "rapids.parallelUnitTestRunner.fixture.barrierDir"
+  val SERIAL_PROPERTY: String = "rapids.parallelUnitTestRunner.fixture.serial"
   private val BARRIER_TIMEOUT_SECONDS = 10L
 
   def awaitPeer(markerName: String, peerMarkerName: String): Unit = {
     val barrierDir = Paths.get(System.getProperty(BARRIER_DIR_PROPERTY))
-    Files.createFile(barrierDir.resolve(markerName))
-    val peerMarker = barrierDir.resolve(peerMarkerName)
-    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(BARRIER_TIMEOUT_SECONDS)
-    while (!Files.exists(peerMarker) && System.nanoTime() - deadline < 0) {
-      Thread.sleep(10)
+    Files.write(barrierDir.resolve(markerName),
+      ManagementFactory.getRuntimeMXBean.getName.getBytes(StandardCharsets.UTF_8))
+    if (!java.lang.Boolean.getBoolean(SERIAL_PROPERTY)) {
+      val peerMarker = barrierDir.resolve(peerMarkerName)
+      val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(BARRIER_TIMEOUT_SECONDS)
+      while (!Files.exists(peerMarker) && System.nanoTime() - deadline < 0) {
+        Thread.sleep(10)
+      }
+      assert(Files.exists(peerMarker), s"Timed out waiting for concurrent suite marker $peerMarker")
     }
-    assert(Files.exists(peerMarker), s"Timed out waiting for concurrent suite marker $peerMarker")
   }
 }
 


### PR DESCRIPTION
Fixes #15939. Follow-up parallelism tuning is tracked in [#15344](https://github.com/NVIDIA/cudf-spark/issues/15344).

### Description

Prevent parallel Scala unit-test workers from overcommitting shared GPU memory and make the RMM pool-size regression test independent of concurrent free-memory changes.

This eliminates timing-dependent suite aborts when other unit-test workers or GPU processes consume memory.

Size the RMM pool test's allocations from the initialized pool after subtracting existing allocations. The first allocation succeeds and the second exceeds the pool capacity even when other unit-test workers share the GPU. A regression case covers 128 MiB of startup allocations in a 256 MiB pool.

Before starting workers, detect free GPU memory once and choose `min(parallelForkCount, suiteBatchCount, 4, floor((freeBytes - 1 GiB) / 4 GiB))`. Run all selected suites in one persistent worker when only one budget fits, and report insufficient memory before launching workers when less than 5 GiB is free. Scale the injected minimum pool fraction by the ratio of free to total GPU memory so existing GPU allocations do not inflate the minimum.

Parallel unit tests currently support at most four concurrent worker JVMs, even when `parallelForkCount` is greater than four. Further UT and IT parallelism tuning is tracked in #15344.

The 4 GiB budget controls worker scheduling; explicitly configured suite pools retain their settings.

Validation on an NVIDIA L4 with JDK 17 and Spark 3.5.0:

| Scala | Parallel suite tests | Actual workers | Result |
| --- | ---: | ---: | --- |
| 2.12 | 78 | 2 | All passed, no skips |
| 2.13 | 78 | 2 | All passed, no skips |

Both runs requested `-DparallelForkCount=4`; the runner selected two workers based on available GPU memory, verified from the worker configurations in the JUnit reports. The five suites were `GpuDeviceManagerSuite`, `ParallelUnitTestRunnerSuite`, `GpuCoalesceBatchesRetrySuite`, `GpuFileScanPrunePartitionSuite`, and `GpuGenerateSuite`.

Both reactor package builds passed. An initial Scala 2.12 run also passed all 40 tests in the two changed suites and the module's 9 JUnit tests. Runner regressions cover the memory thresholds, four-worker cap, a single startup probe across multiple waves, failure before worker launch when memory is insufficient, and execution of all selected suites in one persistent worker.

All changes are limited to test code and its documentation.

AI assistance: implementation and validation were assisted by Codex.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
