### PR TITLE
[SkipRecovery] Restore randomized regex and decimal window coverage [reduced-it] [databricks]

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -1498,12 +1498,18 @@ def test_illegal_regexp_exception():
             assert "INVALID_PARAMETER_VALUE.PATTERN" in cpu_error
             assert "Illegal" in gpu_error # GPU still uses old format
 
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9731')
 def test_re_replace_all():
     """
     regression test for https://github.com/NVIDIA/spark-rapids/issues/8323
     """
-    gen = mk_str_gen('[a-z]{0,2}\n{0,2}[a-z]{0,2}\n{0,2}')
+    # Retain the NEL regression inputs from https://github.com/NVIDIA/cudf-spark/issues/9731
+    # while allowing the rest of the input to vary with the test seed.
+    gen = mk_str_gen('[a-z]{0,2}\n{0,2}[a-z]{0,2}\n{0,2}') \
+        .with_special_case('a\u0085') \
+        .with_special_case('oNÍ[\x87\x01áe>\u0085') \
+        .with_special_case('a\u2028') \
+        .with_special_case('a\u2029') \
+        .with_special_case('a\r\n')
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, gen).selectExpr(
             'REGEXP_REPLACE(a, ".*$", "PROD", 1)'),

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import math
 import pytest
+import re
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_sql_fallback_collect
 from data_gen import *
@@ -21,7 +22,7 @@ from pyspark.sql.types import *
 from pyspark.sql.types import DateType, TimestampType, NumericType
 from pyspark.sql.window import Window
 import pyspark.sql.functions as f
-from spark_session import is_before_spark_320, is_databricks113_or_later, \
+from spark_session import is_before_spark_320, is_databricks113_or_later, is_databricks_runtime, \
     is_spark_350_or_later, spark_version, with_cpu_session, \
     is_scala212, is_spark_340_or_later, is_spark_420_or_later
 import warnings
@@ -3084,7 +3085,12 @@ def spark_bugs_in_decimal_sorting():
     :return: True, if Apache Spark version does not sort Decimal(>20, >2) correctly. False, otherwise.
     """
     v = spark_version()
-    return v < "3.1.4" or v < "3.3.1" or v < "3.2.3" or v < "3.4.0"
+    # SPARK-40089 was backported to Apache Spark 3.3.1. Only narrow the guard for
+    # Apache 3.3 releases; retain the existing guard for older and vendor runtimes.
+    apache_33 = re.fullmatch(r"3\.3\.([0-9]+)", v)
+    if apache_33 and not is_databricks_runtime():
+        return int(apache_33[1]) == 0
+    return v < "3.4.0"
 
 
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -16,13 +16,14 @@ import pytest
 import re
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_sql_fallback_collect
+from conftest import is_apache_runtime
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 from pyspark.sql.types import DateType, TimestampType, NumericType
 from pyspark.sql.window import Window
 import pyspark.sql.functions as f
-from spark_session import is_before_spark_320, is_databricks113_or_later, is_databricks_runtime, \
+from spark_session import is_before_spark_320, is_databricks113_or_later, \
     is_spark_350_or_later, spark_version, with_cpu_session, \
     is_scala212, is_spark_340_or_later, is_spark_420_or_later
 import warnings
@@ -3088,7 +3089,7 @@ def spark_bugs_in_decimal_sorting():
     # SPARK-40089 was backported to Apache Spark 3.3.1. Only narrow the guard for
     # Apache 3.3 releases; retain the existing guard for older and vendor runtimes.
     apache_33 = re.fullmatch(r"3\.3\.([0-9]+)", v)
-    if apache_33 and not is_databricks_runtime():
+    if apache_33 and is_apache_runtime():
         return int(apache_33[1]) == 0
     return v < "3.4.0"
 


### PR DESCRIPTION
**JaCoCo production line coverage: +0 lines** (measured: `delta-lake`, `iceberg`, `shuffle-plugin`, `sql-plugin`, `udf-compiler`; Scala 2.12, shim 350, anchor `2d438c020496`, vs compatible nightly b34)

Fixes #9731. Refs #7429 (decimal-sorting test guard only).

### Description

This test-only PR removes two stale restrictions after their underlying fixes landed: it restores randomized regex-replacement inputs and one nullable-decimal ROWS-window case on fixed Apache Spark 3.3 releases. Production behavior, SQL queries, and parity assertions are unchanged. The documented decimal RANGE limitation and existing Databricks/vendor guards remain in place.

- Keep the historical Unicode next-line (NEL) inputs from #9731 in the existing replacement test's generator, along with other line-terminator cases, while removing its fixed-seed override. The original failing seed and exact inputs now match CPU/GPU after #11663 and #15023.
- Narrow the decimal-sorting guard for plain Apache Spark 3.3.1+ releases, following the [SPARK-40089 backport](https://github.com/apache/spark/commit/e16467c04cd1a69eedb26b73f9fa4088bb583b90). Spark 3.3.0 stays guarded. On Spark 3.3.4, this restores the existing nullable `Decimal(23,10)` negative-ROWS parameter; it does not remove the two Databricks decimal RANGE xfails associated with #7429. The helper's ranking-test caller already requires Spark 3.5+, so it gains no additional cases.

No new test function or parameter dimension is added. No CPU/GPU divergence was observed in the recovered cases.

AI assistance: The change and PR description were prepared with Codex assistance.

#### Validation

- Fresh Maven packaging for shims 350 and 334: `BUILD SUCCESS` for both, using isolated Maven caches.
- Complete `regexp_test.py`: **95 passed, 1 existing skip** on each of Apache Spark 3.5.0 and 3.3.4.
- Complete `window_function_test.py` on Spark 3.3.4: **914 passed, 136 existing skips, 4 existing xfails**; the recovered decimal case passed.
- Regex seeds `1700077791`, `0`, `42`, and `20260911`: all passed. Exact historical inputs returned the same `PRODPROD<NEL>PROD` on CPU/GPU, where `<NEL>` denotes U+0085, with `GpuRegExpReplace` captured. The unmasked decimal case compared all 2,048 rows with GPU window execution confirmed.
- Forced-OOM checks: **78 passed** on Spark 3.5.0 across the two affected functions and the guard's ranking-test caller; **8 passed** on Spark 3.3.4 with `TEST_TYPE=pre-commit` and `REDUCED_IT=true`. All eight recovered-function cases were retained. The regex test has no parametrization, and the window test's matrix is seven data generators × one batch size. Thus `[reduced-it]` retains every recovered combination.
- Version-guard boundary checks: 24 passed, including multi-digit patch versions and unchanged older, Databricks, and vendor-version behavior.

<details>
<summary>Environment and coverage details</summary>

Apache Spark 3.3.4 / 3.5.0, Python 3.10.18, Scala 2.12, JDK 17, UTC, RTX 5880 Ada. Databricks was not run locally; its existing guards are preserved and the title requests Databricks CI.

Both affected functions were replayed with the exact compatible nightly anchor JAR: **8 passed**. All five regenerated module baseline counters matched the published report, with no class-ID mismatches and zero marginal production lines. This measures shim 350 against compatible b34, not the separately refreshed latest b21 report or a Spark 3.3 coverage total.

</details>

### Checklists

Documentation

- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing

- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance

- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
