### PR TITLE
Switch from deprecated inner-join call

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -414,7 +414,7 @@ object JoinImpl {
                              compareNullsEqual: Boolean): GatherMapsResult = {
     // The build table is always the right table, so switch the tables passed in
     val arrayRet = JoinPrimitives.sortMergeInnerJoin(rightKeys, leftKeys,
-      false, false, compareNullsEqual)
+      false, compareNullsEqual)
     // Then switch the gather maps result
     GatherMapsResult(arrayRet(1), arrayRet(0))
   }
@@ -430,7 +430,7 @@ object JoinImpl {
                               compareNullsEqual: Boolean): GatherMapsResult = {
     // The build table is always the right table
     val arrayRet = JoinPrimitives.sortMergeInnerJoin(leftKeys, rightKeys,
-      false, false, compareNullsEqual)
+      false, compareNullsEqual)
     GatherMapsResult(arrayRet(0), arrayRet(1))
   }
 


### PR DESCRIPTION
### Description

[This cs-jni PR](https://github.com/NVIDIA/cudf-spark-jni/pull/5108) updated the cuDF inner-join call to switch away from the deprecated method.  To not break the cudf-spark builds in the meantime, it introduced a new overloaded call at the API layer without the no-longer-needed bool.  This PR updates our callsites to use new method. 

Depends on https://github.com/NVIDIA/cudf-spark-jni/pull/5108. 

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required