### PR TITLE
[SkipRecovery] Restore randomized regex choice coverage [reduced-it] [databricks]

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -792,12 +792,13 @@ def test_character_classes():
             ),
         conf=_regexp_conf)
 
-@datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10641")
 def test_regexp_choice():
     # These choice patterns transpile to many cuDF states (e.g. `(abc1a$|^ab2ab|a3abc)`
     # is ~21 states). They run on the GPU directly now that the regex complexity gate
     # has been removed (#14887).
-    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
+    # Exercise the trailing CRLF capture regression from #10641 with randomized seeds.
+    gen = (mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
+        .with_special_case('aab2ab\r\n'))
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'rlike(a, "[abcd]|[123]")',


### PR DESCRIPTION
**JaCoCo production line coverage: +0 lines** (measured: `delta-lake`, `iceberg`, `shuffle-plugin`, `sql-plugin`, `udf-compiler`; Scala 2.12, shim 350, anchor `2d438c02`, vs nightly coverage b34)

Fixes #10641.

### Description

This test-only recovery restores randomized coverage for regex alternatives containing end-of-line anchors. `test_regexp_choice` still pins seed 0 after a historical CRLF capture mismatch, although the underlying fixes have merged. Production behavior is unchanged; the original failing input and seed now pass CPU/GPU comparison on current main.

Remove the temporary seed override and add the original `aab2ab\r\n` input to the existing generator's special cases. All 12 SQL expressions and their parity assertions remain unchanged. Other regex limitations and fallback tests are outside this change.

The underlying fixes are [cuDF #22763](https://github.com/NVIDIA/cudf/pull/22763) (CRLF anchor semantics) and [#15023](https://github.com/NVIDIA/cudf-spark/pull/15023) (removal of the consuming CRLF rewrite).

AI assistance: The change and PR description were prepared with Codex assistance.

#### Validation

Apache Spark 3.5.0 / Scala 2.12 / Python 3.10.18 / Java 17 / UTC:

- Exact historical input: CPU and GPU both return `ab2ab`, without the trailing CR; `GpuRegExpExtract` presence was asserted.
- Complete `regexp_test.py`, seed `1711561563`, xfail masking disabled: **95 passed, 1 skipped**. The unchanged skip requires Spark 4.0+.
- Focused seeds `0`, `20260911`, and `42`: **1 passed each**. Original seed with OOM injection forced: **1 passed**.
- Current-main shim-350 package build: **BUILD SUCCESS**.

`[reduced-it]` retains the affected test's only collected case: it has no parametrization decorators, and pre-commit reduced collection was checked. Scala UT scheduling remains parallel. Databricks validation is requested through the title marker; no local Databricks pass is claimed.

<details>
<summary>Reproduction commands and artifact evidence</summary>

Build source: `e56c2660c762033f63e39df59c9276d5eb6e81e9`.

```bash
mvn package -pl dist,integration_tests -am -Dbuildver=350 -DskipTests \
  -Dmaven.repo.local=./.mvn-repo \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm

# With SPARK_HOME and both PYSPARK interpreters set to Spark 3.5 / Python 3.10:
TESTS=regexp_test.py DATAGEN_SEED=1711561563 TEST_PARALLEL=2 \
  integration_tests/run_pyspark_from_build.sh --runxfail --test_oom_injection_mode never

# Repeat with DATAGEN_SEED=0, 20260911, and 42:
TESTS=regexp_test.py DATAGEN_SEED=0 TEST_PARALLEL=1 \
  integration_tests/run_pyspark_from_build.sh -k test_regexp_choice \
  --runxfail --test_oom_injection_mode never

TESTS=regexp_test.py DATAGEN_SEED=1711561563 TEST_PARALLEL=1 \
  integration_tests/run_pyspark_from_build.sh -k test_regexp_choice \
  --runxfail --test_oom_injection_mode always
```

Built plugin SHA-256: `4b460b3390641dc617ccc2769f160e4824fbdde182c12d8ddb42715ce47d6d84`. Its JNI dependency embeds cuDF revision `f76d700abdd316b406ca825a269b73153632742d`, which contains the merged CRLF fix.

Coverage: replayed the modified test successfully against the exact nightly class-anchor JAR (`2d438c02049635368d2db1a7189b2093d206bad9`, SHA-256 `e38843bef80d8a33c33a6ba49344f11764cab64a3875747c866176fd5d6402fc`) from [coverage b34](https://prod.blsm.nvidia.com/sw-gpu-spark-jenkins/job/yanxuan_code-coverage/34/). Each module's regenerated baseline counters equal the published report, and merging the test execution adds no lines. No class-ID mismatch or `MemoryCheckerImpl` artifact was present. This restores randomized regression coverage, not new production-line coverage. The newer b21 report was not used because its Iceberg execution data has class-ID mismatches.

</details>

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
