### PR TITLE
Disable Spark testing mode for Iceberg tests [reduced-it]

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -27,7 +27,7 @@ from iceberg import (create_iceberg_table, get_full_table_name, iceberg_write_en
                      ICEBERG_ROW_LINEAGE_INHERITANCE_UNSUPPORTED_REASON,
                      row_lineage_df, rapids_reader_types)
 from marks import allow_non_gpu, allow_non_gpu_conditional, iceberg, ignore_order, datagen_overrides
-from spark_session import is_spark_35x, is_spark_400_or_later, with_cpu_session, with_gpu_session
+from spark_session import is_spark_400_or_later, with_cpu_session, with_gpu_session
 
 pytestmark = iceberg_unsupported_mark
 
@@ -137,13 +137,7 @@ def test_iceberg_delete_unpartitioned_table(spark_tmp_table_factory, delete_mode
 @pytest.mark.skipif(not supports_iceberg_v3, reason=ICEBERG_V3_UNSUPPORTED_REASON)
 @ignore_order(local=True)
 @pytest.mark.parametrize('delete_mode,fallback_exec', [
-    pytest.param(
-        'copy-on-write',
-        'ReplaceDataExec',
-        marks=pytest.mark.xfail(
-            condition=is_spark_35x(),
-            reason="https://github.com/NVIDIA/cudf-spark/issues/15680"),
-        id='cow'),
+    pytest.param('copy-on-write', 'ReplaceDataExec', id='cow'),
     pytest.param('merge-on-read', 'WriteDeltaExec', id='mor')
 ])
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -363,8 +363,14 @@ run_delta_lake_tests() {
 }
 
 run_iceberg_tests() {
-  # Spark's test-only plan validation rejects intermediate plans from some Iceberg row-level
-  # rewrites. Disable it only for the subprocesses launched by this function.
+  # Spark 3.5 validates every optimizer rule's output when the spark.testing JVM property is
+  # present. Iceberg V3 COW rewrites temporarily produce an unresolved ReplaceData plan while
+  # GroupBasedRowLevelOperationScanPlanning rewrites row-lineage columns, so the test-only
+  # validation fails CPU setup before physical planning. Because spark.testing is presence-based
+  # (even false enables it) and cannot be disabled through SparkSession configuration, omit it
+  # from every Iceberg test subprocess.
+  # See https://github.com/NVIDIA/cudf-spark/issues/15680
+  # and https://github.com/NVIDIA/cudf-spark/issues/15950.
   local SPARK_TESTING_ENABLED=0
   export SPARK_TESTING_ENABLED
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -363,6 +363,11 @@ run_delta_lake_tests() {
 }
 
 run_iceberg_tests() {
+  # Spark's test-only plan validation rejects intermediate plans from some Iceberg row-level
+  # rewrites. Disable it only for the subprocesses launched by this function.
+  local SPARK_TESTING_ENABLED=0
+  export SPARK_TESTING_ENABLED
+
   # get the major/minor version of Spark
   ICEBERG_SPARK_VER=$(echo "$SPARK_VER" | cut -d. -f1,2)
   # get the patch version of Spark


### PR DESCRIPTION
Fixes #15680.
Fixes #15950.

### Description

Disable Spark internal testing mode only for Iceberg integration-test subprocesses and remove the
Spark 3.5 Iceberg V3 copy-on-write xfail.

This prevents Spark's test-only plan validation from rejecting intermediate plans produced by
Iceberg row-level rewrites, while retaining the validation for all other nightly integration tests.

`run_iceberg_tests` now shadows the globally enabled `SPARK_TESTING_ENABLED` value with an
exported function-local value of `0`. The Hadoop, REST catalog, and S3 Tables Iceberg invocations
all inherit the override, and the original value is restored when the function returns.

The `test_iceberg_delete_v3_table_fallback[cow]` xfail added for #15680 is no longer necessary and
has been removed along with its unused `is_spark_35x` import.

#15968 tracks re-enabling Spark testing mode for Iceberg after the Spark/Iceberg planning
incompatibility is resolved.

Validation:

- `bash -n jenkins/spark-tests.sh`
- `python -m py_compile integration_tests/src/main/python/iceberg/iceberg_delete_test.py`
- Verified that an exported function-local override is `0` in an Iceberg child process and returns
  to `1` after the function exits.
- Spark 3.5.6 / Iceberg 1.10.1 A/B test used the same four cases, artifacts, `DATAGEN_SEED=42`,
  UTC timezone, and disabled OOM injection:
  - `SPARK_TESTING_ENABLED=1`: all four cases failed with
    `PLAN_VALIDATION_FAILED_RULE_IN_BATCH` from `GroupBasedRowLevelOperationScanPlanning` on an
    unresolved `ReplaceData` plan.
  - `SPARK_TESTING_ENABLED=0`: the same four cases passed (`4 passed`, `32587 deselected`) with no
    XFAIL or XPASS.
- Scala 2.13 / Spark 3.5.0 build passed:
  `env -u SPARK_HOME mvn -f scala2.13/pom.xml -Dbuildver=350 -pl integration_tests -am package -DskipTests -Drat.skip=true`

Existing tests: `test_iceberg_v3_row_lineage_delete_leading_rows` and
`test_iceberg_delete_v3_table_fallback[cow]`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
