### PR TITLE
Fix Variant Parquet scans on Spark 4.1+

### DIFF
--- a/integration_tests/src/main/python/variant_test.py
+++ b/integration_tests/src/main/python/variant_test.py
@@ -21,7 +21,7 @@ from asserts import (assert_cpu_and_gpu_are_equal_collect_with_capture,
 from conftest import is_databricks_runtime
 from data_gen import idfn
 from marks import allow_non_gpu, incompat
-from spark_session import is_before_spark_400, with_cpu_session
+from spark_session import is_before_spark_400, is_spark_411_or_later, with_cpu_session
 
 pytestmark = pytest.mark.skipif(
     is_databricks_runtime(), reason='Enabled in follow-up PR #15645')
@@ -32,6 +32,19 @@ _variant_parquet_conf = {
     'spark.rapids.sql.format.parquet.write.enabled': 'true',
     'spark.sql.sources.useV1SourceList': 'parquet'
 }
+
+_variant_write_conf = {}
+
+if is_spark_411_or_later():
+    # Spark 4.1+ pushes Variant extraction into the Parquet reader and writes shredded
+    # Variant columns by default. The GPU implementation currently operates on unshredded
+    # Variant columns, so disable both features when exercising GpuVariantGet.
+    _variant_parquet_conf['spark.sql.variant.pushVariantIntoScan'] = 'false'
+    _variant_write_conf['spark.sql.variant.writeShredding.enabled'] = 'false'
+
+
+def _with_cpu_variant_session(func):
+    return with_cpu_session(func, conf=_variant_write_conf)
 
 
 def _write_variant_parquet(spark, path):
@@ -91,7 +104,7 @@ def _write_variant_if_parquet(spark, path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_write_falls_back(spark_tmp_path):
     source_path = spark_tmp_path + '/VARIANT_WRITE_SOURCE'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, source_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, source_path))
 
     def write_data(spark, path):
         spark.read.parquet(source_path).write.mode('overwrite').parquet(path)
@@ -110,18 +123,40 @@ def test_parquet_variant_write_falls_back(spark_tmp_path):
         conf=write_conf)
 
 
+@allow_non_gpu('FileSourceScanExec', 'ColumnarToRowExec')
+@incompat
+@pytest.mark.skipif(not is_spark_411_or_later(),
+                    reason='Variant scan pushdown is available in Spark 4.1.1+')
+def test_parquet_variant_shredding_and_scan_pushdown_fall_back(spark_tmp_path):
+    data_path = spark_tmp_path + '/VARIANT_SCAN_PUSHDOWN_FALLBACK_PARQUET'
+    write_conf = {'spark.sql.variant.writeShredding.enabled': 'true'}
+    with_cpu_session(
+        lambda spark: _write_variant_parquet(spark, data_path), conf=write_conf)
+
+    def do_it(spark):
+        return spark.read.parquet(data_path).selectExpr(
+            "try_variant_get(v, '$.x', 'int') AS x",
+            "try_variant_get(v, '$.y', 'string') AS y")
+
+    read_conf = dict(_variant_parquet_conf)
+    read_conf['spark.sql.variant.pushVariantIntoScan'] = 'true'
+    assert_gpu_fallback_collect(
+        do_it, 'FileSourceScanExec', conf=read_conf)
+
+
 @incompat
 @pytest.mark.parametrize('v1_enabled_list', ['parquet', ''], ids=['v1', 'v2'])
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_string(spark_tmp_path, v1_enabled_list):
     data_path = spark_tmp_path + '/VARIANT_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     read_conf = dict(_variant_parquet_conf)
     read_conf['spark.sql.sources.useV1SourceList'] = v1_enabled_list
-    assert_gpu_and_cpu_are_equal_collect(
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: spark.read.parquet(data_path).selectExpr(
             "try_variant_get(v, '$.y', 'string') AS y"),
+        exist_classes='GpuVariantGet',
         conf=read_conf)
 
 
