### PR TITLE
[SkipRecovery] Re-enable CORRECTED Parquet timestamp checks [databricks]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -312,10 +312,13 @@ satisfy the query, the ORC read falls back to the CPU as it is a metadata-only q
 ## Parquet
 
 The Parquet format has more configs because there are multiple versions with some compatibility
-issues between them. Dates and timestamps are where the known issues exist.  For reads when
-`spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `CORRECTED`
-[timestamps](https://github.com/NVIDIA/cudf-spark/issues/132) before the transition between the
-Julian and Gregorian calendars are wrong, but dates are fine. When
+issues between them. Dates and timestamps are where the known issues exist. The
+[CORRECTED timestamp discrepancy](https://github.com/NVIDIA/cudf-spark/issues/132) was reported
+on Spark 3.0. For files written by the CPU on supported Spark versions with both
+`spark.sql.parquet.datetimeRebaseModeInWrite` and `spark.sql.parquet.int96RebaseModeInWrite`
+set to `CORRECTED`, GPU reads support timestamps before the transition between the Julian
+and Gregorian calendars. This does not change LEGACY rebasing or INT96 timestamp-conversion
+limitations. When
 `spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `LEGACY`, the read may fail for
 values occurring before the transition between the Julian and Gregorian calendars, i.e.: date <= 1582-10-04.
 

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -76,7 +76,7 @@ parquet_gens_list = [[byte_gen, short_gen, int_gen, long_gen, float_gen, double_
     StructGen([['child0', ArrayGen(byte_gen)], ['child1', byte_gen], ['child2', float_gen], ['child3', decimal_gen_64bit]]),
     ArrayGen(StructGen([['child0', string_gen], ['child1', double_gen], ['child2', int_gen]]))] +
                      parquet_map_gens + decimal_gens,
-                     pytest.param([timestamp_gen], marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/132'))]
+                     [timestamp_gen]]
 
 # test with original parquet file reader, the multi-file parallel reader for cloud, and coalesce file reader for
 # non-cloud


### PR DESCRIPTION
**JaCoCo production line coverage: +0 lines** (measured: `sql-plugin`, `delta-lake`, `iceberg`, `shuffle-plugin`, `udf-compiler`; Scala 2.12, shim 350, vs compatible nightly b34, anchor `2d438c020496`)

Contributes to #132.

### Description

This is a test-and-documentation recovery; production behavior is unchanged. The existing CORRECTED Parquet timestamp round-trip cases produce matching CPU/GPU results on the tested runtime, but an old expected-failure marker still hides future failures. Remove that marker so these cases enforce parity, and correct the compatibility documentation's blanket warning about ancient CORRECTED timestamps.

- Restores normal failure reporting for 196 existing timestamp combinations across ordinary and flow-controlled readers, without adding tests or parameter combinations.
- Follows the issue's request to retest and the later observation that the discrepancy no longer reproduces on Spark 3.1+. The documented supported case is CPU-written files with both datetime and INT96 write rebasing set to `CORRECTED`.
- Leaves LEGACY rebasing, INT96 timestamp conversion, older-writer files, and the other issue-linked generator restrictions unchanged. This does not close the broader issue.

Validation used Apache Spark 3.5.0, Python 3.10.18, Java 17, and an RTX 5880 Ada. No CPU/GPU divergence was observed in the exercised scope. Databricks and other Spark shims have not been validated locally.

<details>
<summary>Local validation and coverage measurement</summary>

- Maven `package -pl dist,integration_tests -am -Dbuildver=350 -DskipTests`, with an isolated Maven cache: **BUILD SUCCESS**.
- Before editing, both affected tests with `--runxfail`: **392 passed**.
- After editing, all 196 recovered combinations with each of `TIMESTAMP_MICROS` and `TIMESTAMP_MILLIS`: **196 passed per encoding**. INT96 with a second seed and forced OOM injection: **196 passed**.
- A temporary diagnostic checked 11 boundary values (including null, year 1, the calendar cutover, 1590, 1900, epoch, and year 9999), three encodings, three GPU readers, and V1/V2 scans: **18 passed in each of UTC, Asia/Shanghai, and America/New_York**. It explicitly required GPU scan nodes and rejected CPU scan fallback.
- Full modified `parquet_test.py`: **3721 passed, 89 skipped** in 1232.50 seconds, exit 0. The 89 skips are existing runtime guards, not expected failures restored by this change.

Affected existing tests: `test_parquet_read_round_trip` and `test_parquet_read_multithread_flow_ctrl_round_trip` in `integration_tests/src/main/python/parquet_test.py`. The recovered timestamp-only selection is `-k '[Timestamp]'` (52 ordinary-reader cases plus 144 flow-control cases). Runs used seed `20260911`, with `20260912` for the forced-OOM run; both CORRECTED write-rebase settings are set by the tests.

JaCoCo replayed all 196 recovered cases against the exact compatible b34 anchor JAR and merged their execution data with that baseline. All five regenerated module baseline counters matched the published report, with no class-ID mismatch; each module's marginal line delta was zero. This measures restored regression enforcement, not new production lines. b34 is a compatible baseline, not the latest nightly.

</details>

AI assistance: The change and PR description were prepared with Codex assistance.

### Checklists

Documentation

- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing

- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance

- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