@@ -146,7 +181,7 @@ def test_parquet_variant_try_get_string(spark_tmp_path, v1_enabled_list):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_integral_targets(spark_tmp_path, field_name, target_type):
     data_path = spark_tmp_path + '/VARIANT_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -158,7 +193,7 @@ def test_parquet_variant_try_get_integral_targets(spark_tmp_path, field_name, ta
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_nested_object_path(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -182,7 +217,7 @@ def test_parquet_nested_struct_variant_try_get(spark_tmp_path):
           AS source(id, json)
         """).write.mode('overwrite').parquet(data_path)
 
-    with_cpu_session(write_data)
+    _with_cpu_variant_session(write_data)
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -205,7 +240,7 @@ def test_parquet_variant_try_get_null_variant_rows(spark_tmp_path):
           SELECT parse_json('{"x":42}') AS v
         """).write.mode('overwrite').parquet(data_path)
 
-    with_cpu_session(write_data)
+    _with_cpu_variant_session(write_data)
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -228,7 +263,7 @@ def test_parquet_variant_try_get_null_and_missing_fields(spark_tmp_path):
           SELECT parse_json('{"x":7}') AS v
         """).write.mode('overwrite').parquet(data_path)
 
-    with_cpu_session(write_data)
+    _with_cpu_variant_session(write_data)
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -254,7 +289,7 @@ def test_parquet_variant_try_get_integral_boundaries(spark_tmp_path):
             '"int_overflow":2147483648}') AS v
         """).write.mode('overwrite').parquet(data_path)
 
-    with_cpu_session(write_data)
+    _with_cpu_variant_session(write_data)
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -282,7 +317,7 @@ def test_parquet_variant_try_get_integral_boundaries(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_pass_through_filter_project(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_PASS_THROUGH_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path)
@@ -300,7 +335,7 @@ def test_parquet_variant_pass_through_filter_project(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_direct_filter(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_FILTER_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path)
@@ -315,7 +350,7 @@ def test_parquet_variant_try_get_direct_filter(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_aggregate(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_AGGREGATE_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -327,7 +362,7 @@ def test_parquet_variant_try_get_aggregate(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_heterogeneous_values(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_HETEROGENEOUS_PARQUET'
-    with_cpu_session(lambda spark: _write_heterogeneous_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_heterogeneous_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -345,7 +380,7 @@ def test_parquet_variant_try_get_heterogeneous_values(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_try_get_before_shuffle(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_SHUFFLE_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).selectExpr(
@@ -359,7 +394,7 @@ def test_parquet_variant_try_get_before_shuffle(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_parquet_variant_if(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_IF_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_if_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_if_parquet(spark, data_path))
 
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: spark.read.parquet(data_path)
@@ -377,7 +412,7 @@ def test_parquet_variant_if(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_variant_try_get_array_path_falls_back(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_ARRAY_PATH_FALLBACK_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     def do_it(spark):
         return spark.read.parquet(data_path).selectExpr(
@@ -391,7 +426,7 @@ def test_variant_try_get_array_path_falls_back(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_variant_try_get_non_literal_path_falls_back(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_NON_LITERAL_PATH_FALLBACK_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_with_path_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_with_path_parquet(spark, data_path))
 
     def do_it(spark):
         return spark.read.parquet(data_path).selectExpr(
@@ -405,7 +440,7 @@ def test_variant_try_get_non_literal_path_falls_back(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_variant_try_get_quoted_path_falls_back(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_QUOTED_PATH_FALLBACK_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     def do_it(spark):
         return spark.read.parquet(data_path).selectExpr(
@@ -419,7 +454,7 @@ def test_variant_try_get_quoted_path_falls_back(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_variant_get_strict_mode_falls_back(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_STRICT_MODE_FALLBACK_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     def do_it(spark):
         return spark.read.parquet(data_path).selectExpr(
@@ -433,7 +468,7 @@ def test_variant_get_strict_mode_falls_back(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_variant_try_get_unsupported_target_type_falls_back(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_TARGET_TYPE_FALLBACK_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     def do_it(spark):
         return spark.read.parquet(data_path).selectExpr(
@@ -447,7 +482,7 @@ def test_variant_try_get_unsupported_target_type_falls_back(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')
 def test_variant_try_get_cpu_bridge_disabled_falls_back(spark_tmp_path):
     data_path = spark_tmp_path + '/VARIANT_CPU_BRIDGE_DISABLED_FALLBACK_PARQUET'
-    with_cpu_session(lambda spark: _write_variant_parquet(spark, data_path))
+    _with_cpu_variant_session(lambda spark: _write_variant_parquet(spark, data_path))
 
     def do_it(spark):
         return spark.read.parquet(data_path).selectExpr(

--- a/integration_tests/src/main/python/variant_test.py
+++ b/integration_tests/src/main/python/variant_test.py
@@ -195,6 +195,39 @@ def test_parquet_shredded_raw_variant_scan_falls_back(
         do_it, fallback_class, conf=read_conf)
 
 
+@allow_non_gpu('FileSourceScanExec', 'BatchScanExec', 'ColumnarToRowExec',
+               'ProjectExec', 'VariantGet')
+@incompat
+@pytest.mark.parametrize('v1_enabled_list,fallback_class', [
+    ('parquet', 'FileSourceScanExec'),
+    ('', 'BatchScanExec'),
+], ids=['v1', 'v2'])
+@pytest.mark.skipif(not is_spark_411_or_later(),
+                    reason='Variant shredding is enabled by default in Spark 4.1.1+')
+def test_parquet_shredded_variant_aggregate_returns_to_gpu(
+        spark_tmp_path, v1_enabled_list, fallback_class):
+    data_path = spark_tmp_path + '/SHREDDED_VARIANT_AGGREGATE_PARQUET'
+    write_conf = {'spark.sql.variant.writeShredding.enabled': 'true'}
+    with_cpu_session(
+        lambda spark: _write_variant_parquet(spark, data_path), conf=write_conf)
+
+    def do_it(spark):
+        return spark.read.parquet(data_path) \
+            .selectExpr("try_variant_get(v, '$.x', 'int') AS x") \
+            .selectExpr('sum(x) AS total')
+
+    read_conf = dict(_variant_parquet_conf)
+    read_conf['spark.sql.sources.useV1SourceList'] = v1_enabled_list
+    read_conf['spark.sql.adaptive.enabled'] = 'true'
+    read_conf['spark.sql.variant.pushVariantIntoScan'] = 'false'
+    read_conf['spark.sql.variant.allowReadingShredded'] = 'true'
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes=f'{fallback_class},ProjectExec,GpuHashAggregateExec',
+        non_exist_classes='GpuVariantGet',
+        conf=read_conf)
+
+
 @incompat
 @pytest.mark.parametrize('v1_enabled_list', ['parquet', ''], ids=['v1', 'v2'])
 @pytest.mark.skipif(is_before_spark_400(), reason='VariantType is available in Spark 4.0+')

--- a/integration_tests/src/main/python/variant_test.py
+++ b/integration_tests/src/main/python/variant_test.py
@@ -38,8 +38,10 @@ _variant_write_conf = {}
 if is_spark_411_or_later():
     # Spark 4.1+ pushes Variant extraction into the Parquet reader and writes shredded
     # Variant columns by default. The GPU implementation currently operates on unshredded
-    # Variant columns, so disable both features when exercising GpuVariantGet.
+    # Variant columns, so disable pushdown and require unshredded reads when exercising
+    # GpuVariantGet.
     _variant_parquet_conf['spark.sql.variant.pushVariantIntoScan'] = 'false'
+    _variant_parquet_conf['spark.sql.variant.allowReadingShredded'] = 'false'
     _variant_write_conf['spark.sql.variant.writeShredding.enabled'] = 'false'
 
 
@@ -117,6 +119,7 @@ def test_parquet_variant_write_falls_back(spark_tmp_path):
             "try_variant_get(v, '$.n.num', 'int') AS num")
 
     write_conf = dict(_variant_parquet_conf)
+    write_conf.update(_variant_write_conf)
     write_conf['spark.rapids.sql.format.parquet.read.enabled'] = 'false'
     assert_gpu_fallback_write(
         write_data, read_data, spark_tmp_path, ['DataWritingCommandExec', 'WriteFilesExec'],
@@ -140,9 +143,56 @@ def test_parquet_variant_shredding_and_scan_pushdown_fall_back(spark_tmp_path):
 
     read_conf = dict(_variant_parquet_conf)
     read_conf['spark.sql.variant.pushVariantIntoScan'] = 'true'
+    read_conf['spark.sql.variant.allowReadingShredded'] = 'true'
     # TODO(#14251): Replace this fallback assertion when pushed Variant scans run on GPU.
     assert_gpu_fallback_collect(
         do_it, 'FileSourceScanExec', conf=read_conf)
+
+
+@allow_non_gpu('FileSourceScanExec', 'BatchScanExec', 'ColumnarToRowExec',
+               'ProjectExec', 'VariantGet', 'ShuffleExchangeExec')
+@incompat
+@pytest.mark.parametrize('pushdown_enabled,nested_pass_through,repartition_before_extract', [
+    ('true', True, False),
+    ('false', False, False),
+    ('false', False, True),
+], ids=['nested-pass-through', 'pushdown-disabled', 'aqe-query-stage'])
+@pytest.mark.parametrize('v1_enabled_list,fallback_class', [
+    ('parquet', 'FileSourceScanExec'),
+    ('', 'BatchScanExec'),
+], ids=['v1', 'v2'])
+@pytest.mark.skipif(not is_spark_411_or_later(),
+                    reason='Variant shredding is enabled by default in Spark 4.1.1+')
+def test_parquet_shredded_raw_variant_scan_falls_back(
+        spark_tmp_path, pushdown_enabled, nested_pass_through, repartition_before_extract,
+        v1_enabled_list, fallback_class):
+    data_path = spark_tmp_path + '/RAW_SHREDDED_VARIANT_SCAN_FALLBACK_PARQUET'
+
+    def write_data(spark):
+        spark.sql("""
+          SELECT
+            parse_json('{"x":7}') AS v,
+            named_struct('payload', parse_json('{"x":42}')) AS nested
+        """).write.mode('overwrite').parquet(data_path)
+
+    write_conf = {'spark.sql.variant.writeShredding.enabled': 'true'}
+    with_cpu_session(write_data, conf=write_conf)
+
+    def do_it(spark):
+        df = spark.read.parquet(data_path)
+        if nested_pass_through:
+            return df.selectExpr('to_json(nested) AS nested')
+        if repartition_before_extract:
+            df = df.repartition(2)
+        return df.selectExpr("try_variant_get(v, '$.x', 'int') AS x")
+
+    read_conf = dict(_variant_parquet_conf)
+    read_conf['spark.sql.sources.useV1SourceList'] = v1_enabled_list
+    read_conf['spark.sql.adaptive.enabled'] = 'true'
+    read_conf['spark.sql.variant.pushVariantIntoScan'] = pushdown_enabled
+    read_conf['spark.sql.variant.allowReadingShredded'] = 'true'
+    assert_gpu_fallback_collect(
+        do_it, fallback_class, conf=read_conf)
 
 
 @incompat

--- a/integration_tests/src/main/python/variant_test.py
+++ b/integration_tests/src/main/python/variant_test.py
@@ -140,6 +140,7 @@ def test_parquet_variant_shredding_and_scan_pushdown_fall_back(spark_tmp_path):
 
     read_conf = dict(_variant_parquet_conf)
     read_conf['spark.sql.variant.pushVariantIntoScan'] = 'true'
+    # TODO(#14251): Replace this fallback assertion when pushed Variant scans run on GPU.
     assert_gpu_fallback_collect(
         do_it, 'FileSourceScanExec', conf=read_conf)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -74,7 +74,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
-import org.apache.spark.sql.execution.QueryExecutionException
+import org.apache.spark.sql.execution.{QueryExecutionException, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{DataSourceUtils, PartitionedFile, PartitioningAwareFileIndex, SchemaColumnConvertNotSupportedException}
 import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
@@ -164,6 +164,20 @@ case class GpuParquetScan(
 }
 
 object GpuParquetScan {
+  private def tagScanAndAncestorsForCpu(meta: RapidsMeta[_, _, _], reason: String): Unit = {
+    meta.willNotWorkOnGpu(reason)
+    var ancestor = meta.parent
+    while (ancestor.isDefined) {
+      ancestor.get.wrapped match {
+        case plan: SparkPlan =>
+          plan.setTagValue(RapidsMeta.gpuSupportedTag,
+            plan.getTagValue(RapidsMeta.gpuSupportedTag).getOrElse(Set.empty) + reason)
+        case _ =>
+      }
+      ancestor = ancestor.get.parent
+    }
+  }
+
   def tagSupport(scanMeta: ScanMeta[ParquetScan]): Unit = {
     val scan = scanMeta.wrapped
     val schema = StructType(scan.readDataSchema ++ scan.readPartitionSchema)
@@ -192,6 +206,19 @@ object GpuParquetScan {
     }
     if (schemaHasPushedVariant) {
       meta.willNotWorkOnGpu("GPU Parquet reader does not support Variant extraction pushdown")
+    }
+
+    val sqlConf = sparkSession.sessionState.conf
+    val schemaHasPotentiallyShreddedVariant = readSchema.exists { field =>
+      TrampolineUtil.dataTypeExistsRecursively(
+        field.dataType, ParquetVariantShims.isPotentiallyShreddedVariant(_, sqlConf))
+    }
+    if (schemaHasPotentiallyShreddedVariant) {
+      val reason = "GPU Parquet reader cannot safely read Variant columns when Spark allows " +
+        "shredded Variant input"
+      // A CPU-to-GPU transition cannot carry a raw Variant column, so keep the scan and its
+      // ancestor operators on CPU.
+      tagScanAndAncestorsForCpu(meta, reason)
     }
 
     FileFormatChecks.tag(meta, readSchema, ParquetFormatType, ReadFileOp)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -44,7 +44,8 @@ import com.nvidia.spark.rapids.jni.{DateTimeRebase, ParquetFooter, RmmSpark}
 import com.nvidia.spark.rapids.jni.fileio.{RapidsFileIO, RapidsInputFile}
 import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile.CopyRange
 import com.nvidia.spark.rapids.parquet.ParquetPartitionReader.{LocalCopy, PARQUET_MAGIC}
-import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuParquetCrypto, GpuTypeShims, ShimFilePartitionReaderFactory, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuParquetCrypto, GpuTypeShims,
+  ParquetVariantShims, ShimFilePartitionReaderFactory, SparkShimImpl}
 import com.nvidia.spark.rapids.shims.parquet.{GpuParquetUtilsShims, ParquetLegacyNanoAsLongShims, ParquetSchemaClipShims, ParquetStringPredShims}
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
 import org.apache.hadoop.conf.Configuration
@@ -183,6 +184,14 @@ object GpuParquetScan {
     if (!meta.conf.isParquetReadEnabled) {
       meta.willNotWorkOnGpu("Parquet input has been disabled. To enable set" +
         s"${RapidsConf.ENABLE_PARQUET_READ} to true")
+    }
+
+    val schemaHasPushedVariant = readSchema.exists { field =>
+      TrampolineUtil.dataTypeExistsRecursively(
+        field.dataType, ParquetVariantShims.isPushedVariantStruct)
+    }
+    if (schemaHasPushedVariant) {
+      meta.willNotWorkOnGpu("GPU Parquet reader does not support Variant extraction pushdown")
     }
 
     FileFormatChecks.tag(meta, readSchema, ParquetFormatType, ReadFileOp)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -164,17 +164,30 @@ case class GpuParquetScan(
 }
 
 object GpuParquetScan {
-  private def tagScanAndAncestorsForCpu(meta: RapidsMeta[_, _, _], reason: String): Unit = {
+  private def hasPotentiallyShreddedVariant(
+      dataTypes: Iterable[DataType], sqlConf: SQLConf): Boolean = {
+    dataTypes.exists { dataType =>
+      TrampolineUtil.dataTypeExistsRecursively(
+        dataType, ParquetVariantShims.isPotentiallyShreddedVariant(_, sqlConf))
+    }
+  }
+
+  private def tagVariantScanPrefixForCpu(
+      meta: RapidsMeta[_, _, _], reason: String, sqlConf: SQLConf): Unit = {
     meta.willNotWorkOnGpu(reason)
     var ancestor = meta.parent
-    while (ancestor.isDefined) {
-      ancestor.get.wrapped match {
+    var outputContainsVariant = true
+    while (ancestor.isDefined && outputContainsVariant) {
+      val current = ancestor.get
+      current.wrapped match {
         case plan: SparkPlan =>
           plan.setTagValue(RapidsMeta.gpuSupportedTag,
             plan.getTagValue(RapidsMeta.gpuSupportedTag).getOrElse(Set.empty) + reason)
+          outputContainsVariant = hasPotentiallyShreddedVariant(
+            plan.output.map(_.dataType), sqlConf)
         case _ =>
       }
-      ancestor = ancestor.get.parent
+      ancestor = current.parent
     }
   }
 
@@ -209,16 +222,13 @@ object GpuParquetScan {
     }
 
     val sqlConf = sparkSession.sessionState.conf
-    val schemaHasPotentiallyShreddedVariant = readSchema.exists { field =>
-      TrampolineUtil.dataTypeExistsRecursively(
-        field.dataType, ParquetVariantShims.isPotentiallyShreddedVariant(_, sqlConf))
-    }
+    val schemaHasPotentiallyShreddedVariant =
+      hasPotentiallyShreddedVariant(readSchema.map(_.dataType), sqlConf)
     if (schemaHasPotentiallyShreddedVariant) {
       val reason = "GPU Parquet reader cannot safely read Variant columns when Spark allows " +
         "shredded Variant input"
-      // A CPU-to-GPU transition cannot carry a raw Variant column, so keep the scan and its
-      // ancestor operators on CPU.
-      tagScanAndAncestorsForCpu(meta, reason)
+      // Keep the scan and its consumers on CPU until an operator no longer outputs Variant.
+      tagVariantScanPrefixForCpu(meta, reason, sqlConf)
     }
 
     FileFormatChecks.tag(meta, readSchema, ParquetFormatType, ReadFileOp)

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
@@ -65,4 +65,6 @@ object ParquetVariantShims {
   }
 
   def isPushedVariantStruct(_dataType: DataType): Boolean = false
+
+  def isPotentiallyShreddedVariant(_dataType: DataType, _sqlConf: SQLConf): Boolean = false
 }

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
@@ -51,6 +51,7 @@ package com.nvidia.spark.rapids.shims
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.DataType
 
 /**
  * Shim for Parquet variant-related configurations.
@@ -62,4 +63,6 @@ object ParquetVariantShims {
     // No-op for Spark versions before 4.1.0
     // PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE doesn't exist
   }
+
+  def isPushedVariantStruct(_dataType: DataType): Boolean = false
 }

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.execution.datasources.VariantMetadata
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, VariantType}
 
 /**
  * Shim for Parquet variant-related configurations in Spark 4.1.0+.
@@ -44,4 +44,7 @@ object ParquetVariantShims {
 
   def isPushedVariantStruct(dataType: DataType): Boolean =
     VariantMetadata.isVariantStruct(dataType)
+
+  def isPotentiallyShreddedVariant(dataType: DataType, sqlConf: SQLConf): Boolean =
+    dataType == VariantType && sqlConf.getConf(SQLConf.VARIANT_ALLOW_READING_SHREDDED)
 }

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/ParquetVariantShims.scala
@@ -25,7 +25,9 @@ package com.nvidia.spark.rapids.shims
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.sql.execution.datasources.VariantMetadata
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.DataType
 
 /**
  * Shim for Parquet variant-related configurations in Spark 4.1.0+.
@@ -39,4 +41,7 @@ object ParquetVariantShims {
       SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key,
       sqlConf.parquetAnnotateVariantLogicalType.toString)
   }
+
+  def isPushedVariantStruct(dataType: DataType): Boolean =
+    VariantMetadata.isVariantStruct(dataType)
 }


### PR DESCRIPTION
Fixes #15952.

### Description

Spark 4.1.1+ enables Variant shredding and pushes Variant extraction into Parquet scans by default. The pushed read schema contains synthetic Variant structs understood by Spark's CPU Parquet reader but not by the GPU Parquet reader. These scans could therefore fail with missing schema-index or empty-footer errors.

This PR detects pushed Variant structs using Spark's `VariantMetadata` and prevents the Parquet scan from running on GPU, allowing it to fall back cleanly to CPU. Spark 4.0 behavior is unchanged.

The integration tests now cover:

- Shredding and pushdown disabled: `try_variant_get` executes using `GpuVariantGet` for Parquet V1 and V2.
- Shredding and pushdown enabled: the Parquet scan falls back to CPU without failure.

Validation:

- Spark 4.2 `variant_test.py`: 36 passed.
- Spark 4.1.1 focused Variant tests: 3 passed.

Performance:

This correctness fix intentionally falls back to CPU when a raw Variant column may use Spark's shredded Parquet representation. The affected shredded path failed before this change, so it has no successful GPU baseline to compare against. GPU execution for explicitly unshredded Variant input remains unchanged.

GPU support for Variant Parquet scans is tracked by #15180. Pushed Variant extraction support is tracked separately by #14251.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required